### PR TITLE
changed default mechanism from NULL to CURVE in volttron-ctl auth add

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -771,7 +771,7 @@ def list_auth(opts, indices=None):
 
 def _ask_for_auth_fields(domain=None, address=None, user_id=None,
                          capabilities=None, roles=None, groups=None,
-                         mechanism='NULL', credentials=None, comments=None,
+                         mechanism='CURVE', credentials=None, comments=None,
                          enabled=True, **kwargs):
     class Asker(object):
         def __init__(self):


### PR DESCRIPTION
As I was going through `volttron-control auth add` documentation I realized that it makes more sense for the default mechanism field to be `CURVE` rather than `NULL`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/843)
<!-- Reviewable:end -->
