### PR TITLE
import build_agent from utils.py

### DIFF
--- a/scripts/bacnet/proxy_grab_bacnet_config.py
+++ b/scripts/bacnet/proxy_grab_bacnet_config.py
@@ -53,7 +53,8 @@ from volttron.platform.agent import utils
 from volttron.platform.agent.bacnet_proxy_reader import BACnetReader
 from volttron.platform.keystore import KeyStore
 from volttron.platform.messaging import topics
-from volttron.platform.vip.agent import Agent, PubSub, errors, build_agent
+from volttron.platform.vip.agent import Agent, PubSub, errors
+from volttron.platform.vip.agent.utils import build_agent
 from volttron.platform.jsonrpc import RemoteError
 
 


### PR DESCRIPTION
# Description

`build_agent` function was moved to utils.
It was previously imported from the __init__.py but got removed.

## Type of change

Bug fix (non-breaking change which fixes an issue)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1655?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1655'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>