### PR TITLE
Downgrades wheel to 0.30

### DIFF
--- a/services/core/VolttronCentral/package.json
+++ b/services/core/VolttronCentral/package.json
@@ -40,7 +40,7 @@
     "font-awesome": "^4.6.3",
     "history": "^3.0.0",
     "immutable": "^3.8.1",
-    "jquery": "^2.1.3",
+    "jquery": "^3.0.0",
     "keymirror": "^0.1.1",
     "moment": "^2.10.3",
     "node-uuid": "^1.4.2",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ requirements = [
     'pymodbus>=1.2,<2',
     'setuptools',
     'simplejson>=3.3,<4',
-    'wheel>=0.24,<2',
+    'wheel=0.30',
 ]
 
 install_requires = (

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ requirements = [
     'pymodbus>=1.2,<2',
     'setuptools',
     'simplejson>=3.3,<4',
-    'wheel=0.30',
+    'wheel==0.30',
 ]
 
 install_requires = (


### PR DESCRIPTION
# Description

This pull request downgrades wheel to be stuck at 0.30 as the upgrade to 0.31 has broken installing agentss

Fixes # (issue)

#1652

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Installed agent before change and it was messed up...after the patch and it works as expected.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1653?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1653'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>