### PR TITLE
Correct a bad documentation URL in JupyterNoteboks/README

### DIFF
--- a/examples/JupyterNotebooks/README
+++ b/examples/JupyterNotebooks/README
@@ -4,4 +4,4 @@ Jupyter Notebooks for VOLTTRON
 In order to run Jupyter notebooks with VOLTTRON, please begin by executing the server setup
 and configuration steps described in:
 
-http://volttron.readthedocs.io/en/devguides/supporting/utilities/JupyterNotebooks.html
+http://volttron.readthedocs.io/en/develop/devguides/supporting/JupyterNotebooks.html


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron/1475)
<!-- Reviewable:end -->
