### PR TITLE
Bacpypes imports fix

### DIFF
--- a/scripts/bacnet/bacnet_scan.py
+++ b/scripts/bacnet/bacnet_scan.py
@@ -67,8 +67,8 @@ from bacpypes.consolecmd import ConsoleCmd
 from bacpypes.core import run, stop
 
 from bacpypes.pdu import Address, GlobalBroadcast
-from bacpypes.app import LocalDeviceObject, BIPSimpleApplication
-
+from bacpypes.app import BIPSimpleApplication
+from bacpypes.service.device import LocalDeviceObject
 from bacpypes.apdu import WhoIsRequest, IAmRequest
 from bacpypes.basetypes import ServicesSupported
 from bacpypes.errors import DecodingError

--- a/scripts/bacnet/grab_bacnet_config.py
+++ b/scripts/bacnet/grab_bacnet_config.py
@@ -62,7 +62,8 @@ from csv import DictWriter
 import json
 from os.path import basename
 from bacpypes.debugging import bacpypes_debugging, ModuleLogger
-from bacpypes.app import LocalDeviceObject, BIPSimpleApplication
+from bacpypes.app import BIPSimpleApplication
+from bacpypes.service.device import LocalDeviceObject
 from bacpypes.consolelogging import ConfigArgumentParser
 from bacpypes.pdu import Address, GlobalBroadcast
 from bacpypes.core import run, stop

--- a/scripts/scalability-testing/virtual-drivers/bacnet.py
+++ b/scripts/scalability-testing/virtual-drivers/bacnet.py
@@ -69,7 +69,8 @@ from bacpypes.primitivedata import Atomic, Real, Unsigned
 from bacpypes.constructeddata import Array, Any
 from bacpypes.basetypes import ServicesSupported, ErrorType
 from bacpypes.apdu import ReadPropertyMultipleACK, ReadAccessResult, ReadAccessResultElement, ReadAccessResultElementChoice
-from bacpypes.app import LocalDeviceObject, BIPSimpleApplication
+from bacpypes.app import BIPSimpleApplication
+from bacpypes.service.device import LocalDeviceObject
 from bacpypes.object import AnalogValueObject, PropertyError, get_object_class
 from bacpypes.apdu import Error
 from bacpypes.errors import ExecutionError


### PR DESCRIPTION
The new version of BACpypes has changes to module names which break the import statements in the BACnet helper scripts.  Updating the import statements per http://bacpypes.readthedocs.io/en/stable/migration/migration001.html#localdeviceobject allowed me to successfully run bacnet_scan.py and grab_bacnet_config.py.  I also updated one other place where the same import statements appear, though I have not tested anything there. There is a fourth instance, which was not updated, but it is in a directory marked deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1352)
<!-- Reviewable:end -->
