### PR TITLE
added default message for vctl list when no agents are installed

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1179,6 +1179,7 @@ def _show_filtered_agents(opts, field_name, field_callback, agents=None):
             filtered |= match
         agents = list(filtered)
     if not agents:
+        _stderr.write('No installed Agents found\n')
         return
     agents.sort()
     if not opts.min_uuid_len:


### PR DESCRIPTION
# Description

Added a simple "no agents installed message when running 'vctl list' without any agents, previously there was no output, which was a little confusing, as you couldn't tell if there was an exception or there just weren't any agents.

Fixes #1666 

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running vctl list without any agents installed generates the appropriate warning message


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1667%23issuecomment-382546415%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1667%23issuecomment-382546415%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20do%20you%20feel%20the%20same%20way%20about%20when%20vctl%20status%20is%20called%3F%20%20vctl%20list%20is%20able%20to%20be%20called%20when%20the%20platform%20isn%27t%20running%2C%20but%20the%20vctl%20status%20will%20give%20the%20same%20empty%20result%20if%20there%20isn%27t%20any%20agents%20installed.%22%2C%20%22created_at%22%3A%20%222018-04-18T22%3A15%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1667#issuecomment-382546415'>General Comment</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> So do you feel the same way about when vctl status is called?  vctl list is able to be called when the platform isn't running, but the vctl status will give the same empty result if there isn't any agents installed.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1667?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1667?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1667'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>