### PR TITLE
volttron-ctl auth keypair now prints keys to stdout rather than a file

### DIFF
--- a/docs/source/core_services/security/Key-Stores.rst
+++ b/docs/source/core_services/security/Key-Stores.rst
@@ -36,5 +36,5 @@ both the ``publickey`` and ``secretkey`` parameters are specified
 when the agent is initialized. If an agent's key store does not exist
 it will automatically be generated upon access.
 
-Users can generate a key pair (in a key-store file) by running the
+Users can generate a key pair by running the
 ``volttron-ctl auth keypair`` command.

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -733,14 +733,8 @@ def send_agent(opts):
 
 
 def gen_keypair(opts):
-    if os.path.isfile(opts.keystore_file):
-        _stdout.write('{} already exists.\n'.format(opts.keystore_file))
-        if not _ask_yes_no('Overwrite?', default='no'):
-            return
-    keystore = KeyStore(opts.keystore_file)
-    keystore.generate()  # call generate to force new keys to be generated
-    _stdout.write('public key: {}\n'.format(keystore.public))
-    _stdout.write('keys written to {}\n'.format(opts.keystore_file))
+    keypair = KeyStore.generate_keypair_dict()
+    _stdout.write('{}\n'.format(json.dumps(keypair, indent=2)))
 
 
 def add_server_key(opts):
@@ -1564,10 +1558,7 @@ def main(argv=sys.argv):
 
     auth_keypair = add_parser('keypair', subparser=auth_subparsers,
             help='generate CurveMQ keys for encrypting VIP connections')
-    auth_keypair.add_argument('keystore_file', metavar='keystore-file',
-            help='path to save keystore file', nargs='?')
-    auth_keypair.set_defaults(func=gen_keypair,
-            keystore_file=KeyStore.get_default_path())
+    auth_keypair.set_defaults(func=gen_keypair)
 
     auth_list = add_parser('list', help='list authentication records',
             subparser=auth_subparsers)

--- a/volttron/platform/keystore.py
+++ b/volttron/platform/keystore.py
@@ -129,11 +129,16 @@ class KeyStore(BaseJSONStore):
     def get_default_path():
         return os.path.join(get_home(), 'keystore')
 
-    def generate(self):
-        """Generate new key pair"""
+    @staticmethod
+    def generate_keypair_dict():
+        """Generate and return new keypair as dictionary"""
         public, secret = curve_keypair()
-        self.store({'public': encode_key(public),
-                    'secret': encode_key(secret)})
+        return {'public': encode_key(public),
+                'secret': encode_key(secret)}
+
+    def generate(self):
+        """Generate and store new key pair"""
+        self.store(self.generate_keypair_dict())
 
     def _get_key(self, keyname):
         """Get key and make sure it's type is str (not unicode)


### PR DESCRIPTION
`volttron-ctl auth keypair` used to write to `$VOLTTRON_HOME/keystore` (the platform's key pair) by default, and the user could specify an optional path to write to a different file. The platform automatically generates a key pair on startup if it does not already exist, so this default behavior of the `keypair` command was not very useful.

Now running `volttron-ctl auth keypair` generates a new key pair and writes it to `stdout`:

```
(volttron)$ volttron-ctl auth keypair
{
  "secret": "HMbnbEQnWYMZNbNCwplORUajhXa-tzx7hGGGlJRJmQk", 
  "public": "VchRI7e8zKQOaypl4VTzEwjet0hENi0tXl3L0AFMORo"
}
```
Side note: because it is in JSON format, the user can redirect the command's output to a file to replace a keystore (which is *currently* a JSON file):

```(volttron)$ volttron-ctl auth keypair > $VOLLTRON_HOME/keystore```
or
```(volttron)$ volttron-ctl auth keypair > $VOLLTRON_HOME/keystores/master.web/keystore.json```

This is not an advertised feature in the documentation because we are looking into replacing the keystore JSON files with the `ConfigStore`, but I figured it was worth mentioning here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1073)
<!-- Reviewable:end -->
