### PR TITLE
Fixed filename to be back to volttron.log

### DIFF
--- a/examples/rotatinglog.py
+++ b/examples/rotatinglog.py
@@ -11,7 +11,7 @@
             'class': 'logging.handlers.TimedRotatingFileHandler',
             'level': 'INFO',
             'formatter': 'agent',
-            'filename': 'volttron_log',
+            'filename': 'volttron.log',
             'encoding': 'utf-8',
             'when': 'midnight',
             'backupCount': 7,


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1538?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1538'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>