### PR TITLE
Allow port selection for modbus tcp and default to 502 if port undefined

### DIFF
--- a/volttron/drivers/driver.ini
+++ b/volttron/drivers/driver.ini
@@ -22,6 +22,8 @@ Metadata/Location/Building = Building Number 1
 [/campus1/building1/modbus1]
 type = volttron.drivers.modbus.Modbus
 ip_address = <PUT YOUR MODBUS DEVICE IP HERE>
+#Optional port, defaults to 502 if not specified
+#port = 8585
 Metadata/Instrument/Manufacturer = <PUT INSTRUMENT MANUFACTURER HERE>
 Metadata/Instrument/ModelName = <PUT INSTRUMENT MODEL HERE>
 #slave_id = 8

--- a/volttron/drivers/modbus.py
+++ b/volttron/drivers/modbus.py
@@ -403,7 +403,7 @@ class Modbus(BaseSmapVolttron):
     def get_interface(self, opts):
         ip_address = opts['ip_address']
         slave_id = int(opts.get('slave_id',0))
-        port = int(opts.get('port',502))
+        port = int(opts.get('port', opts['port'] if 'port' in opts else 502))
         catalyst_config = opts.get('register_config', configFile)
         
         return ModbusInterface(ip_address, slave_id=slave_id, port=port, config_file=catalyst_config)


### PR DESCRIPTION
Specifying a modbus tcp port can be useful in cases where only non-privileged ports are available. For instance, simulating a modbus slave using pyModSlave on port 502 requires root whereas ports above 1024 (such as 8585) do not.