### PR TITLE
Issue 1506 external platform pubsub subscriptions were not sent to ot…

### DIFF
--- a/volttron/platform/vip/keydiscovery.py
+++ b/volttron/platform/vip/keydiscovery.py
@@ -122,7 +122,11 @@ class KeyDiscoveryAgent(Agent):
             #Read External web addresses file
             try:
                 web_addresses = self._read_platform_address_file()
-                web_addresses.remove(self._my_web_address)
+                try:
+                    web_addresses.remove(self._my_web_address)
+                except ValueError:
+                    _log.debug("My web address is not in the external bind web adress list")
+
                 op = b'web-addresses'
                 self._send_to_router(op, web_addresses)
             except IOError as exc:

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -173,6 +173,13 @@ class PubSubService(object):
         for platform, bus, prefix in items:
             self._add_peer_subscription(peer, bus, prefix, platform)
 
+            if platform == 'all' and self._ext_router is not None:
+                # Send subscription message to all connected platforms
+                external_platforms = self._ext_router.get_connected_platforms()
+                self._send_external_subscriptions(external_platforms)
+                #self._logger.debug("SYNC sending to external platform subscriptions: {}".
+                #                   format(self._peer_subscriptions['all']))
+
     def _peer_sync(self, frames):
         """
         Synchronizes the subscriptions with the calling agent.


### PR DESCRIPTION
…her platforms when new agent gets connected to the platform.
As part of synchronize activity, external subscriptions need to be sent to other platforms.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1507?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1507'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>