### PR TITLE
Added 'volttron-ctl upgrade' command

### DIFF
--- a/services/core/FailoverAgent/tests/test_failover.py
+++ b/services/core/FailoverAgent/tests/test_failover.py
@@ -44,8 +44,8 @@ def tcp_to(instance):
     return "{}?serverkey={}&publickey={}&secretkey={}".format(
         instance.vip_address,
         instance.serverkey,
-        key.public(),
-        key.secret())
+        key.public,
+        key.secret)
 
 
 def all_agents_running(instance):

--- a/services/core/FailoverAgent/tests/test_simple_failover.py
+++ b/services/core/FailoverAgent/tests/test_simple_failover.py
@@ -3,8 +3,6 @@ import tempfile
 import pytest
 import gevent
 
-from volttron.platform.auth import AuthEntry, AuthFile
-from volttron.platform.keystore import KeyStore
 
 simple_primary_config = {
     "agent_id": "primary",

--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -8,8 +8,6 @@ import pytest
 from zmq.utils import jsonapi
 
 from volttron.platform.messaging import headers as headers_mod
-from volttron.platform.auth import AuthEntry, AuthFile
-from volttron.platform.keystore import KeyStore
 
 from volttrontesting.utils.platformwrapper import build_vip_address
 

--- a/services/core/ForwardHistorian/tests/test_forwardhistorian.py
+++ b/services/core/ForwardHistorian/tests/test_forwardhistorian.py
@@ -193,7 +193,7 @@ def forwarder(request, volttron_instances):
 
         # add public key of instance1 to instance2 auth file
         authfile = AuthFile(volttron_instance2.volttron_home + "/auth.json")
-        entry = AuthEntry(credentials=ks.public())
+        entry = AuthEntry(credentials=ks.public)
         authfile.add(entry)
 
         # setup destination address to include keys
@@ -201,7 +201,7 @@ def forwarder(request, volttron_instances):
             "{}?serverkey={}&publickey={}&secretkey={}".format(
                 volttron_instance2.vip_address,
                 volttron_instance2.serverkey,
-                ks.public(), ks.secret())
+                ks.public, ks.secret)
     else:
         forwarder_config["destination-vip"] = volttron_instance2.vip_address
     # 1: Install historian agent

--- a/services/core/VolttronCentralPlatform/tests/test_platformagent.py
+++ b/services/core/VolttronCentralPlatform/tests/test_platformagent.py
@@ -26,7 +26,7 @@ def get_new_keypair():
     tf = tempfile.NamedTemporaryFile()
     ks = KeyStore(tf.name)
     ks.generate()
-    return ks.public(), ks.secret()
+    return ks.public, ks.secret
 
 
 def add_to_auth(volttron_home, publickey, capabilities=None):

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -284,7 +284,8 @@ class AIPplatform(object):
             raise
         return agent_uuid
 
-    def install_agent(self, agent_wheel, vip_identity=None):
+    def install_agent(self, agent_wheel, vip_identity=None, publickey=None,
+                      secretkey=None, add_auth=True):
         while True:
             agent_uuid = str(uuid.uuid4())
             if agent_uuid in self.agents:
@@ -306,7 +307,13 @@ class AIPplatform(object):
             final_identity = self._setup_agent_vip_id(agent_uuid,
                                                       vip_identity=vip_identity)
 
-            self._authorize_agent_keys(agent_uuid, final_identity)
+            if publickey is not None and secretkey is not None:
+                keystore = self.get_agent_keystore(agent_uuid)
+                keystore.public = publickey
+                keystore.secret = secretkey
+
+            if add_auth:
+                self._authorize_agent_keys(agent_uuid, final_identity)
 
         except Exception:
             shutil.rmtree(agent_path)
@@ -364,23 +371,22 @@ class AIPplatform(object):
 
         return final_identity
 
-    def get_agent_publickey(self, agent_uuid):
+    def get_agent_keystore(self, agent_uuid):
         agent_path = os.path.join(self.install_dir, agent_uuid)
         name = self.agent_name(agent_uuid)
         agent_path_with_name = os.path.join(agent_path, name)
         data_dir = self._get_data_dir(agent_path_with_name)
         keystore_path = os.path.join(data_dir, 'keystore.json')
-        keystore = KeyStore(keystore_path)
-        return keystore.public()
+        return KeyStore(keystore_path)
 
     def _authorize_agent_keys(self, agent_uuid, identity):
-        publickey = self.get_agent_publickey(agent_uuid)
+        publickey = self.get_agent_keystore(agent_uuid).public
         entry = AuthEntry(credentials=publickey, user_id=identity,
                           comments='Automatically added on agent install')
         AuthFile().add(entry)
 
     def _unauthorize_agent_keys(self, agent_uuid):
-        publickey = self.get_agent_publickey(agent_uuid)
+        publickey = self.get_agent_keystore(agent_uuid).public
         AuthFile().remove_by_credentials(publickey)
 
     def _get_data_dir(self, agent_path):
@@ -391,8 +397,8 @@ class AIPplatform(object):
             os.mkdir(data_dir)
         return data_dir
 
-    def get_all_agent_identities(self):
-        results = set()
+    def get_agent_identity_to_uuid_mapping(self):
+        results = {}
         for agent_uuid in self.list_agents():
             try:
                 agent_identity = self.agent_identity(agent_uuid)
@@ -400,9 +406,12 @@ class AIPplatform(object):
                 continue
 
             if agent_identity is not None:
-                results.add(agent_identity)
+                results[agent_identity] = agent_uuid
 
         return results
+
+    def get_all_agent_identities(self):
+       return self.get_agent_identity_to_uuid_mapping().keys()
 
     def _get_available_agent_identity(self, name_template):
         all_agent_identities = self.get_all_agent_identities()
@@ -419,12 +428,13 @@ class AIPplatform(object):
                 return test_name
             count += 1
 
-    def remove_agent(self, agent_uuid):
+    def remove_agent(self, agent_uuid, remove_auth=True):
         if agent_uuid not in os.listdir(self.install_dir):
             raise ValueError('invalid agent')
         self.stop_agent(agent_uuid)
         self.agents.pop(agent_uuid, None)
-        self._unauthorize_agent_keys(agent_uuid)
+        if remove_auth:
+            self._unauthorize_agent_keys(agent_uuid)
         shutil.rmtree(os.path.join(self.install_dir, agent_uuid))
 
     def agent_name(self, agent_uuid):

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -211,13 +211,13 @@ class ControlService(BaseAgent):
         return self._aip.tag_agent(uuid, tag)
 
     @RPC.export
-    def remove_agent(self, uuid):
+    def remove_agent(self, uuid, remove_auth=True):
         if not isinstance(uuid, basestring):
             identity = bytes(self.vip.rpc.context.vip_message.peer)
             raise TypeError("expected a string for 'uuid';"
                             "got {!r} from identity: {}".format(
                 type(uuid).__name__, identity))
-        self._aip.remove_agent(uuid)
+        self._aip.remove_agent(uuid, remove_auth=remove_auth)
 
     @RPC.export
     def prioritize_agent(self, uuid, priority='50'):
@@ -248,11 +248,16 @@ class ControlService(BaseAgent):
         return self._aip.agent_identity(uuid)
 
     @RPC.export
-    def install_agent_local(self, filename, vip_identity=None):
-        return self._aip.install_agent(filename, vip_identity=vip_identity)
+    def install_agent_local(self, filename, vip_identity=None, publickey=None,
+                            secretkey=None, add_auth=True):
+        return self._aip.install_agent(filename, vip_identity=vip_identity,
+                                       publickey=publickey,
+                                       secretkey=secretkey,
+                                       add_auth=add_auth)
 
     @RPC.export
-    def install_agent(self, filename, channel_name, vip_identity=None):
+    def install_agent(self, filename, channel_name, vip_identity=None,
+                      publickey=None, secretkey=None, add_auth=True):
         """ Installs an agent on the instance instance.
 
         The installation of an agent through this method involves sending
@@ -291,7 +296,12 @@ class ControlService(BaseAgent):
             The name of the agent packaged file that is being written.
         @param:string:channel_name:
             The name of the channel that the agent file will be sent on.
-
+        @param:string:publickey:
+            Encoded public key the installed agent will use
+        @param:string:secretkey:
+            Encoded secret key the installed agent will use
+        @param:bool:add_auth:
+            Add the agent's credentials to the authorized-agent list
         """
 
         peer = bytes(self.vip.rpc.context.vip_message.peer)
@@ -340,7 +350,11 @@ class ControlService(BaseAgent):
                 channel.close(linger=0)
                 del channel
 
-            agent_uuid = self._aip.install_agent(path, vip_identity=vip_identity)
+            agent_uuid = self._aip.install_agent(path,
+                                                 vip_identity=vip_identity,
+                                                 publickey=publickey,
+                                                 secretkey=secretkey,
+                                                 add_auth=add_auth)
             return agent_uuid
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -403,7 +417,31 @@ def filter_agent(agents, pattern, opts):
     return next(filter_agents(agents, [pattern], opts))[1]
 
 
-def install_agent(opts):
+def upgrade_agent(opts):
+    publickey = None
+    secretkey = None
+    identity = opts.vip_identity
+    if not identity:
+        raise ValueError("Missing required VIP IDENTITY option")
+
+    identity_to_uuid = opts.aip.get_agent_identity_to_uuid_mapping()
+    agent_uuid = identity_to_uuid.get(identity, None)
+    if agent_uuid:
+        keystore = opts.aip.get_agent_keystore(agent_uuid)
+        publickey = keystore.public
+        secretkey = keystore.secret
+        _stdout.write('Removing previous version of agent "{}"\n'
+                .format(identity))
+        opts.connection.call('remove_agent', agent_uuid, remove_auth=False)
+    else:
+        _stdout.write(('Could not find agent with VIP IDENTITY "{}". '
+                       'Installing as new agent\n').format(identity))
+
+    install_agent(opts, publickey=publickey, secretkey=secretkey,
+                  add_auth=False)
+
+
+def install_agent(opts, publickey=None, secretkey=None, add_auth=True):
     aip = opts.aip
     filename = opts.wheel
     tag = opts.tag
@@ -414,7 +452,10 @@ def install_agent(opts):
         filename = config.expandall(filename)
         agent_uuid = opts.connection.call('install_agent_local',
                                           filename,
-                                          vip_identity=vip_identity)
+                                          vip_identity=vip_identity,
+                                          publickey=publickey,
+                                          secretkey=secretkey,
+                                          add_auth=add_auth)
 
         if tag:
             opts.connection.call('tag_agent', agent_uuid, tag)
@@ -429,7 +470,10 @@ def install_agent(opts):
             agent_uuid = opts.connection.call_no_get('install_agent',
                                                      filename,
                                                      channel_name,
-                                                     vip_identity=vip_identity)
+                                                     vip_identity=vip_identity,
+                                                     publickey=publickey,
+                                                     secretkey=secretkey,
+                                                     add_auth=add_auth)
 
             _log.debug('Sending wheel to control')
             sha512 = hashlib.sha512()
@@ -498,7 +542,7 @@ def tag_agent(opts):
             _stdout.writelines([agent.tag, '\n'])
 
 
-def remove_agent(opts):
+def remove_agent(opts, remove_auth=True):
     agents = _list_agents(opts.aip)
     for pattern, match in filter_agents(agents, opts.pattern, opts):
         if not match:
@@ -514,7 +558,8 @@ def remove_agent(opts):
             return 10
         for agent in match:
             _stdout.write('Removing {} {}\n'.format(agent.uuid, agent.name))
-            opts.connection.call('remove_agent', agent.uuid)
+            opts.connection.call('remove_agent', agent.uuid,
+                                 remove_auth=remove_auth)
 
 
 def _calc_min_uuid_length(agents):
@@ -735,7 +780,7 @@ def gen_keypair(opts):
             return
     keystore = KeyStore(opts.keystore_file)
     keystore.generate()  # call generate to force new keys to be generated
-    _stdout.write('public key: {}\n'.format(keystore.public()))
+    _stdout.write('public key: {}\n'.format(keystore.public))
     _stdout.write('keys written to {}\n'.format(opts.keystore_file))
 
 
@@ -1015,7 +1060,7 @@ def _show_filtered_agents(opts, field_name, field_callback, agents=None):
 def get_agent_publickey(opts):
 
     def get_key(agent):
-        return opts.aip.get_agent_publickey(agent.uuid)
+        return opts.aip.get_agent_keypair(agent.uuid)[0]
 
     _show_filtered_agents(opts, 'PUBLICKEY', get_key)
 
@@ -1141,8 +1186,8 @@ def get_keys(opts):
     hosts = KnownHostsStore(opts.known_hosts_file)
     serverkey = hosts.serverkey(opts.vip_address)
     key_store = KeyStore(opts.keystore_file)
-    publickey = key_store.public()
-    secretkey = key_store.secret()
+    publickey = key_store.public
+    secretkey = key_store.secret
     return {'publickey': publickey, 'secretkey': secretkey,
             'serverkey': serverkey}
 
@@ -1331,6 +1376,23 @@ def main(argv=sys.argv):
                          dest='verify_agents',
                          help=argparse.SUPPRESS)
     run.set_defaults(func=run_agent)
+
+    upgrade = add_parser('upgrade', help='upgrade agent from wheel',
+                         epilog='Optionally you may specify the --tag argument to tag the '
+                                'agent during upgrade without requiring a separate call to '
+                                'the tag command. ')
+    upgrade.add_argument('vip_identity', metavar='vip-identity',
+            help='VIP IDENTITY of agent to upgrade')
+    upgrade.add_argument('wheel', help='path to new agent wheel')
+    upgrade.add_argument('--tag', help='tag for the upgraded agent')
+    if HAVE_RESTRICTED:
+        upgrade.add_argument('--verify', action='store_true',
+                             dest='verify_agents',
+                             help='verify agent integrity during upgrade')
+        upgrade.add_argument('--no-verify', action='store_false',
+                             dest='verify_agents',
+                             help=argparse.SUPPRESS)
+    upgrade.set_defaults(func=upgrade_agent, verify_agents=True)
 
     auth_cmds = add_parser("auth",
             help="manage authorization entries and encryption keys")

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1060,7 +1060,7 @@ def _show_filtered_agents(opts, field_name, field_callback, agents=None):
 def get_agent_publickey(opts):
 
     def get_key(agent):
-        return opts.aip.get_agent_keypair(agent.uuid)[0]
+        return opts.aip.get_agent_keystore(agent.uuid).public
 
     _show_filtered_agents(opts, 'PUBLICKEY', get_key)
 

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -771,7 +771,7 @@ def list_auth(opts, indices=None):
 
 def _ask_for_auth_fields(domain=None, address=None, user_id=None,
                          capabilities=None, roles=None, groups=None,
-                         mechanism='NULL', credentials=None, comments=None,
+                         mechanism='CURVE', credentials=None, comments=None,
                          enabled=True, **kwargs):
     class Asker(object):
         def __init__(self):

--- a/volttron/platform/keystore.py
+++ b/volttron/platform/keystore.py
@@ -140,17 +140,27 @@ class KeyStore(BaseJSONStore):
                 key = None
         return key
 
+    @property
     def public(self):
         """Return encoded public key"""
         return self._get_key('public')
 
+    @public.setter
+    def public(self, encoded_public_key):
+        self.update({'public': encoded_public_key, 'secret': self.secret})
+
+    @property
     def secret(self):
         """Return encoded secret key"""
         return self._get_key('secret')
 
+    @secret.setter
+    def secret(self, encoded_secret_key):
+        self.update({'public': self.public, 'secret': encoded_secret_key})
+
     def isvalid(self):
         """Check if key pair is valid"""
-        return self.public() and self.secret()
+        return self.public and self.secret
 
 
 class KnownHostsStore(BaseJSONStore):

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -517,7 +517,7 @@ def start_volttron_process(opts):
         st = os.stat(keystore.filename)
         if st.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
             _log.warning('insecure mode on key file')
-        publickey = decode_key(keystore.public())
+        publickey = decode_key(keystore.public)
         if publickey:
             _log.info('public key: %s', encode_key(publickey))
             # Authorize the platform key:
@@ -530,7 +530,7 @@ def start_volttron_process(opts):
             known_hosts.add(opts.vip_local_address, encode_key(publickey))
             for addr in opts.vip_address:
                 known_hosts.add(addr, encode_key(publickey))
-        secretkey = decode_key(keystore.secret())
+        secretkey = decode_key(keystore.secret)
 
     # The following line doesn't appear to do anything, but it creates
     # a context common to the green and non-green zmq modules.

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -521,7 +521,7 @@ class Core(BasicCore):
 
         keystore_path = os.path.join(keystore_dir, 'keystore.json')
         keystore = KeyStore(keystore_path)
-        return keystore.public(), keystore.secret()
+        return keystore.public, keystore.secret
 
     def _get_keys_from_addr(self):
         url = list(urlparse.urlsplit(self.address))

--- a/volttrontesting/platform/auth_test.py
+++ b/volttrontesting/platform/auth_test.py
@@ -17,10 +17,10 @@ def build_agent(platform, identity):
     keys.generate()
     agent = platform.build_agent(identity=identity,
                                  serverkey=platform.serverkey,
-                                 publickey=keys.public(),
-                                 secretkey=keys.secret())
+                                 publickey=keys.public,
+                                 secretkey=keys.secret)
     # Make publickey easily accessible for these tests
-    agent.publickey = keys.public()
+    agent.publickey = keys.public
     return agent
 
 

--- a/volttrontesting/platform/connection_test.py
+++ b/volttrontesting/platform/connection_test.py
@@ -30,8 +30,8 @@ def setup_control_connection(request, get_volttron_instances):
         control_connection = Connection(address=wrapper.vip_address,
                                         peer=CONTROL,
                                         serverkey=wrapper.serverkey,
-                                        publickey=ks.public(),
-                                        secretkey=ks.secret())
+                                        publickey=ks.public,
+                                        secretkey=ks.secret)
     else:
         control_connection = Connection(address=wrapper.local_vip_address,
                                         peer=CONTROL, developer_mode=True)

--- a/volttrontesting/platform/keystore_test.py
+++ b/volttrontesting/platform/keystore_test.py
@@ -24,15 +24,15 @@ def test_keystore_generated_when_created(tmpdir_factory):
     kspath = str(tmpdir_factory.mktemp('keys').join('keys.json'))
     ks = keystore.KeyStore(kspath)
     assert os.stat(kspath).st_mode & 0o777 == 0o600
-    assert ks.secret()
-    assert ks.public()
+    assert ks.secret
+    assert ks.public
 
 
 @pytest.mark.keystore
 def test_generated_keys_length(keystore_instance1):
     '''The keys should be the len:gth of an encoded curve-key (43)'''
-    assert len(keystore_instance1.public()) == 43
-    assert len(keystore_instance1.secret()) == 43
+    assert len(keystore_instance1.public) == 43
+    assert len(keystore_instance1.secret) == 43
 
 
 @pytest.mark.keystore
@@ -40,17 +40,17 @@ def test_keystore_with_same_path(keystore_instance1):
     '''Reading from the same path should fetch the same keys'''
     path = keystore_instance1.filename
     keys = keystore.KeyStore(path)
-    assert keystore_instance1.public() == keys.public()
-    assert keystore_instance1.secret() == keys.secret()
+    assert keystore_instance1.public == keys.public
+    assert keystore_instance1.secret == keys.secret
 
 
 @pytest.mark.keystore
 def test_keystore_overwrite_keys(keystore_instance1):
-    public = keystore_instance1.public()
-    secret = keystore_instance1.secret()
+    public = keystore_instance1.public
+    secret = keystore_instance1.secret
     keystore_instance1.generate()
-    assert keystore_instance1.public() != public
-    assert keystore_instance1.secret() != secret
+    assert keystore_instance1.public != public
+    assert keystore_instance1.secret != secret
 
 
 @pytest.fixture(scope="module")
@@ -103,4 +103,4 @@ def test_invalid_unicode_key(keystore_instance1):
         keystore_json = json.load(fp)
     keystore_json['public'] = u'\u0100'
     keystore_instance1.update(keystore_json)
-    assert keystore_instance1.public() is None
+    assert keystore_instance1.public is None

--- a/volttrontesting/utils/build_agent.py
+++ b/volttrontesting/utils/build_agent.py
@@ -31,10 +31,10 @@ def build_agent_with_key(platform, identity=None):
     keys.generate()
     agent = platform.build_agent(identity=identity,
                                   serverkey=platform.publickey,
-                                  publickey=keys.public(),
-                                  secretkey=keys.secret())
+                                  publickey=keys.public,
+                                  secretkey=keys.secret)
     # Make publickey easily accessible for these tests
-    agent.publickey = keys.public()
+    agent.publickey = keys.public
     gevent.sleep(0.1) # switch context for a bit
     os.environ.pop('VOLTTRON_HOME')
     return agent

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -240,8 +240,8 @@ class PlatformWrapper:
             keyfile = tempfile.mktemp(".keys", "agent", self.volttron_home)
             keys = KeyStore(keyfile)
             keys.generate()
-            publickey = keys.public()
-            secretkey = keys.secret()
+            publickey = keys.public
+            secretkey = keys.secret
         if self.encrypt:
             conn = Connection(address=address, peer=peer, publickey=publickey,
                               secretkey=secretkey, serverkey=serverkey,
@@ -280,8 +280,8 @@ class PlatformWrapper:
                 keyfile = tempfile.mktemp(".keys", "agent", self.volttron_home)
                 keys = KeyStore(keyfile)
                 keys.generate()
-                publickey=keys.public()
-                secretkey=keys.secret()
+                publickey=keys.public
+                secretkey=keys.secret
 
         if address is None:
             if not self.encrypt:
@@ -423,7 +423,7 @@ class PlatformWrapper:
         config = {}
 
         # Add platform's public key to known hosts file
-        publickey = self.keystore.public()
+        publickey = self.keystore.public
         known_hosts_file = os.path.join(self.volttron_home, 'known_hosts')
         known_hosts = KnownHostsStore(known_hosts_file)
         known_hosts.add(self.opts['vip_local_address'], publickey)
@@ -484,7 +484,7 @@ class PlatformWrapper:
         # A negative means that the process exited with an error.
         assert self.p_process.poll() is None
 
-        self.serverkey = self.keystore.public()
+        self.serverkey = self.keystore.public
         assert self.serverkey
         agent = self.build_agent()
 


### PR DESCRIPTION
 * `volttron-ctl upgrade` removes and installs agent while preserving the agent's existing authorization entry in `$VOLTTRON_HOME/auth.json`
 * Changed `KeyStore` methods `public` and `secret` to properties (this helped with preserving authorization entry and it is more pythonic)
 * Removed unused imports of `KeyStore`, `AuthEntry`, and `AuthFile`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/849)
<!-- Reviewable:end -->
