### PR TITLE
added campus to example command

### DIFF
--- a/docs/source/core_services/drivers/Driver-Configuration.rst
+++ b/docs/source/core_services/drivers/Driver-Configuration.rst
@@ -166,7 +166,7 @@ Note the name ``registry_configs/hvac.csv`` matches the configuration reference 
 
 To store the driver configuration run the command
 
-``volttron-ctl config store platform.driver devices/my_building/hvac1 modbus1.config``
+``volttron-ctl config store platform.driver devices/my_campus/my_building/hvac1 modbus1.config``
 
 
 Converting Old Style Configuration


### PR DESCRIPTION
campus is a required field for device hierarchy, non-standard example was confusing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1100)
<!-- Reviewable:end -->
