### PR TITLE
fixed typo bug in Core._set_keys

### DIFF
--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -444,14 +444,13 @@ class Core(BasicCore):
         self.__connected = False
 
     def _set_keys(self):
-        """
-        Implements logic for setting encryption keys and putting
+        """Implements logic for setting encryption keys and putting
         those keys in the parameters of the VIP address
         """
         if self.developer_mode:
             self.publickey = None
             self.secretkey = None
-            self.serverkye = None
+            self.serverkey = None
             return
 
         self._set_server_key()


### PR DESCRIPTION
The effect of this typo was limited to the case when `Agent` is initialized with a non-`None` `serverkey` and `developer_mode=True`. Even then, the keys would not be used in VIP, but calling `agent.core.serverkey` would return a `serverkey` that wasn't actually used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/865)
<!-- Reviewable:end -->
