### PR TITLE
Consistent serverkey

### DIFF
--- a/docs/source/core_services/security/Known-Hosts-File.rst
+++ b/docs/source/core_services/security/Known-Hosts-File.rst
@@ -19,7 +19,7 @@ Suppose a user wants to connect to a platform at ``192.168.0.42:22916``, and the
 platform's public key is ``uhjbCUm3kT5QWj5Py9w0XZ7c1p6EP8pdo4Hq4dNEIiQ``.
 To save this address-to-server-key association, the user can run::
 
-    volttron-ctl auth add-known-host --host 192.168.0.42:22916 --server-key uhjbCUm3kT5QWj5Py9w0XZ7c1p6EP8pdo4Hq4dNEIiQ
+    volttron-ctl auth add-known-host --host 192.168.0.42:22916 --serverkey uhjbCUm3kT5QWj5Py9w0XZ7c1p6EP8pdo4Hq4dNEIiQ
 
 Now agents on this system will automatically use the correct server key when
 connecting to the platform at ``192.168.0.42:22916``.

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1422,7 +1422,7 @@ def main(argv=sys.argv):
             help='add server public key to known-hosts file')
     auth_add_known_host.add_argument('--host', required=True,
             help='hostname or IP address with optional port')
-    auth_add_known_host.add_argument('--server-key', required=True)
+    auth_add_known_host.add_argument('--serverkey', required=True)
     auth_add_known_host.set_defaults(func=add_server_key)
 
     auth_keypair = add_parser('keypair', subparser=auth_subparsers,


### PR DESCRIPTION
Fixes: #945 serverkey not server-key is used everywhere else.  Made this consistent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/946)
<!-- Reviewable:end -->
