### PR TITLE
fixed issue with readthedocs sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -400,7 +400,7 @@ def run_apidoc(docs_dir, agent_dirs, exclude_list):
         name = os.path.basename(agent_dir)
         cmd = ["sphinx-apidoc", '--force', '-o',
             os.path.join(apidocs_base_dir, "volttron"),
-            script_dir + "/../../volttron"
+            script_dir + "/../../volttron"]
         cmd.extend(exclude_list)
         subprocess.check_call(cmd)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -398,13 +398,11 @@ def run_apidoc(docs_dir, agent_dirs, exclude_list):
         sys.path.insert(0, agent_dir)
         print "Added to syspath {}".format(agent_dir)
         name = os.path.basename(agent_dir)
-        cmd = ["sphinx-apidoc", '-M', '-d 4', '-o',
-             os.path.join(docs_dir, name),
-             agent_dir, os.path.join(agent_dir, "setup.py"),
-             '--force']
+        cmd = ["sphinx-apidoc", '--force', '-o',
+            os.path.join(apidocs_base_dir, "volttron"),
+            script_dir + "/../../volttron"
         cmd.extend(exclude_list)
         subprocess.check_call(cmd)
-
 
 def clean_apirst(app, exception):
     """


### PR DESCRIPTION
# Description
Fixed a call to sphinx when building readthedocs
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1698?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1698'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>