### PR TITLE
#1532 With multiplatform implementation, storing the subscriptions was modifie…

### DIFF
--- a/docs/source/core_services/multiplatform/Multiplatform-RPC.rst
+++ b/docs/source/core_services/multiplatform/Multiplatform-RPC.rst
@@ -21,7 +21,7 @@ Here is an example:
 
 .. code:: python
 
-    self.vip.rpc.call(peer, 'say_hello', 'Bob', platform='platform2').get()
-    self.vip.rpc.notify(peer, 'ready', platform='platform2')
+    self.vip.rpc.call(peer, 'say_hello', 'Bob', external_platform='platform2').get()
+    self.vip.rpc.notify(peer, 'ready', external_platform='platform2')
 
 Here, 'platform2' is the platform name of the remote platform.

--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -462,6 +462,8 @@ class PubSub(SubsystemBase):
         List of prefixes
         """
         topics = []
+        bus_subscriptions = dict()
+        subscriptions = dict()
         if prefix is None:
             if callback is None:
                 if platform in self._my_subscriptions:

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -212,10 +212,7 @@ class PubSubService(object):
             peer = frames[0].bytes
             prefix = msg['prefix']
             bus = msg['bus']
-            try:
-                is_all = msg['all_platforms']
-            except KeyError:
-                is_all = False
+            is_all = msg.get('all_platforms', False)
 
             if is_all:
                 platform = 'all'
@@ -260,7 +257,7 @@ class PubSubService(object):
                     unsubmsg = msg
                 except KeyError:
                     unsubmsg['internal'] = msg
-
+            self._logger.debug("Before unsubscribe: {}".format(unsubmsg))
             for platform in msg:
                 prefix = msg[platform]['prefix']
                 bus = msg[platform]['bus']
@@ -285,6 +282,7 @@ class PubSubService(object):
                     # Send updated subscription list to all connected platforms
                     external_platforms = self._ext_router.get_connected_platforms()
                     self._send_external_subscriptions(external_platforms)
+            self._logger.debug("After unsubscribe: {}".format(self._peer_subscriptions))
             return True
 
     def _peer_publish(self, frames, user_id):
@@ -336,10 +334,7 @@ class PubSubService(object):
             bus = msg['bus']
             subscribed = msg['subscribed']
             reverse = msg['reverse']
-            try:
-                is_all = msg['all_platforms']
-            except KeyError:
-                is_all = False
+            is_all = msg.get('all_platforms', False)
 
             if not is_all:
                 platform = 'internal'

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -257,7 +257,7 @@ class PubSubService(object):
                     unsubmsg = msg
                 except KeyError:
                     unsubmsg['internal'] = msg
-            self._logger.debug("Before unsubscribe: {}".format(unsubmsg))
+
             for platform in msg:
                 prefix = msg[platform]['prefix']
                 bus = msg[platform]['bus']
@@ -282,7 +282,6 @@ class PubSubService(object):
                     # Send updated subscription list to all connected platforms
                     external_platforms = self._ext_router.get_connected_platforms()
                     self._send_external_subscriptions(external_platforms)
-            self._logger.debug("After unsubscribe: {}".format(self._peer_subscriptions))
             return True
 
     def _peer_publish(self, frames, user_id):

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -212,7 +212,10 @@ class PubSubService(object):
             peer = frames[0].bytes
             prefix = msg['prefix']
             bus = msg['bus']
-            is_all = msg['all_platforms']
+            try:
+                is_all = msg['all_platforms']
+            except KeyError:
+                is_all = False
 
             if is_all:
                 platform = 'all'
@@ -246,6 +249,17 @@ class PubSubService(object):
             data = frames[7].bytes
             msg = jsonapi.loads(data)
             peer = frames[0].bytes
+            unsubmsg = dict()
+            #Added for backward compatibility
+            try:
+                sub = msg['internal']
+                unsubmsg = msg
+            except KeyError:
+                try:
+                    sub = msg['all']
+                    unsubmsg = msg
+                except KeyError:
+                    unsubmsg['internal'] = msg
 
             for platform in msg:
                 prefix = msg[platform]['prefix']
@@ -268,10 +282,10 @@ class PubSubService(object):
                             del subscriptions[prefix]
 
                 if platform == 'all' and self._ext_router is not None:
-                    # Send subscription message to all connected platforms
+                    # Send updated subscription list to all connected platforms
                     external_platforms = self._ext_router.get_connected_platforms()
                     self._send_external_subscriptions(external_platforms)
-                return True
+            return True
 
     def _peer_publish(self, frames, user_id):
         """Publish the incoming message to all the subscribers subscribed to the specified topic.
@@ -322,7 +336,11 @@ class PubSubService(object):
             bus = msg['bus']
             subscribed = msg['subscribed']
             reverse = msg['reverse']
-            is_all = msg['all_platforms']
+            try:
+                is_all = msg['all_platforms']
+            except KeyError:
+                is_all = False
+
             if not is_all:
                 platform = 'internal'
             else:
@@ -455,7 +473,8 @@ class PubSubService(object):
             frames[:] = []
             frames[0:7] = b'', proto, user_id, msg_id, subsystem, b'external_publish', topic, data
             for platform_id in external_subscribers:
-                #self._logger.debug("PUBSUBSERVICE sending external publish {0}, subscriptions: {1}".format(platform_id, external_subscribers))
+                #self._logger.debug("PUBSUBSERVICE sending external publish {0}, subscriptions: {1}".
+                # format(platform_id, external_subscribers))
                 try:
                     if self._ext_router is not None:
                         # Send the message to the external platform


### PR DESCRIPTION
…d which breaks when we run it with a platform using previous version of message bus implementation. Added a fix to store the subscription in default 'internal' subscription entry.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1533%23discussion_r145235467%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1533%23issuecomment-337349732%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1533%23issuecomment-337392900%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1533%23issuecomment-337349732%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40shwethanidd%20can%20you%20make%20the%20releases/5.0rc%20branch%20the%20base%20instead%20of%20develop.%20%20I%20will%20merge%20it%20back%20this%20week%20into%20develop%22%2C%20%22created_at%22%3A%20%222017-10-17T19%3A50%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changing%20base%20to%205.0rc%22%2C%20%22created_at%22%3A%20%222017-10-17T22%3A25%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2070c5cb2884719c22121afa164f02043313ab85e0%20volttron/platform/vip/pubsubservice.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1533%23discussion_r145235467%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Rather%20than%20this%20use%20msg.get%28%27all_platforms%27%2C%20False%29%22%2C%20%22created_at%22%3A%20%222017-10-17T19%3A46%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20volttron/platform/vip/pubsubservice.py%3AL212-222%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 70c5cb2884719c22121afa164f02043313ab85e0 volttron/platform/vip/pubsubservice.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1533#discussion_r145235467'>File: volttron/platform/vip/pubsubservice.py:L212-222</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> Rather than this use msg.get('all_platforms', False)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1533#issuecomment-337349732'>General Comment</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> @shwethanidd can you make the releases/5.0rc branch the base instead of develop.  I will merge it back this week into develop
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> Changing base to 5.0rc


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1533?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1533?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1533'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>