### PR TITLE
log message when attempting to register websocket without web

### DIFF
--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -497,7 +497,7 @@ class MasterWebService(Agent):
         if self.appContainer:
             self.appContainer.create_ws_endpoint(endpoint, identity)
         else:
-            _log.debug('Attempting to register endpoint without web'
+            _log.error('Attempting to register endpoint without web'
                        'subsystem initialized')
             raise AttributeError("self does not contain"
                                  " attribute appContainer")

--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -494,7 +494,13 @@ class MasterWebService(Agent):
         identity = bytes(self.vip.rpc.context.vip_message.peer)
         _log.debug('Caller identity: {}'.format(identity))
         _log.debug('REGISTERING ENDPOINT: {}'.format(endpoint))
-        self.appContainer.create_ws_endpoint(endpoint, identity)
+        if self.appContainer:
+            self.appContainer.create_ws_endpoint(endpoint, identity)
+        else:
+            _log.debug('Attempting to register endpoint without web'
+                       'subsystem initialized')
+            raise AttributeError("self does not contain"
+                                 " attribute appContainer")
 
     @RPC.export
     def unregister_websocket(self, endpoint):


### PR DESCRIPTION
This should address #1344, need a good way to test, if agreeable, this could be applied to the rpc exported functions in the web system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1391)
<!-- Reviewable:end -->
