### PR TITLE
Prevent setup_logging multiple handlers

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -222,13 +222,14 @@ class AgentFormatter(logging.Formatter):
 
 
 def setup_logging(level=logging.DEBUG):
-    handler = logging.StreamHandler()
-    if isapipe(sys.stderr):
-        handler.setFormatter(JsonFormatter())
-    else:
-        handler.setFormatter(logging.Formatter(
-                '%(asctime)s %(name)s %(levelname)s: %(message)s'))
     root = logging.getLogger()
-    root.addHandler(handler)
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        if isapipe(sys.stderr):
+            handler.setFormatter(JsonFormatter())
+        else:
+            handler.setFormatter(logging.Formatter(
+                    '%(asctime)s %(name)s %(levelname)s: %(message)s'))
+        root.addHandler(handler)
     root.setLevel(level)
 


### PR DESCRIPTION
Resolves issue #24 
Updated volttron.platform.agent.utils.set_logging() to check for
existing root logging handler before instantiating new handler.
