### PR TITLE
Resolves #71, 'volttron-ctl remove' fails to remove agent.

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -318,7 +318,7 @@ def remove_agent(opts):
             return 10
         for agent in match:
             _stdout.write('Removing {} {}\n'.format(agent.uuid, agent.name))
-            opts.aip.remove_agent(agent.uuid)
+            opts.connection.call('remove_agent', agent.uuid)
 
 def _calc_min_uuid_length(agents):
     n = 0

--- a/volttrontesting/testutils/test_platformwrapper.py
+++ b/volttrontesting/testutils/test_platformwrapper.py
@@ -102,6 +102,25 @@ def test_can_call_rpc_method(volttron_instance1):
     print('The agent list is: {}'.format(agent_list))
     assert agent_list is not None
 
+@pytest.mark.wrapper
+def test_can_remove_agent(volttron_instance1):
+    """ Confirms that 'volttron-ctl remove' removes agent as expected. """
+    assert volttron_instance1 is not None
+    assert volttron_instance1.is_running()
+
+    # Install ListenerAgent as the agent to be removed.
+    agent_uuid = volttron_instance1.install_agent(agent_dir="examples/ListenerAgent", start=False)
+    assert agent_uuid is not None
+    started = volttron_instance1.start_agent(agent_uuid)
+    assert started is not None
+    assert volttron_instance1.agent_status(agent_uuid) is not None
+
+    #Now attempt removal
+    volttron_instance1.remove_agent(agent_uuid)
+
+    #Confirm that it has been removed.
+    assert volttron_instance1.agent_status(agent_uuid) is None
+
 
 messages = {}
 def onmessage(peer, sender, bus, topic, headers, message):

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -479,9 +479,14 @@ class PlatformWrapper:
         return aip.list_agents()
 
     def remove_agent(self, agent_uuid):
-        aip = self._aip()
-        uuid = aip.remove_agent(agent_uuid)
-        return aip.agent_status(uuid)
+        """Remove the agent specified by agent_uuid"""
+        _log.debug("REMOVING AGENT: {}".format(agent_uuid))
+        try:
+            cmd = ['volttron-ctl', 'remove', agent_uuid]
+            res = subprocess.check_output(cmd, env=self.env)
+        except CalledProcessError as ex:
+            _log.error("Exception: {}".format(ex))
+        return self.agent_status(agent_uuid)
 
     def is_agent_running(self, agent_uuid):
         return self.agent_status(agent_uuid) is not None


### PR DESCRIPTION
The problem occurred because volttron-ctl was not making an rpc call to remove
agent but was calling the AIPPlatform instance directly.  The inline call removed the
installed agent files but did not remove the agent from volttron's list of agents.

This commit includes a new test in test_platformwrapper: test_can_remove_agent,  along
with a corresponding change in PlatformWrapper.remove_agent which now makes a remote
call rather than calling the aip inline.  Its possible this was a workaround for
some other problem but I don't see any new tests failing because of the change.  Let me know if I've missed something.

I do see an indeterminate number of 'auth' tests failing (6-9) before and after
this change which I assume is related to my environment.  All other tests are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/451)
<!-- Reviewable:end -->
