### PR TITLE
Added default signal int handler to list of flags to override

### DIFF
--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -173,7 +173,7 @@ class BasicCore(object):
         self.oninterrupt = None
         prev_int_signal = gevent.signal.getsignal(signal.SIGINT)
         # To avoid a child agent handler overwriting the parent agent handler
-        if prev_int_signal in [None, signal.SIG_IGN, signal.SIG_DFL]:
+        if prev_int_signal in [None, signal.SIG_IGN, signal.SIG_DFL, signal.default_int_handler]:
             self.oninterrupt = gevent.signal.signal(signal.SIGINT, self._on_sigint_handler)
         self._owner = owner
 
@@ -314,10 +314,9 @@ class BasicCore(object):
         :param _:
         :return:
         '''
-        _log.debug("SIG interrupt received. Calling stop")
+        _log.debug("SIG interrupt received. Setting stop event")
         if signo == signal.SIGINT:
             self._stop_event.set()
-            #self.stop()
 
     def send(self, func, *args, **kwargs):
         self._async_calls.append((func, args, kwargs))


### PR DESCRIPTION
Now the correct signal INT handler gets called when an agent is stopped. However, the platform needs to be cleanly shutdown as well and we need to have further discussion on that.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1627%23issuecomment-369988410%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1627%23issuecomment-369988410%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Related%20to%20%231615%22%2C%20%22created_at%22%3A%20%222018-03-02T17%3A17%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1627#issuecomment-369988410'>General Comment</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> Related to #1615


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1627?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1627?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1627'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>