### PR TITLE
Attempt to fix issue with get_volttron_instances api change

### DIFF
--- a/volttrontesting/testutils/test_platformwrapper.py
+++ b/volttrontesting/testutils/test_platformwrapper.py
@@ -241,7 +241,9 @@ def test_can_ping_router(volttron_instance):
 
 @pytest.mark.wrapper
 def test_can_install_listener_on_two_platforms(get_volttron_instances):
-    (_, volttron_instance1), (_,volttron_instance2) = get_volttron_instances(2)
+    first, second = get_volttron_instances(2)
+    _, volttron_instance1 = first
+    _,volttron_instance2 = second
     global messages
     clear_messages()
     auuid = volttron_instance1.install_agent(

--- a/volttrontesting/testutils/test_platformwrapper.py
+++ b/volttrontesting/testutils/test_platformwrapper.py
@@ -241,9 +241,10 @@ def test_can_ping_router(volttron_instance):
 
 @pytest.mark.wrapper
 def test_can_install_listener_on_two_platforms(get_volttron_instances):
-    first, second = get_volttron_instances(2)
-    _, volttron_instance1 = first
-    _,volttron_instance2 = second
+
+    param, (volttron_instance1,
+            volttron_instance2) = get_volttron_instances(2)
+
     global messages
     clear_messages()
     auuid = volttron_instance1.install_agent(

--- a/volttrontesting/testutils/test_platformwrapper.py
+++ b/volttrontesting/testutils/test_platformwrapper.py
@@ -241,7 +241,7 @@ def test_can_ping_router(volttron_instance):
 
 @pytest.mark.wrapper
 def test_can_install_listener_on_two_platforms(get_volttron_instances):
-    volttron_instance1, volttron_instance2 = get_volttron_instances(2)
+    (_, volttron_instance1), (_,volttron_instance2) = get_volttron_instances(2)
     global messages
     clear_messages()
     auuid = volttron_instance1.install_agent(


### PR DESCRIPTION
The api changed to returning the param (encrypted or unencrypted) and then the wrapper instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/626)
<!-- Reviewable:end -->
