### PR TITLE
Fix a typo in migration doc

### DIFF
--- a/docs/source/devguides/roadmap/4.1-5.0_Migration.rst
+++ b/docs/source/devguides/roadmap/4.1-5.0_Migration.rst
@@ -11,7 +11,7 @@ Key issues to note are:
 Operations Agents
 -----------------
 
-Several agents have been moved from "services/core" to "services/operations" to highlight their use in monitoring a
+Several agents have been moved from "services/core" to "services/ops" to highlight their use in monitoring a
 deployment. They are not necessary when developing against a single instance, but are essential for VOLTTRON(tm) in a
 deployed environment.
 


### PR DESCRIPTION
ops instead of operations
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1522?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1522'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>