### PR TITLE
Added timeout to device config for BACnet Proxy Agent

### DIFF
--- a/docs/source/core_services/drivers/BACnet-Proxy-Agent.rst
+++ b/docs/source/core_services/drivers/BACnet-Proxy-Agent.rst
@@ -148,12 +148,10 @@ a device on the first network
 
     {
         "driver_config": {"device_address": "1002:12",
-                          "proxy_address": "platform.bacnet_proxy_47808" },
-        "campus": "campus",
-        "building": "building",
-        "unit": "bacnet1",
+                          "proxy_address": "platform.bacnet_proxy_47808",
+                          "timeout": 10},
         "driver_type": "bacnet",
-        "registry_config":"/home/kyle/configs/bacnet.csv",
+        "registry_config":"config://registry_configs/bacnet.csv",
         "interval": 60,
         "timezone": "UTC",
         "heart_beat_point": "Heartbeat"
@@ -165,17 +163,18 @@ and a device on the second network
 
     {
         "driver_config": {"device_address": "12000:5",
-                          "proxy_address": "platform.bacnet_proxy_47809" },
-        "campus": "campus",
-        "building": "building",
-        "unit": "bacnet2",
+                          "proxy_address": "platform.bacnet_proxy_47809",
+                          "timeout": 10},
         "driver_type": "bacnet",
-        "registry_config":"/home/kyle/configs/bacnet.csv",
+        "registry_config":"config://registry_configs/bacnet.csv",
         "interval": 60,
         "timezone": "UTC",
         "heart_beat_point": "Heartbeat"
     }
 
 Notice that both configs use the same registry configuration
-(/home/kyle/configs/bacnet.csv). This is perfectly fine as long as the
+(config://registry_configs/bacnet.csv). This is perfectly fine as long as the
 registry configuration is appropriate for both devices.
+For scraping large numbers of points from a single BACnet device, 
+there is an optional timeout parameter provided, to prevent the master driver 
+timing out while the BACnet Proxy Agent is collecting points.

--- a/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
+++ b/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
@@ -67,7 +67,7 @@ _log = logging.getLogger(__name__)
 
 
 class Register(BaseRegister):
-    def __init__(self, instance_number, object_type, property_name, read_only, pointName, units, 
+    def __init__(self, instance_number, object_type, property_name, read_only, pointName, units,
                  description = '',
                  priority = None,
                  list_index = None):
@@ -77,161 +77,162 @@ class Register(BaseRegister):
         self.property = property_name
         self.priority = priority
         self.index = list_index
-        
 
-        
+
+
 class Interface(BaseInterface):
     def __init__(self, **kwargs):
         super(Interface, self).__init__(**kwargs)
-        
+
     def configure(self, config_dict, registry_config_str):
         self.min_priority = config_dict.get("min_priority", 8)
-        self.parse_config(registry_config_str)         
+        self.parse_config(registry_config_str)
         self.target_address = config_dict["device_address"]
         self.device_id = int(config_dict["device_id"])
         self.proxy_address = config_dict.get("proxy_address", "platform.bacnet_proxy")
-        self.max_per_request = config_dict.get("max_per_request") 
-        
-        self.ping_retry_interval = timedelta(seconds=config_dict.get("ping_retry_interval", 5.0))   
+        self.max_per_request = config_dict.get("max_per_request")
+        self.timeout = float(config_dict.get("timeout", 10.0))
+
+        self.ping_retry_interval = timedelta(seconds=config_dict.get("ping_retry_interval", 5.0))
         self.scheduled_ping = None
-        
+
         self.ping_target()
-        
+
     def schedule_ping(self):
         if self.scheduled_ping is None:
             now = datetime.now()
             next_try = now + self.ping_retry_interval
             self.scheduled_ping = self.core.schedule(next_try, self.ping_target)
-                                         
-    def ping_target(self): 
-        #Some devices (mostly RemoteStation addresses behind routers) will not be reachable without 
+
+    def ping_target(self):
+        #Some devices (mostly RemoteStation addresses behind routers) will not be reachable without
         # first establishing the route to the device. Sending a directed WhoIsRequest is will
-        # settle that for us when the response comes back. 
-        
+        # settle that for us when the response comes back.
+
         pinged = False
         try:
-            self.vip.rpc.call(self.proxy_address, 'ping_device', self.target_address, self.device_id).get(timeout=10.0)
+            self.vip.rpc.call(self.proxy_address, 'ping_device', self.target_address, self.device_id).get(timeout=self.timeout)
             pinged = True
         except errors.Unreachable:
             _log.warning("Unable to reach BACnet proxy.")
-            
+
         except errors.VIPError:
             _log.warning("Error trying to ping device.")
-            
+
         self.scheduled_ping = None
-        
+
         #Schedule retry.
         if not pinged:
-            self.schedule_ping()            
-        
-        
-    def get_point(self, point_name, get_priority_array=False): 
-        register = self.get_register_by_name(point_name)   
+            self.schedule_ping()
+
+
+    def get_point(self, point_name, get_priority_array=False):
+        register = self.get_register_by_name(point_name)
         my_property = "priorityArray" if get_priority_array else register.property
-        point_map = {point_name:[register.object_type, 
-                                 register.instance_number, 
+        point_map = {point_name:[register.object_type,
+                                 register.instance_number,
                                  my_property]}
-        result = self.vip.rpc.call(self.proxy_address, 'read_properties', 
-                                       self.target_address, point_map).get(timeout=10.0)
+        result = self.vip.rpc.call(self.proxy_address, 'read_properties',
+                                       self.target_address, point_map).get(timeout=self.timeout)
         return result[point_name]
-    
-    def set_point(self, point_name, value, priority=None):    
+
+    def set_point(self, point_name, value, priority=None):
         #TODO: support writing from an array.
-        register = self.get_register_by_name(point_name)  
+        register = self.get_register_by_name(point_name)
         if register.read_only:
             raise  IOError("Trying to write to a point configured read only: "+point_name)
-        
+
         if priority is not None and priority < self.min_priority:
             raise  IOError("Trying to write with a priority lower than the minimum of "+str(self.min_priority))
-        
+
         #We've already validated the register priority against the min priority.
         args = [self.target_address, value,
-                register.object_type, 
-                register.instance_number, 
+                register.object_type,
+                register.instance_number,
                 register.property,
                 priority if priority is not None else register.priority]
-        result = self.vip.rpc.call(self.proxy_address, 'write_property', *args).get(timeout=10.0)
+        result = self.vip.rpc.call(self.proxy_address, 'write_property', *args).get(timeout=self.timeout)
         return result
-        
+
     def scrape_all(self):
         #TODO: support reading from an array.
         point_map = {}
         read_registers = self.get_registers_by_type("byte", True)
-        write_registers = self.get_registers_by_type("byte", False) 
-        for register in read_registers + write_registers:             
-            point_map[register.point_name] = [register.object_type, 
-                                              register.instance_number, 
+        write_registers = self.get_registers_by_type("byte", False)
+        for register in read_registers + write_registers:
+            point_map[register.point_name] = [register.object_type,
+                                              register.instance_number,
                                               register.property]
-        
+
         try:
-            result = self.vip.rpc.call(self.proxy_address, 'read_properties', 
+            result = self.vip.rpc.call(self.proxy_address, 'read_properties',
                                            self.target_address, point_map,
-                                           self.max_per_request).get(timeout=10.0)
+                                           self.max_per_request).get(timeout=self.timeout)
         except errors.Unreachable:
             _log.warning("Unable to reach BACnet proxy.")
             self.schedule_ping()
             raise
-            
+
         return result
-    
+
     def revert_all(self, priority=None):
         """Revert entrire device to it's default state"""
         #TODO: Add multipoint write support
-        write_registers = self.get_registers_by_type("byte", False) 
-        for register in write_registers:             
+        write_registers = self.get_registers_by_type("byte", False)
+        for register in write_registers:
             self.revert_point(register.point_name, priority=priority)
-    
+
     def revert_point(self, point_name, priority=None):
         """Revert point to it's default state"""
         self.set_point(point_name, None, priority=priority)
-        
-    
+
+
     def parse_config(self, configDict):
         if configDict is None:
             return
-        
+
         for regDef in configDict:
             #Skip lines that have no address yet.
 #             if not regDef['Point Name']:
 #                 continue
-            
+
             io_type = regDef['BACnet Object Type']
             read_only = regDef['Writable'].lower() != 'true'
-            point_name = regDef['Volttron Point Name']        
-            index = int(regDef['Index'])   
-                
+            point_name = regDef['Volttron Point Name']
+            index = int(regDef['Index'])
+
             list_index = regDef.get('Array Index', '')
             list_index = list_index.strip()
             if not list_index:
                 list_index = None
             else:
-                list_index = int(list_index) 
-                
+                list_index = int(list_index)
+
             priority = regDef.get('Write Priority', '')
             priority = priority.strip()
             if not priority:
                 priority = None
             else:
-                priority = int(priority) 
-                
+                priority = int(priority)
+
                 if priority < self.min_priority:
                     message = "{point} configured with a priority {priority} which is lower than than minimum {min}."
                     raise DriverConfigError(message.format(point=point_name,
                                                            priority=priority,
                                                            min=self.min_priority))
-                
-            description = regDef.get('Notes', '')                 
-            units = regDef['Units']       
-            property_name = regDef['Property']       
-                        
-            register = Register(index, 
-                                io_type, 
-                                property_name, 
-                                read_only, 
+
+            description = regDef.get('Notes', '')
+            units = regDef['Units']
+            property_name = regDef['Property']
+
+            register = Register(index,
+                                io_type,
+                                property_name,
+                                read_only,
                                 point_name,
-                                units, 
+                                units,
                                 description = description,
                                 priority = priority,
                                 list_index = list_index)
-                
+
             self.insert_register(register)

--- a/services/core/MasterDriverAgent/master_driver/test_bacnet1.config
+++ b/services/core/MasterDriverAgent/master_driver/test_bacnet1.config
@@ -1,11 +1,9 @@
 {
     "driver_config": {"device_address": "130.20.116.13",
-    				  "device_id": 500},
-    "campus": "campus",
-    "building": "building",
-    "unit": "bacnet1",
+    				  "device_id": 500,
+                      "timeout": 10},
     "driver_type": "bacnet",
-    "registry_config":"/home/kyle/workspaces/volttron/volttron/drivers/bacnet_lab.csv",
+    "registry_config":"config://registry_configs/bacnet_lab.csv",
     "interval": 60,
     "timezone": "UTC"
 }

--- a/services/core/MasterDriverAgent/master_driver/test_bacnet2.config
+++ b/services/core/MasterDriverAgent/master_driver/test_bacnet2.config
@@ -1,11 +1,9 @@
 {
     "driver_config": {"device_address": "130.20.116.13",
-    				  "device_id": 500},
-    "campus": "campus",
-    "building": "building",
-    "unit": "bacnet2",
+    				  "device_id": 500,
+                      "timeout": 10},
     "driver_type": "bacnet",
-    "registry_config":"/home/kyle/workspaces/volttron/volttron/drivers/bacnet_lab.csv",
+    "registry_config":"config://registry_configs/bacnet_lab.csv",
     "interval": 5,
     "timezone": "UTC"
 }


### PR DESCRIPTION
The timeout for how long master driver would wait for the BACnet proxy to scrape requested points was hardcoded to 10 seconds, on large scrapes with slower devices, this timeout could be reached. The timeout is now exposed for each device config. This resolves  #1136 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1134)
<!-- Reviewable:end -->
