### PR TITLE
Fix for issue #1312: A VIP message is now sent to the router to remov…

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -186,7 +186,11 @@ class ControlService(BaseAgent):
             raise TypeError("expected a string for 'uuid';"
                             "got {!r} from identity: {}".format(
                 type(uuid).__name__, identity))
+        identity = self.agent_vip_identity(uuid)
         self._aip.stop_agent(uuid)
+        #Send message to router that agent is shutting down
+        frames = [bytes(identity)]
+        self.core.socket.send_vip(b'', 'agentstop', frames, copy=False)
 
     @RPC.export
     def restart_agent(self, uuid):

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -338,6 +338,14 @@ class Router(BaseRouter):
             sender = bytes(frames[0])
             if sender == b'control' and user_id == self.default_user_id:
                 raise KeyboardInterrupt()
+        elif subsystem == b'agentstop':
+            try:
+                drop = frames[6].bytes
+                self._drop_peer(drop)
+                _log.debug("ROUTER received agent stop message. dropping peer: {}".format(drop))
+            except IndexError:
+                pass
+            return False
         elif subsystem == b'query':
             try:
                 name = bytes(frames[6])


### PR DESCRIPTION
Fix for issue #1312: A VIP message is now sent to the router to remove the entry of the agent from the peerlist whenever an agent is unistalled or stopped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1313)
<!-- Reviewable:end -->
