### PR TITLE
Fixes #1660 Installs 0.30 version of wheel before requirements.txt

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -231,7 +231,13 @@ def update(operation, verbose=None, upgrade=False, offline=False):
         try:
             import wheel
         except ImportError:
-            pip('install', ['wheel'], verbose, offline=offline)
+            # wheel version 0.31 breaks packaging.
+            # TODO Look towards fixing the packaging so that it works with 0.31
+            pip('install', ['wheel==0.30'], verbose, offline=offline)
+    # Downgrade wheel if necessary so things don't break.
+    # TODO Fix hard coded version in this spot...should be somewhere else.
+    pip('install', ['wheel==0.30'], verbose, offline=offline)
+
     # Build option_requirements separately to pass install options
     build_option = '--build-option' if wheeling else '--install-option'
     for requirement, options in option_requirements:


### PR DESCRIPTION
# Description

Fixes #1660 

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested installing against clean branch.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1661?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1661'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>