### PR TITLE
added 'volttron' string to front of log messages for syslog compatibilty

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -172,13 +172,13 @@ def load_config(config_path):
 def update_kwargs_with_config(kwargs, config):
     """
     Loads the user defined configurations into kwargs.
-     
+
       1. Converts any dash/hyphen in config variables into underscores
-      2. Checks for configured "identity" value. Prints a deprecation 
-      warning and uses it. 
-      3. Checks for configured "agentid" value. Prints a deprecation warning 
+      2. Checks for configured "identity" value. Prints a deprecation
+      warning and uses it.
+      3. Checks for configured "agentid" value. Prints a deprecation warning
       and ignores it
-      
+
     :param kwargs: kwargs to be updated
     :param config: dictionary of user/agent configuration
     """
@@ -321,7 +321,7 @@ def vip_main(agent_class, identity=None, version='0.1', **kwargs):
                             address=address, agent_uuid=agent_uuid,
                             volttron_home=volttron_home,
                             version=version, **kwargs)
-        
+
         try:
             run = agent.run
         except AttributeError:
@@ -380,7 +380,7 @@ class AgentFormatter(logging.Formatter):
                 and 'tornado.access' in record.__dict__['composite_name']:
             record.__dict__['msg'] = ','.join([str(b) for b in record.args])
             record.__dict__['args'] = []
-        return super(AgentFormatter, self).format(record)
+        return "volttron: " + super(AgentFormatter, self).format(record)
 
 
 def setup_logging(level=logging.DEBUG):
@@ -400,10 +400,10 @@ def setup_logging(level=logging.DEBUG):
 def format_timestamp(time_stamp):
     """Create a consistent datetime string representation based on
     ISO 8601 format.
-    
+
     YYYY-MM-DDTHH:MM:SS.mmmmmm for unaware datetime objects.
     YYYY-MM-DDTHH:MM:SS.mmmmmm+HH:MM for aware datetime objects
-    
+
     :param time_stamp: value to convert
     :type time_stamp: datetime
     :returns: datetime in string format
@@ -476,7 +476,7 @@ def parse_timestamp_string(time_stamp_str):
 
 def get_aware_utc_now():
     """Create a timezone aware UTC datetime object from the system time.
-    
+
     :returns: an aware UTC datetime object
     :rtype: datetime
     """
@@ -594,12 +594,12 @@ def create_file_if_missing(path, permission=0o660, contents=None):
 def fix_sqlite3_datetime(sql=None):
     """Primarily for fixing the base historian cache on certain versions
     of python.
-    
+
     Registers a new datetime converter to that uses dateutil parse. This
     should
     better resolve #216, #174, and #91 without the goofy workarounds that
     change data.
-    
+
     Optional sql argument is for testing only.
     """
     if sql is None:


### PR DESCRIPTION
This allows log entries to properly be parsed for program name by syslog compatible processors.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1526%23issuecomment-337085584%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1526%23issuecomment-337256842%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1526%23issuecomment-337366661%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1526%23issuecomment-337085584%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20believe%20that%20it%20would%20be%20better%20to%20add%20a%20different%20AgentFormatter%20rather%20than%20change%20the%20current%20functionality.%22%2C%20%22created_at%22%3A%20%222017-10-17T00%3A55%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20agree%20except%20that%20you%27ve%20already%20got%20the%20severity%20and%20other%20information%20added%20to%20the%20agent%20formatter%2C%20it%27s%20really%20only%20missing%20the%20program%20name%20to%20be%20complete.%20Does%20this%20break%20compatibility%20for%20your%20log%20parsing%3F%22%2C%20%22created_at%22%3A%20%222017-10-17T14%3A49%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/977415%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/acedrew%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20it%20does...though%20refactoring%20the%20way%20the%20formatting%20works%20is%20a%20good%20idea%20I%20think...%22%2C%20%22created_at%22%3A%20%222017-10-17T20%3A50%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1526#issuecomment-337085584'>General Comment</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> I believe that it would be better to add a different AgentFormatter rather than change the current functionality.
- <a href='https://github.com/acedrew'><img border=0 src='https://avatars3.githubusercontent.com/u/977415?v=4' height=16 width=16></a> I would agree except that you've already got the severity and other information added to the agent formatter, it's really only missing the program name to be complete. Does this break compatibility for your log parsing?
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> Yeah it does...though refactoring the way the formatting works is a good idea I think...


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1526?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1526?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1526'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>