### PR TITLE
make platform market service config file parsible by utils.load_config.

### DIFF
--- a/services/core/MarketServiceAgent/config
+++ b/services/core/MarketServiceAgent/config
@@ -1,6 +1,6 @@
 {
-    'market_period': 300,
-    'reservation_delay': 0,
-    'offer_delay': 120,
-    'verbose_logging': False
+    "market_period"    : 300,
+    "reservation_delay": 0,
+    "offer_delay"      : 120,
+    "verbose_logging"  : 0
 }


### PR DESCRIPTION
# Description
The MarketServiceAgent could not parse its config file via utils.load_config.

Fixes # (issue)
changed quotes to double-quotes and the value of the 'verbose_logging'  key to 0 instead of
False.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
with the platform running, from a command shell,  i ran:
           pydev-python MarketServiceAgent/market_service/agent.py
with AGENT_CONFIG set to 
           MarketServiceAgent/config

before modifying config file, the agent call to
        config = utils.load_config(config_path)  failed.
after modifying config file(per 'Fixes' above), the agent call to
        config = utils.load_config(config_path)  succeeded.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1686?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1686'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>