### PR TITLE
Add comments demonstrating port selection for modbus tcp which defaults ...

### DIFF
--- a/volttron/drivers/driver.ini
+++ b/volttron/drivers/driver.ini
@@ -22,6 +22,8 @@ Metadata/Location/Building = Building Number 1
 [/campus1/building1/modbus1]
 type = volttron.drivers.modbus.Modbus
 ip_address = <PUT YOUR MODBUS DEVICE IP HERE>
+#Optional port, defaults to 502 if not specified
+#port = <PUT YOUR MODBUS DEVICE PORT HERE>
 Metadata/Instrument/Manufacturer = <PUT INSTRUMENT MANUFACTURER HERE>
 Metadata/Instrument/ModelName = <PUT INSTRUMENT MODEL HERE>
 #slave_id = 8


### PR DESCRIPTION
...to 502 if port undefined

Specifying a modbus tcp port can be useful in cases where only non-privileged ports are available. For instance, simulating a modbus slave using pyModSlave on port 502 requires root whereas ports above 1024 (such as 8585) do not.

Replaces PR #26.