### PR TITLE
Check on reasoning

### DIFF
--- a/docs/source/volttron_applications/Simulated-Drivers.rst
+++ b/docs/source/volttron_applications/Simulated-Drivers.rst
@@ -114,13 +114,6 @@ Install each simulation agent:
         --config       $SIMULATION_ROOT/SimulationAgent/simulationagent.config \
         --force
 
-Now restart VOLTTRON (to refresh the auth cache). To run the simulation, start the agents:
-::
-
-    $ volttron-ctl start --tag simulationclock
-    $ volttron-ctl start --tag simulation.driver
-    $ volttron-ctl start --tag simulationagent
-
 SimulationAgent Configuration Parameters
 ========================================
 


### PR DESCRIPTION
@ffreckle 
@rob-calvert

The removed comments below are your internal auth cache or the platform auth cache.  The platform auth cache will be updated every time you install an agent.  So with the code right above it, it would be updated 3 times.

If you added --start to the commands that would start the agents as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1360)
<!-- Reviewable:end -->
