### PR TITLE
require https for ubuntu 18.04

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -166,7 +166,7 @@ def bootstrap(dest, prompt='(volttron)', version=None, verbose=None):
             '''Download the virtualenv tarball into directory.'''
             if self.version is None:
                 self.version = self.get_version()
-            url = ('http://pypi.python.org/packages/source/v/virtualenv/'
+            url = ('https://pypi.python.org/packages/source/v/virtualenv/'
                    'virtualenv-{}.tar.gz'.format(self.version))
             _log.info('Downloading virtualenv %s', self.version)
             tarball = os.path.join(directory, 'virtualenv.tar.gz')


### PR DESCRIPTION
# Description

On Ubuntu 18.04 the bootstrap fails because of the lack of https in downloading the initial package.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/jhaack%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/6992449%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1679%23issuecomment-385827841%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-05-02T00%3A16%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/6992449%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jhaack%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1679%23issuecomment-385827841%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/jhaack'><img src='https://avatars0.githubusercontent.com/u/6992449?v=4' width=34 height=34></a>

<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1679?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1679?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1679'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>