### PR TITLE
do not add allow-all entry in MasterWebService, fixes #673

### DIFF
--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -189,18 +189,6 @@ class MasterWebService(Agent):
         super(MasterWebService, self).__init__(identity, address, **kwargs)
 
         self.bind_web_address = bind_web_address
-        # if the web address is bound then we need to allow the web agent
-        # to be discoverable.  That means we need to allow connections to
-        # the message bus in some known addresses if they aren't already
-        # specified.
-        if self.bind_web_address:
-            authfile = AuthFile()
-            entries, _, _ = authfile.read()
-            if not entries:
-                _log.debug(
-                    'Adding default curve credentials for discoverability.')
-                authfile.add(AuthEntry(credentials="/.*/"))
-
         self.serverkey = serverkey
         self.registeredroutes = []
         self.peerroutes = defaultdict(list)


### PR DESCRIPTION
The removed code was not being run anyways, because the AuthFile will always have at least one entry (the platform itself).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1007)
<!-- Reviewable:end -->
