### PR TITLE
improved master driver timeout log output

### DIFF
--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -62,8 +62,8 @@ import sys
 import random
 import gevent
 from volttron.platform.messaging import headers as headers_mod
-from volttron.platform.messaging.topics import (DRIVER_TOPIC_BASE, 
-                                                DRIVER_TOPIC_ALL, 
+from volttron.platform.messaging.topics import (DRIVER_TOPIC_BASE,
+                                                DRIVER_TOPIC_ALL,
                                                 DEVICES_VALUE,
                                                 DEVICES_PATH)
 
@@ -77,7 +77,7 @@ utils.setup_logging()
 _log = logging.getLogger(__name__)
 
 
-class DriverAgent(BasicAgent): 
+class DriverAgent(BasicAgent):
     def __init__(self, parent, config, time_slot, driver_scrape_interval, device_path,
                  default_publish_depth_first_all = True,
                  default_publish_breadth_first_all=True,
@@ -164,8 +164,8 @@ class DriverAgent(BasicAgent):
 
         from_midnight = datetime.timedelta(seconds=next_in_seconds)
         return midnight + from_midnight + datetime.timedelta(seconds=self.time_slot_offset)
-            
-        
+
+
     def get_interface(self, driver_type, config_dict, config_string):
         """Returns an instance of the interface"""
         module_name = "interfaces." + driver_type
@@ -175,35 +175,35 @@ class DriverAgent(BasicAgent):
         interface = klass(vip=self.vip, core=self.core)
         interface.configure(config_dict, config_string)
         return interface
-        
+
     @Core.receiver('onstart')
     def starting(self, sender, **kwargs):
         self.setup_device()
-        
+
         # interval = self.config.get("interval", 60)
         # self.core.periodic(interval, self.periodic_read, wait=None)
 
         next_periodic_read = self.find_starting_datetime(utils.get_aware_utc_now())
 
         self.periodic_read_event = self.core.schedule(next_periodic_read, self.periodic_read, next_periodic_read)
-            
+
         self.all_path_depth, self.all_path_breadth = self.get_paths_for_point(DRIVER_TOPIC_ALL)
 
 
     def setup_device(self):
 
         config = self.config
-        driver_config = config["driver_config"] 
-        driver_type = config["driver_type"] 
+        driver_config = config["driver_config"]
+        driver_type = config["driver_type"]
         registry_config = config.get("registry_config")
-        
-        self.heart_beat_point = config.get("heart_beat_point") 
-        
 
-                           
+        self.heart_beat_point = config.get("heart_beat_point")
+
+
+
         self.interface = self.get_interface(driver_type, driver_config, registry_config)
         self.meta_data = {}
-        
+
         for point in self.interface.get_register_names():
             register = self.interface.get_register_by_name(point)
             if register.register_type == 'bit':
@@ -215,17 +215,17 @@ class DriverAgent(BasicAgent):
                     ts_type = 'float'
                 elif register.python_type is str:
                     ts_type = 'string'
-            
+
             self.meta_data[point] = {'units': register.get_units(),
                                      'type': ts_type,
                                      'tz': config.get('timezone', '')}
-            
+
         self.base_topic = DEVICES_VALUE(campus='',
                                         building='',
                                         unit='',
                                         path=self.device_path,
                                         point=None)
-        
+
         self.device_name = DEVICES_PATH(base='',
                                         node='',
                                         campus='',
@@ -233,10 +233,10 @@ class DriverAgent(BasicAgent):
                                         unit='',
                                         path=self.device_path,
                                         point='')
-        
+
         # self.parent.device_startup_callback(self.device_name, self)
-            
-        
+
+
     def periodic_read(self, now):
         #we not use self.core.schedule to prevent drift.
         next_scrape_time = now + datetime.timedelta(seconds=self.interval)
@@ -255,72 +255,72 @@ class DriverAgent(BasicAgent):
         self.periodic_read_event = self.core.schedule(next_scrape_time, self.periodic_read, next_scrape_time)
 
         _log.debug("scraping device: " + self.device_name)
-        
+
         self.parent.scrape_starting(self.device_name)
-        
+
         try:
             results = self.interface.scrape_all()
-        except Exception as ex:
+        except (Exception, gevent.Timeout) as ex:
             _log.error('Failed to scrape ' + self.device_name + ': ' + str(ex))
             return
-        
+
         # XXX: Does a warning need to be printed?
         if not results:
             return
-        
+
         utcnow = utils.get_aware_utc_now()
         utcnow_string = utils.format_timestamp(utcnow)
-        
+
         headers = {
             headers_mod.DATE: utcnow_string,
             headers_mod.TIMESTAMP: utcnow_string,
         }
-        
-            
+
+
 
         if self.publish_depth_first or self.publish_breadth_first:
             for point, value in results.iteritems():
                 depth_first_topic, breadth_first_topic = self.get_paths_for_point(point)
                 message = [value, self.meta_data[point]]
-                   
-                if self.publish_depth_first:  
-                    self._publish_wrapper(depth_first_topic, 
-                                          headers=headers, 
+
+                if self.publish_depth_first:
+                    self._publish_wrapper(depth_first_topic,
+                                          headers=headers,
                                           message=message)
-                
+
                 if self.publish_breadth_first:
-                    self._publish_wrapper(breadth_first_topic, 
-                                          headers=headers, 
+                    self._publish_wrapper(breadth_first_topic,
+                                          headers=headers,
                                           message=message)
-         
-        message = [results, self.meta_data] 
+
+        message = [results, self.meta_data]
         if self.publish_depth_first_all:
-            self._publish_wrapper(self.all_path_depth, 
-                                  headers=headers, 
+            self._publish_wrapper(self.all_path_depth,
+                                  headers=headers,
                                   message=message)
-        
-        if self.publish_breadth_first_all: 
-            self._publish_wrapper(self.all_path_breadth, 
-                                  headers=headers, 
+
+        if self.publish_breadth_first_all:
+            self._publish_wrapper(self.all_path_breadth,
+                                  headers=headers,
                                   message=message)
 
         self.parent.scrape_ending(self.device_name)
-        
-        
+
+
     def _publish_wrapper(self, topic, headers, message):
         while True:
             try:
                 with publish_lock():
                     _log.debug("publishing: " + topic)
-                    self.vip.pubsub.publish('pubsub', 
-                                        topic, 
-                                        headers=headers, 
+                    self.vip.pubsub.publish('pubsub',
+                                        topic,
+                                        headers=headers,
                                         message=message).get(timeout=10.0)
-                                        
+
                     _log.debug("finish publishing: " + topic)
             except gevent.Timeout:
                 _log.warn("Did not receive confirmation of publish to "+topic)
-                break                           
+                break
             except Again:
                 _log.warn("publish delayed: " + topic + " pubsub is busy")
                 gevent.sleep(random.random())
@@ -329,32 +329,32 @@ class DriverAgent(BasicAgent):
                 break
             else:
                 break
-            
-    
+
+
     def heart_beat(self):
         if self.heart_beat_point is None:
             return
-        
+
         self.heart_beat_value = int(not bool(self.heart_beat_value))
-        
+
         _log.debug("sending heartbeat: " + self.device_name + ' ' + str(self.heart_beat_value))
-        
+
         self.set_point(self.heart_beat_point, self.heart_beat_value)
 
     def get_paths_for_point(self, point):
         depth_first = self.base_topic(point=point)
-         
+
         parts = depth_first.split('/')
         breadth_first_parts = parts[1:]
         breadth_first_parts.reverse()
         breadth_first_parts = [DRIVER_TOPIC_BASE] + breadth_first_parts
         breadth_first = '/'.join(breadth_first_parts)
-         
-        return depth_first, breadth_first 
-    
+
+        return depth_first, breadth_first
+
     def get_point(self, point_name, **kwargs):
         return self.interface.get_point(point_name, **kwargs)
-    
+
     def set_point(self, point_name, value, **kwargs):
         return self.interface.set_point(point_name, value, **kwargs)
 
@@ -370,10 +370,10 @@ class DriverAgent(BasicAgent):
         return self.interface.set_multiple_points(self.device_name,
                                                   point_names_values,
                                                   **kwargs)
-    
+
     def revert_point(self, point_name, **kwargs):
         self.interface.revert_point(point_name, **kwargs)
-    
+
     def revert_all(self, **kwargs):
         self.interface.revert_all(**kwargs)
-        
+


### PR DESCRIPTION
Fixes #1302 which was caused by the gevent.Timeout not inheriting exception, thereby not being caught and logged correctly, here we explicitly catch the gevent.Timeout as well as other exceptions and log them correctly, because there was a bunch of trailing whitespace, there are a lot of changes, however the only one that actually affects the code is on line 262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1323)
<!-- Reviewable:end -->
