### PR TITLE
volttron-ctl upgrade adds agent authorization if it does not exist

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -249,15 +249,14 @@ class ControlService(BaseAgent):
 
     @RPC.export
     def install_agent_local(self, filename, vip_identity=None, publickey=None,
-                            secretkey=None, add_auth=True):
+                            secretkey=None):
         return self._aip.install_agent(filename, vip_identity=vip_identity,
                                        publickey=publickey,
-                                       secretkey=secretkey,
-                                       add_auth=add_auth)
+                                       secretkey=secretkey)
 
     @RPC.export
     def install_agent(self, filename, channel_name, vip_identity=None,
-                      publickey=None, secretkey=None, add_auth=True):
+                      publickey=None, secretkey=None):
         """
         Installs an agent on the instance instance.
 
@@ -303,8 +302,6 @@ class ControlService(BaseAgent):
             Encoded public key the installed agent will use
         :param:string:secretkey:
             Encoded secret key the installed agent will use
-        :param:bool:add_auth:
-            Add the agent's credentials to the authorized-agent list
         """
 
         peer = bytes(self.vip.rpc.context.vip_message.peer)
@@ -356,8 +353,7 @@ class ControlService(BaseAgent):
             agent_uuid = self._aip.install_agent(path,
                                                  vip_identity=vip_identity,
                                                  publickey=publickey,
-                                                 secretkey=secretkey,
-                                                 add_auth=add_auth)
+                                                 secretkey=secretkey)
             return agent_uuid
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -423,7 +419,6 @@ def filter_agent(agents, pattern, opts):
 def upgrade_agent(opts):
     publickey = None
     secretkey = None
-    add_auth = False
 
     identity = opts.vip_identity
     if not identity:
@@ -445,13 +440,11 @@ def upgrade_agent(opts):
     if secretkey is None or publickey is None:
         publickey = None
         secretkey = None
-        add_auth = True
 
-    install_agent(opts, publickey=publickey, secretkey=secretkey,
-                  add_auth=add_auth)
+    install_agent(opts, publickey=publickey, secretkey=secretkey)
 
 
-def install_agent(opts, publickey=None, secretkey=None, add_auth=True):
+def install_agent(opts, publickey=None, secretkey=None):
     aip = opts.aip
     filename = opts.wheel
     tag = opts.tag
@@ -464,8 +457,7 @@ def install_agent(opts, publickey=None, secretkey=None, add_auth=True):
                                           filename,
                                           vip_identity=vip_identity,
                                           publickey=publickey,
-                                          secretkey=secretkey,
-                                          add_auth=add_auth)
+                                          secretkey=secretkey)
 
         if tag:
             opts.connection.call('tag_agent', agent_uuid, tag)
@@ -482,8 +474,7 @@ def install_agent(opts, publickey=None, secretkey=None, add_auth=True):
                                                      channel_name,
                                                      vip_identity=vip_identity,
                                                      publickey=publickey,
-                                                     secretkey=secretkey,
-                                                     add_auth=add_auth)
+                                                     secretkey=secretkey)
 
             _log.debug('Sending wheel to control')
             sha512 = hashlib.sha512()


### PR DESCRIPTION
fixes #1070

Now `volttron-ctl install` and `volttron-ctl upgrade` will always try to add the agent's authorization entry. If it already exists, then it will continue on silently. I couldn't think of a good reason to warn the user if the entry already exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1072)
<!-- Reviewable:end -->
