### PR TITLE
Feature/volttron config

### DIFF
--- a/services/core/VolttronCentral/setup.py
+++ b/services/core/VolttronCentral/setup.py
@@ -78,11 +78,11 @@ agent_module = agent_package + '.' + MAIN_MODULE
 _temp = __import__(agent_module, globals(), locals(), ['__version__'], -1)
 __version__ = _temp.__version__
 
-# Setup
 setup(
+    include_package_data=True,
     name=agent_package + 'agent',
     version=__version__,
-    install_requires=['volttron', 'tornado'],
+    install_requires=['volttron'],
     packages=packages,
     package_data={
         package: ['webroot/*.*', 'webroot/font/*.*', 'webroot/css/*.css',

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ if __name__ == '__main__':
                 'volttron = volttron.platform.main:_main',
                 'volttron-ctl = volttron.platform.control:_main',
                 'volttron-pkg = volttron.platform.packaging:_main',
+                'volttron-cfg = volttron.platform.config:_main',
             ]
         },
         zip_safe = False,

--- a/volttron/platform/config.py
+++ b/volttron/platform/config.py
@@ -72,7 +72,9 @@ import os as _os
 import re as _re
 import shlex as _shlex
 import sys as _sys
-
+from gevent import subprocess
+from gevent.subprocess import Popen
+from . import get_home
 
 class TrackingString(str):
     '''String subclass that allows attaching source information.'''
@@ -558,3 +560,189 @@ _patch_argparse()
 
 def expandall(string):
     return _os.path.expanduser(_os.path.expandvars(string))
+
+def prompt_response(inputs):
+    """ Prompt the user for answers.
+
+    The inputs argument is a list or tuple with the following elements:
+    [0] - The prompt to the user
+    [1] - (Optional) A valid selection of responses
+    [2] - (Optional) Default value if the user just types enter.
+    """
+    while True:
+        resp = raw_input(inputs[0])
+        if resp == '' and len(inputs) == 3:
+            return inputs[2]
+        # No validation or tthe response was in the list of values.
+        if len(inputs) == 1 or resp in inputs[1]:
+            return resp
+        else:
+            print('Invalid response proper responses are: ')
+            print(inputs[1])
+
+def _install_vc(autostart):
+    print('Installing volttron central...')
+    from tempfile import NamedTemporaryFile
+    import hashlib
+    import json
+
+    cmd = ['volttron-ctl', 'remove', '--tag', 'vc', '--force']
+    process = Popen(cmd, env=_os.environ)
+    process.wait()
+
+    admin_pass = hashlib.sha512('admin').hexdigest()
+    cfg_file = NamedTemporaryFile()
+    cfg = {
+        "identity": "volttron.central",
+        "server" : {
+            "host": "127.0.0.1",
+            "port": 8070,
+            "debug": False
+        },
+        "users" : {
+            "admin" : {
+                "password" : admin_pass,
+                "groups" : [
+                    "admin"
+                ]
+            }
+        }
+    }
+    cfg_file = NamedTemporaryFile()
+    with open(cfg_file.name, 'w') as cf:
+        cf.write(json.dumps(cfg))
+
+    cmd = ['scripts/core/pack_install.sh',
+            'services/core/VolttronCentral',
+            cfg_file.name,
+            'vc']
+    process = Popen(cmd, env=_os.environ)
+
+    process.wait()
+    if autostart:
+        cmd = ['volttron-ctl',
+                'enable',
+                '--tag',
+                'vc']
+        process = Popen(cmd, env=_os.environ)
+        process.wait()
+
+def _install_platform(is_vc):
+    print('Installing platform...')
+    cfg_file = 'services/core/Platform/config'
+    if is_vc:
+        cfg_file = 'services/core/Platform/vc.platform.config'
+    cmd = ['volttron-ctl', 'remove', '--tag', 'platform', '--force']
+    process = Popen(cmd, env=_os.environ)
+    process.wait()
+
+    cmd = ['scripts/core/pack_install.sh',
+            'services/core/Platform',
+            cfg_file,
+            'platform']
+    process = Popen(cmd, env=_os.environ)
+    process.wait()
+
+    cmd = ['volttron-ctl',
+            'enable',
+            '--tag',
+            'platform']
+    process = Popen(cmd, env=_os.environ)
+    process.wait()
+
+def _enable_discovery(address_port):
+    """ Enable discovery will autostart when the volttron instance starts.
+
+    Puts the port and binding ip address that should be bound to in the root
+    directory of VOLTTRON_HOME.
+    """
+    discovery_file = _os.path.join(_os.environ['VOLTTRON_HOME'], 'DISCOVERY')
+    with open(discovery_file, 'w') as df:
+        df.write(address_port)
+
+def _start_platform():
+    cmd = ['volttron', '--developer-mode']
+
+    pid = Popen(cmd, env=_os.environ, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    print('Configuring instance...')
+    return pid
+
+def _shutdown_platform():
+    print('Shutting down platform...')
+    cmd = ['volttron-ctl', 'shutdown', '--platform']
+
+    pid = Popen(cmd, env=_os.environ)
+
+def _make_configuration(external_uri, volttron_central=None):
+    print('Building cofiguration file.')
+    import ConfigParser as configparser # python3 has configparser rather than
+                                        # this name.
+    config = configparser.ConfigParser()
+    config.add_section('volttron')
+    config.set('volttron', 'vip-address', external_uri)
+    if volttron_central:
+        config.set('volttron', 'volttron-central', volttron_central)
+    cfgfile = _os.path.join(get_home(), 'config')
+    with open(cfgfile, 'w') as cf:
+        config.write(cf)
+
+def _resolvable(uri_and_port):
+    import requests
+    discovery_uri = "http://"+uri_and_port+"/discovery/"
+    req = requests.request('GET', discovery_uri)
+    return True
+
+def _main():
+    """ Routine for configuring an insalled volttron instance.
+
+    The function interactively sets up the instance for working with volttron
+    central and the discovery service.
+    """
+    volttron_home = _os.path.normpath(expandall(
+            _os.environ.get('VOLTTRON_HOME', '~/.volttron')))
+    _os.environ['VOLTTRON_HOME'] = volttron_home
+    if not _os.path.exists(volttron_home):
+        _os.makedirs(volttron_home, 0o755)
+
+    y_or_n = ('Y', 'N', 'y', 'n')
+    y = ('Y', 'y')
+    t = ('Is this instance discoverable (Y/N)? [N] ', y_or_n, 'N')
+    is_discoverable = prompt_response(t)
+
+    if is_discoverable in ('Y', 'y'):
+        t = ('What is the external ip address for this instance? ',)
+        external_ip = prompt_response(t)
+        t = ('What is the vip port this instance? [22916] ',)
+        vip_port = prompt_response(t)
+        if not vip_port:
+            vip_port = 22916
+        t = ('What is the port for discovery? [8080] ',)
+        external_port = prompt_response(t)
+        if not external_port:
+            external_port = 8080
+        t = ('Is this instance a volttron central (Y/N)? [N] ', y_or_n, 'N')
+        is_vc = prompt_response(t)
+        vc_autostart = 'Y'
+        if is_vc in y:
+            t = ('Should volttron central autostart(Y/N)? [Y] ', y_or_n, 'Y')
+            vc_autostart = prompt_response(t)
+        else:
+            t = ('Address and port of volttron central? ',)
+            vc_ipaddress = prompt_response(t)
+            while not _resolvable(vc_ipaddress):
+                print("Couldn't resolve {}".format(vc_ipaddress))
+                vc_ipaddress = prompt_response(t)
+        try:
+            external_uri = "tcp://{}:{}".format(external_ip, vip_port)
+            _make_configuration(external_uri, vc_ipaddress)
+        except: # Should only happen if this is a vc instance.
+            _make_configuration(external_uri)
+
+        _start_platform()
+        _install_platform(is_vc in y)
+        _enable_discovery(r'{}:{}'.format(external_ip, external_port))
+        if is_vc in y:
+            _install_vc(vc_autostart in y)
+        _shutdown_platform()
+        print('Finished configuration\n')

--- a/volttron/platform/jsonrpc.py
+++ b/volttron/platform/jsonrpc.py
@@ -63,6 +63,7 @@ See http://www.jsonrpc.org/specification for the complete specification.
 import sys
 from contextlib import contextmanager
 
+from zmq.utils import jsonapi
 
 __all__ = ['Error', 'MethodNotFound', 'RemoteError', 'Dispatcher']
 
@@ -76,6 +77,14 @@ INTERNAL_ERROR = -32603
 # implementation-defined server-errors:
 UNHANDLED_EXCEPTION = -32000
 UNAUTHORIZED = -32001
+UNABLE_TO_REGISTER_INSTANCE = -32002
+DISCOVERY_ERROR = -32003
+
+
+def json_validate_request(jsonrequest):
+    assert jsonrequest.get('id', None)
+    assert jsonrequest.get('jsonrpc', None) == '2.0'
+    assert jsonrequest.get('method', None)
 
 
 def json_method(ident, method, args, kwargs):
@@ -103,6 +112,40 @@ def json_error(ident, code, message, **data):
     if data:
         error['data'] = data
     return {'jsonrpc': '2.0', 'id': ident, 'error': error}
+
+
+class ParseError(StandardError):
+    pass
+
+
+class JsonRpcData(object):
+    ''' A `JsonRpcData` reprepresents the data associated with an rpc request.
+    '''
+    def __init__(self, id, version, method, params, authorization):
+        self.id = id
+        self.version = version
+        self.method = method
+        self.params = params
+        self.authorization = authorization
+
+    @staticmethod
+    def parse(jsonstr):
+        data = jsonapi.loads(jsonstr)
+        id = data.get('id', None)
+        version = data.get('jsonrpc', None)
+        method = data.get('method', None)
+        params = data.get('params', None)
+        authorization = data.get('authorization', None)
+
+        if id == None:
+            raise ParseError("Invalid id")
+        if version != '2.0':
+            print("VERSION IS: {}".format(version))
+            raise ParseError('Invalid jsonrpc version')
+        if method == None:
+            raise ParseError('Method not specified.')
+
+        return JsonRpcData(id, version, method, params, authorization)
 
 
 class Error(Exception):

--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -64,6 +64,9 @@ from urlparse import urlparse, urljoin
 
 from gevent import pywsgi
 import mimetypes
+
+from requests.packages.urllib3.connection import (ConnectionError,
+                                                  NewConnectionError)
 from zmq.utils import jsonapi
 
 from .auth import AuthEntry, AuthFile
@@ -98,8 +101,6 @@ class DiscoveryInfo(object):
         self.discovery_address = kwargs.pop('discovery_address')
         self.vip_address = kwargs.pop('vip-address')
         self.serverkey = kwargs.pop('serverkey')
-        self.vcpublickey = kwargs.pop('vcpublickey', None)
-        self.papublickey = kwargs.pop('papublickey', None)
         assert len(kwargs) == 0
 
     @staticmethod
@@ -116,14 +117,21 @@ class DiscoveryInfo(object):
 
         assert parsed.scheme
         assert not parsed.path
-
+        try:
         real_url = urljoin(discovery_address, "/discovery/")
+            _log.debug('Connecting to: {}'.format(real_url))
         response = requests.get(real_url)
 
         if not response.ok:
             raise DiscoveryError(
                 "Invalid discovery response from {}".format(real_url)
             )
+        except (ConnectionError, NewConnectionError) as e:
+            raise DiscoveryError(
+                "Connection to {} not available".format(real_url)
+            )
+        except Exception as e:
+            raise DiscoveryError("Unhandled exception {}".format(e))
 
         return DiscoveryInfo(
             discovery_address=discovery_address, **(response.json()))
@@ -134,12 +142,6 @@ class DiscoveryInfo(object):
             'vip_address': self.vip_address,
             'serverkey': self.serverkey
         }
-
-        if self.vcpublickey:
-            dk['vcpublickey'] = self.vcpublickey
-
-        if self.papublickey:
-            dk['papublickey'] = self.papublickey
 
         return jsonapi.dumps(dk)
 
@@ -179,12 +181,28 @@ class MasterWebService(Agent):
         super(MasterWebService, self).__init__(identity, address)
 
         self.bind_web_address = bind_web_address
+        # if the web address is bound then we need to allow the web agent
+        # to be discoverable.  That means we need to allow connections to
+        # the message bus in some known addresses if they aren't already
+        # specified.
+        if self.bind_web_address:
+            authfile = AuthFile()
+            entries, _, _ = authfile.read()
+            if not entries:
+                _log.debug(
+                    'Adding default curve credentials for discoverability.')
+                authfile.add(AuthEntry(credentials="/CURVE:.*/"))
+
         self.serverkey = serverkey
         self.registeredroutes = []
         self.peerroutes = defaultdict(list)
         self.aip = aip
         if not mimetypes.inited:
             mimetypes.init()
+
+        authentry = AuthEntry(credentials="/CURVE:.*/")
+        authfile = AuthFile()
+        authfile.add(authentry)
 
     @RPC.export
     def get_bind_web_address(self):
@@ -221,7 +239,13 @@ class MasterWebService(Agent):
         compiled = re.compile(regex)
         self.registeredroutes.append((compiled, 'path', root_dir))
 
-    def _redirect_index(self, env, start_response):
+    def _redirect_index(self, env, start_response, data=None):
+        """ Redirect to the index page.
+        @param env:
+        @param start_response:
+        @param data:
+        @return:
+        """
         start_response('302 Found', [('Location', '/index.html')])
         return ['1']
 
@@ -265,18 +289,6 @@ class MasterWebService(Agent):
         peers = self.vip.peerlist().get(timeout=2)
 
         return_dict = {}
-        vc_publickey = None
-        pa_publickey = None
-        if 'volttron.central' in peers:
-            print('doing vc public key')
-            vc_publickey = self.aip.agent_publickey('volttron.central')
-            # vc_publickey = q.query(b'publickey', b'volttron.central').get(timeout=2)
-            return_dict['vcpublickey'] = vc_publickey
-        if 'platform.agent' in peers:
-            print('doing pa public key')
-            pa_publickey = self.aip.agent_publickey('platform.agent')
-            # pa_publickey = q.query(b'publickey', b'platform.agent').get(timeout=2)
-            return_dict['papublickey'] = pa_publickey
 
         if self.serverkey:
             return_dict['serverkey'] = encode_key(self.serverkey)
@@ -310,6 +322,7 @@ class MasterWebService(Agent):
             if k.match(path_info):
                 _log.debug("MATCHED:\npattern: {}, path_info: {}\n v: {}"
                            .format(k.pattern, path_info, v))
+                _log.debug('registered route t is: {}'.format(t))
                 if t == 'callable':  # Generally for locally called items.
                     return v(env, start_response, data)
                 elif t == 'peer_route':  # RPC calls from agents on the platform.
@@ -367,7 +380,7 @@ class MasterWebService(Agent):
         hostname = parsed.hostname
         port = parsed.port
 
-        _log.debug('Starting web server binding to {}:{}.' \
+        _log.info('Starting web server binding to {}:{}.' \
                    .format(hostname, port))
         self.registeredroutes.append((re.compile('^/discovery/$'), 'callable',
                                       self._get_discovery))
@@ -379,3 +392,23 @@ class MasterWebService(Agent):
         port = int(port)
         server = pywsgi.WSGIServer((hostname, port), self.app_routing)
         server.serve_forever()
+
+
+def build_vip_address_string(vip_root, serverkey, publickey, secretkey):
+    """ Build a full vip address string based upon the passed arguments
+
+    All arguments are required to be non-None in order for the string to be
+    created successfully.
+
+    :raises ValueError if one of the parameters is None.
+    """
+    _log.debug("root: {}, serverkey: {}, publickey: {}, secretkey: {}".format(
+        vip_root, serverkey, publickey, secretkey))
+    if not (serverkey and publickey and secretkey and vip_root):
+        raise ValueError("All parameters must be entered.")
+
+    root = "{}?serverkey={}&publickey={}&secretkey={}".format(
+        vip_root, serverkey, publickey, secretkey
+    )
+
+    return root

--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -118,14 +118,14 @@ class DiscoveryInfo(object):
         assert parsed.scheme
         assert not parsed.path
         try:
-        real_url = urljoin(discovery_address, "/discovery/")
-            _log.debug('Connecting to: {}'.format(real_url))
-        response = requests.get(real_url)
+            real_url = urljoin(discovery_address, "/discovery/")
+            _log.info('Connecting to: {}'.format(real_url))
+            response = requests.get(real_url)
 
-        if not response.ok:
-            raise DiscoveryError(
-                "Invalid discovery response from {}".format(real_url)
-            )
+            if not response.ok:
+                raise DiscoveryError(
+                    "Invalid discovery response from {}".format(real_url)
+                )
         except (ConnectionError, NewConnectionError) as e:
             raise DiscoveryError(
                 "Connection to {} not available".format(real_url)


### PR DESCRIPTION
I broke out the volttron-cfg into its own little pull request so that we can test that separately.

Please use volttron-cfg as the starting point for evaluating this pull request.  The goal of this is to install a platform agent and a volttroncentral agent to a volttron instance.

Use VOLTTRON_HOME=/tmp to set where the configurations will be setup.

This will also set up an external ip addres in the VOLTTRON_HOME/config file.

**Note** this will need to be modified again as the feature/web branch has different agent for platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/472)
<!-- Reviewable:end -->
