### PR TITLE
Possible fix for "ZMQ too many open files" error on travis ci

### DIFF
--- a/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
@@ -1845,7 +1845,6 @@ def test_revert_point(publish_agent, cancel_schedules):
 
 
 @pytest.mark.actuator_pubsub
-@pytest.mark.dev
 def test_revert_device(publish_agent, cancel_schedules):
     """
     Test setting a float value of a point  through pubsub.

--- a/services/core/SQLHistorian/tests/test_sqlhistorian.py
+++ b/services/core/SQLHistorian/tests/test_sqlhistorian.py
@@ -665,7 +665,6 @@ def test_exact_timestamp_with_z(request, sqlhistorian, publish_agent,
     assert_timestamp(result['values'][0][0], now_date, now_time)
     assert (result['values'][0][1] == mixed_reading)
 
-
 @pytest.mark.sqlhistorian
 @pytest.mark.historian
 def test_query_start_time(request, sqlhistorian, publish_agent, query_agent,

--- a/services/core/VolttronCentral/tests/test_vc_vcp_local.py
+++ b/services/core/VolttronCentral/tests/test_vc_vcp_local.py
@@ -35,7 +35,6 @@ def setup_first(request, get_volttron_instances):
     return wrapper
 
 
-@pytest.mark.dev
 def test_agentlist(setup_first):
     wrapper = setup_first
 
@@ -46,7 +45,6 @@ def test_agentlist(setup_first):
         cn_vcp.kill()
 
 
-@pytest.mark.dev
 def test_discovered(setup_first):
     wrapper = setup_first
 

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -597,47 +597,24 @@ class PlatformWrapper:
 
         agent = self.build_agent()
         self.logit('Creating channel for sending the agent.')
-        channel_name = str(uuid.uuid4())
-        channel = agent.vip.channel('control',
-                                    channel_name)
         gevent.sleep(0.3)
         self.logit('calling control install agent.')
-        result = agent.vip.rpc.call('control',
-                                    'install_agent',
-                                    wheel_file,
-                                    channel_name,
-                                    vip_identity)
-        self.logit('waiting for ready')
-        response = channel.recv()
-        if response != b'ready':
-            raise ValueError('Invalid channel protocol returned {}'.format(
-                response))
-
-        with open(wheel_file, 'rb') as fin:
-            _log.debug('sending wheel to control.')
-            while True:
-                data = fin.read(8125)
-                if not data:
-                    _log.debug('Finished sending data')
-                    break
-                channel.send(data)
-
-        _log.debug('sending done message.')
-        channel.send('done')
-        try:
-            # must do this before channel closes or process will hang.
-            auuid = result.get(timeout=10)
-            _log.debug('closing channel')
-        except gevent.Timeout:
-            _log.error('Timeout in channel')
-        finally:
-            channel.close(linger=0)
-            del channel
+        self.logit("VOLTTRON_HOME SETTING: {}".format(
+            self.env['VOLTTRON_HOME']))
+        env = self.env.copy()
+        cmd = ['volttron-ctl', '-vv', 'install', wheel_file]
+        if vip_identity:
+            cmd = ['volttron-ctl', '-vv', 'install', wheel_file,
+                   '--vip-identity', vip_identity]
+        res = subprocess.check_output(cmd, env=env)
+        assert res, "failed to install wheel:{}".format(wheel_file)
+        agent_uuid = res.split(' ')[-2]
+        self.logit(agent_uuid)
 
         if start:
-            self.start_agent(auuid)
+             self.start_agent(agent_uuid)
 
-        return auuid
+        return agent_uuid
 
     def install_multiple_agents(self, agent_configs):
         """

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -604,8 +604,7 @@ class PlatformWrapper:
         env = self.env.copy()
         cmd = ['volttron-ctl', '-vv', 'install', wheel_file]
         if vip_identity:
-            cmd = ['volttron-ctl', '-vv', 'install', wheel_file,
-                   '--vip-identity', vip_identity]
+            cmd.extend(['--vip-identity', vip_identity])
         res = subprocess.check_output(cmd, env=env)
         assert res, "failed to install wheel:{}".format(wheel_file)
         agent_uuid = res.split(' ')[-2]


### PR DESCRIPTION
calling volttron-ctl command to install agent instead of rpc.call('control','install_agent',wheel_file,channel_name,vip_identity) in the hope to fix the "ZMQ too many open files" error on travis ci

removed pytest.mark.dev from test cases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/763)
<!-- Reviewable:end -->
