### PR TITLE
Added start-volttron script

### DIFF
--- a/start-volttron
+++ b/start-volttron
@@ -5,6 +5,11 @@ if [ ! -e "./volttron/platform" ]; then
     exit 0
 fi
 
+if [ ! -e "env/bin/volttron" ]; then
+    echo "Bootstrap the environment before using this script."
+    exit 0
+fi
+
 echo "Starting VOLTTRON with rotatinglog.py in the background."
 
 env/bin/volttron -L examples/rotatinglog.py > /dev/null 2>&1&

--- a/start-volttron
+++ b/start-volttron
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-echo "Starting volttron with rotatinglog.py in the background."
+if [ ! -e "./volttron/platform" ]; then
+    echo "Please execute from root of volttron repository."
+    exit 0
+fi
+
+echo "Starting VOLTTRON with rotatinglog.py in the background."
 
 env/bin/volttron -L examples/rotatinglog.py > /dev/null 2>&1&

--- a/start-volttron
+++ b/start-volttron
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Starting volttron with rotatinglog.py in the background."
+
+env/bin/volttron -L examples/rotatinglog.py > /dev/null 2>&1&

--- a/stop-volttron
+++ b/stop-volttron
@@ -5,6 +5,11 @@ if [ ! -e "./volttron/platform" ]; then
     exit 0
 fi
 
+if [ ! -e "env/bin/volttron" ]; then
+    echo "Bootstrap the environment before using this script."
+    exit 0
+fi
+
 echo "Shutting down VOLTTRON"
 
 env/bin/volttron-ctl shutdown --platform

--- a/stop-volttron
+++ b/stop-volttron
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ ! -e "./volttron/platform" ]; then
+    echo "Please execute from root VOLTTRON directory."
+    exit 0
+fi
+
+echo "Shutting down VOLTTRON"
+
+env/bin/volttron-ctl shutdown --platform


### PR DESCRIPTION
Added a script that will allow simple startup of a deployed volttron in the background.  The shell need not be activated in order to run the script.  The environment does need to be bootstrapped however.  It uses the rotatinglog.py script as it's mechanism for logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1236)
<!-- Reviewable:end -->
