### PR TITLE
remove spawn later link #765

### DIFF
--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -343,6 +343,12 @@ class BasicCore(object):
         self.greenlet.link(lambda glt: greenlet.kill())
         return greenlet
 
+    def spawn_later(self, seconds, func, *args, **kwargs):
+        assert self.greenlet is not None
+        greenlet = gevent.spawn_later(seconds, func, *args, **kwargs)
+        self.greenlet.link(lambda glt: greenlet.kill())
+        return greenlet
+
     def spawn_in_thread(self, func, *args, **kwargs):
         result = gevent.event.AsyncResult()
 

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -69,6 +69,7 @@ import threading
 import time
 import urlparse
 import uuid
+import weakref
 
 import gevent.event
 from zmq import green as zmq
@@ -178,6 +179,7 @@ class BasicCore(object):
 
     def __init__(self, owner):
         self.greenlet = None
+        self.spawned_greenlets = weakref.WeakSet()
         self._async = None
         self._async_calls = []
         self._stop_event = None
@@ -214,7 +216,7 @@ class BasicCore(object):
 
         def start_periodics(sender, **kwargs):   # pylint: disable=unused-argument
             for periodic in periodics:
-                sender.greenlet.link(lambda glt: periodic.kill())
+                sender.spawned_greenlets.add(periodic)
                 periodic.start()
             del periodics[:]
         self.onstart.connect(start_periodics)
@@ -231,7 +233,7 @@ class BasicCore(object):
 
     def link_receiver(self, receiver, sender, **kwargs):
         greenlet = gevent.spawn(receiver, sender, **kwargs)
-        self.greenlet.link(lambda glt: greenlet.kill())
+        self.spawned_greenlets.add(greenlet)
         return greenlet
 
     def run(self, running_event=None):   # pylint: disable=method-hidden
@@ -239,6 +241,10 @@ class BasicCore(object):
 
         self.setup()
         self.greenlet = current = gevent.getcurrent()
+        def kill_leftover_greenlets():
+            for glt in self.spawned_greenlets:
+                glt.kill()
+        self.greenlet.link(lambda _: kill_leftover_greenlets())
 
         def handle_async():
             '''Execute pending calls.'''
@@ -246,7 +252,7 @@ class BasicCore(object):
             while calls:
                 func, args, kwargs = calls.pop()
                 greenlet = gevent.spawn(func, *args, **kwargs)
-                current.link(lambda glt: greenlet.kill())
+                self.spawned_greenlets.add(greenlet)
 
         def schedule_loop():
             heap = self._schedule
@@ -279,7 +285,7 @@ class BasicCore(object):
 
         loop = looper.next()
         if loop:
-            current.link(lambda glt: loop.kill())
+            self.spawned_greenlets.add(loop)
         scheduler = gevent.spawn(schedule_loop)
         if loop:
             loop.link(lambda glt: scheduler.kill())
@@ -340,13 +346,13 @@ class BasicCore(object):
     def spawn(self, func, *args, **kwargs):
         assert self.greenlet is not None
         greenlet = gevent.spawn(func, *args, **kwargs)
-        self.greenlet.link(lambda glt: greenlet.kill())
+        self.spawned_greenlets.add(greenlet)
         return greenlet
 
     def spawn_later(self, seconds, func, *args, **kwargs):
         assert self.greenlet is not None
         greenlet = gevent.spawn_later(seconds, func, *args, **kwargs)
-        self.greenlet.link(lambda glt: greenlet.kill())
+        self.spawned_greenlets.add(greenlet)
         return greenlet
 
     def spawn_in_thread(self, func, *args, **kwargs):
@@ -365,7 +371,7 @@ class BasicCore(object):
     @dualmethod
     def periodic(self, period, func, args=None, kwargs=None, wait=0):
         greenlet = Periodic(period, args, kwargs, wait).get(func)
-        self.greenlet.link(lambda glt: greenlet.kill())
+        self.spawned_greenlets.add(greenlet)
         greenlet.start()
         return greenlet
 

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -343,12 +343,6 @@ class BasicCore(object):
         self.greenlet.link(lambda glt: greenlet.kill())
         return greenlet
 
-    def spawn_later(self, seconds, func, *args, **kwargs):
-        assert self.greenlet is not None
-        greenlet = gevent.spawn_later(seconds, func, *args, **kwargs)
-        self.greenlet.link(lambda glt: greenlet.kill())
-        return greenlet
-
     def spawn_in_thread(self, func, *args, **kwargs):
         result = gevent.event.AsyncResult()
 

--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -64,6 +64,7 @@ import random
 import re
 import weakref
 
+import gevent
 from zmq import green as zmq
 from zmq import SNDMORE
 from zmq.utils import jsonapi
@@ -140,7 +141,7 @@ class PubSub(SubsystemBase):
     def _peer_add(self, sender, peer, **kwargs):
         # Delay sync by some random amount to prevent reply storm.
         delay = random.random()
-        self.core().spawn_later(delay, self.synchronize, peer)
+        gevent.spawn_later(delay, self.synchronize, peer)
 
     def _peer_drop(self, sender, peer, **kwargs):
         self._sync(peer, {})

--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -64,7 +64,6 @@ import random
 import re
 import weakref
 
-import gevent
 from zmq import green as zmq
 from zmq import SNDMORE
 from zmq.utils import jsonapi
@@ -141,7 +140,7 @@ class PubSub(SubsystemBase):
     def _peer_add(self, sender, peer, **kwargs):
         # Delay sync by some random amount to prevent reply storm.
         delay = random.random()
-        gevent.spawn_later(delay, self.synchronize, peer)
+        self.core().spawn_later(delay, self.synchronize, peer)
 
     def _peer_drop(self, sender, peer, **kwargs):
         self._sync(peer, {})


### PR DESCRIPTION
This is a pretty common pattern:
```
greenlet = gevent.spawn_later(seconds, func, *args, **kwargs)
self.greenlet.link(lambda glt: greenlet.kill())
```
we could probably remove it in more places but this one is the most noticeable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/869)
<!-- Reviewable:end -->
