### PR TITLE
1132 unhandled closed connections

### DIFF
--- a/services/core/SQLHistorian/sqlhistorian/historian.py
+++ b/services/core/SQLHistorian/sqlhistorian/historian.py
@@ -181,8 +181,7 @@ class SQLHistorian(BaseHistorian):
                 if topic_id is None:
                     # _log.debug('Inserting topic: {}'.format(topic))
                     # Insert topic name as is in db
-                    row = self.bg_thread_dbutils.insert_topic(topic)
-                    topic_id = row[0]
+                    topic_id = self.bg_thread_dbutils.insert_topic(topic)
                     # user lower case topic name when storing in map
                     # for case insensitive comparison
                     self.topic_id_map[lowercase_name] = topic_id

--- a/volttron/platform/dbutils/basedb.py
+++ b/volttron/platform/dbutils/basedb.py
@@ -353,11 +353,10 @@ class DbDriver(object):
 
         :return: True if successful, False otherwise
         """
-        successful = False
         if self.__connection is not None:
             try:
                 self.__connection.commit()
-                successful = True
+                return True
             except sqlite3.OperationalError as e:
                 if "database is locked" in e.message:
                     _log.error("EXCEPTION: SQLITE3 Database is locked. This "
@@ -372,11 +371,8 @@ class DbDriver(object):
                                "\"timeout\"]  "
                                "Default value is 10. Timeout units is seconds")
                 raise
-
-        else:
-            _log.warning('connection was null during commit phase.')
-
-        return successful
+        _log.warning('connection was null during commit phase.')
+        return False
 
     def rollback(self):
         """
@@ -384,14 +380,11 @@ class DbDriver(object):
 
         :return: True if successful, False otherwise
         """
-        successful = False
         if self.__connection is not None:
             self.__connection.rollback()
-            successful = True
-        else:
-            _log.warning('connection was null during rollback phase.')
-
-        return successful
+            return True
+        _log.warning('connection was null during rollback phase.')
+        return False
 
     def close(self):
         """

--- a/volttron/platform/dbutils/basedb.py
+++ b/volttron/platform/dbutils/basedb.py
@@ -282,9 +282,9 @@ class DbDriver(object):
         self.__connect()
         cursor = self.__connection.cursor()
         cursor.execute(self.insert_topic_query(), (topic,))
-        row = [cursor.lastrowid]
+        topic_id = cursor.lastrowid
         cursor.close()
-        return row
+        return topic_id
 
     def update_topic(self, topic, topic_id):
         """
@@ -329,9 +329,9 @@ class DbDriver(object):
         cursor = self.__connection.cursor()
         cursor.execute(self.insert_agg_topic_stmt(),
                        (topic, agg_type, agg_time_period))
-        row = [cursor.lastrowid]
+        topic_id = cursor.lastrowid
         cursor.close()
-        return row
+        return topic_id
 
     def update_agg_topic(self, agg_id, agg_topic_name):
         """

--- a/volttron/platform/dbutils/basedb.py
+++ b/volttron/platform/dbutils/basedb.py
@@ -37,6 +37,7 @@
 # }}}
 from __future__ import absolute_import, print_function
 
+import contextlib
 import importlib
 import logging
 import threading
@@ -56,6 +57,23 @@ class ConnectionError(Exception):
     pass
 
 
+@contextlib.contextmanager
+def closing(obj):
+    try:
+        yield obj
+    finally:
+        try:
+            obj.close()
+        except Exception as exc:
+            if isinstance(exc, StandardError) and exc.__class__.__module__ == 'exceptions':
+                # Don't ignore built-in exceptions because they likely indicate
+                # a bug that should stop execution. psycopg2.Error subclasses
+                # StandardError, so the module must also be checked. :-(
+                raise
+            _log.exception('An exception was raised while closing '
+                           'the cursor and is being ignored.')
+
+
 class DbDriver(object):
     """
     Parent class used by :py:class:`sqlhistorian.historian.SQLHistorian` to
@@ -67,28 +85,31 @@ class DbDriver(object):
     """
     def __init__(self, dbapimodule, **kwargs):
         thread_name = threading.currentThread().getName()
-        _log.debug("Constructing Driver for {} in thread: {}".format(
-            dbapimodule, thread_name)
-        )
-
-        self.__dbmodule = importlib.import_module(dbapimodule)
+        _log.debug("Constructing Driver for %s in thread: %s",
+                   dbapimodule, thread_name)
+        _log.debug("kwargs for connect is %r", kwargs)
+        dbapimodule = importlib.import_module(dbapimodule)
+        self.__connect = lambda: dbapimodule.connect(**kwargs)
         self.__connection = None
-        self.__connect_params = kwargs
-        _log.debug("kwargs for connect is {}".format(kwargs))
 
-    def __connect(self):
+    def cursor(self):
+        if self.__connection is not None and not getattr(self.__connection, "closed", False):
+            try:
+                return self.__connection.cursor()
+            except Exception:
+                _log.exception("An exception occured while creating "
+                               "a cursor and is being ignored")
+        self.__connection = None
         try:
-            if self.__connection is None:
-                self.__connection = self.__dbmodule.connect(
-                    **self.__connect_params)
-
+            self.__connection = self.__connect()
         except Exception as e:
             _log.error("Could not connect to database. Raise ConnectionError")
             raise ConnectionError(e), None, sys.exc_info()[2]
-
         if self.__connection is None:
             raise ConnectionError(
                 "Unknown error. Could not connect to database")
+        return self.__connection.cursor()
+
 
     def read_tablenames_from_db(self, meta_table_name):
         """
@@ -251,9 +272,8 @@ class DbDriver(object):
         :return: True if execution completes. Raises exception if unable to
         connect to database
         """
-        self.__connect()
         self.execute_stmt(self.insert_meta_query(),
-                       (topic_id, jsonapi.dumps(metadata)), commit=False)
+                          (topic_id, jsonapi.dumps(metadata)), commit=False)
         return True
 
     def insert_data(self, ts, topic_id, data):
@@ -266,9 +286,8 @@ class DbDriver(object):
         :return: True if execution completes. raises Exception if unable to
         connect to database
         """
-        self.__connect()
         self.execute_stmt(self.insert_data_query(),
-                       (ts, topic_id, jsonapi.dumps(data)), commit=False)
+                          (ts, topic_id, jsonapi.dumps(data)), commit=False)
         return True
 
     def insert_topic(self, topic):
@@ -279,12 +298,9 @@ class DbDriver(object):
         :return: id of the topic inserted if insert was successful.
                  Raises exception if unable to connect to database
         """
-        self.__connect()
-        cursor = self.__connection.cursor()
-        cursor.execute(self.insert_topic_query(), (topic,))
-        topic_id = cursor.lastrowid
-        cursor.close()
-        return topic_id
+        with closing(self.cursor()) as cursor:
+            cursor.execute(self.insert_topic_query(), (topic,))
+            return cursor.lastrowid
 
     def update_topic(self, topic, topic_id):
         """
@@ -295,8 +311,6 @@ class DbDriver(object):
         :return: True if execution is complete. Raises exception if unable to
         connect to database
         """
-
-        self.__connect()
         self.execute_stmt(self.update_topic_query(), (topic, topic_id),
                           commit=False)
         return True
@@ -310,9 +324,8 @@ class DbDriver(object):
         :return: True if execution completes. Raises exception if connection to
         database fails
         """
-        self.__connect()
         self.execute_stmt(self.replace_agg_meta_stmt(),
-                       (topic_id, jsonapi.dumps(metadata)), commit=False)
+                          (topic_id, jsonapi.dumps(metadata)), commit=False)
         return True
 
     def insert_agg_topic(self, topic, agg_type, agg_time_period):
@@ -325,13 +338,10 @@ class DbDriver(object):
         :return: id of the topic inserted if insert was successful.
                  Raises exception if unable to connect to database
         """
-        self.__connect()
-        cursor = self.__connection.cursor()
-        cursor.execute(self.insert_agg_topic_stmt(),
-                       (topic, agg_type, agg_time_period))
-        topic_id = cursor.lastrowid
-        cursor.close()
-        return topic_id
+        with closing(self.cursor()) as cursor:
+            cursor.execute(self.insert_agg_topic_stmt(),
+                           (topic, agg_type, agg_time_period))
+            return cursor.lastrowid
 
     def update_agg_topic(self, agg_id, agg_topic_name):
         """
@@ -342,9 +352,8 @@ class DbDriver(object):
         :return: True if execution is complete. Raises exception if unable to
         connect to database
         """
-        self.__connect()
         self.execute_stmt(self.update_agg_topic_stmt(),
-                              (agg_id, agg_topic_name),commit=False)
+                          (agg_id, agg_topic_name),commit=False)
         return True
 
     def commit(self):
@@ -405,18 +414,18 @@ class DbDriver(object):
         :return: resultant rows if fetch_all is True else returns the cursor
         It is up to calling method to close the cursor
         """
-        self.__connect()
-        cursor = self.__connection.cursor()
-        if args is not None:
+        if not args:
+            args = ()
+        cursor = self.cursor()
+        try:
             cursor.execute(query, args)
-        else:
-            cursor.execute(query)
-        if fetch_all:
-            rows = cursor.fetchall()
+        except Exception:
             cursor.close()
-        else:
-            rows = cursor
-        return rows
+            raise
+        if fetch_all:
+            with closing(cursor):
+                return cursor.fetchall()
+        return cursor
 
     def execute_stmt(self, stmt, args=None, commit=False):
         """
@@ -428,16 +437,13 @@ class DbDriver(object):
         False
         :return: count of the number of affected rows
         """
-
-        self.__connect()
-        cursor = self.__connection.cursor()
-        if args is not None:
+        if args is None:
+            args = ()
+        with closing(self.cursor()) as cursor:
             cursor.execute(stmt, args)
-        else:
-            cursor.execute(stmt)
-        if commit:
-            self.commit()
-        return cursor.rowcount
+            if commit:
+                self.commit()
+            return cursor.rowcount
 
     def execute_many(self, stmt, args, commit=False):
         """
@@ -449,13 +455,11 @@ class DbDriver(object):
         False
         :return: count of the number of affected rows
         """
-
-        self.__connect()
-        cursor = self.__connection.cursor()
-        cursor.executemany(stmt, args)
-        if commit:
-            self.commit()
-        return cursor.rowcount
+        with closing(self.cursor()) as cursor:
+            cursor.executemany(stmt, args)
+            if commit:
+                self.commit()
+            return cursor.rowcount
 
     @abstractmethod
     def query(self, topic_ids, id_name_map, start=None, end=None,
@@ -543,8 +547,6 @@ class DbDriver(object):
         :return: True if execution was successful, raises exception
         in case of connection failures
         """
-
-        self.__connect()
         table_name = agg_type + '_' + period
         _log.debug("Inserting aggregate: {} {} {} {} into table {}".format(
             ts, agg_topic_id, jsonapi.dumps(data), str(topic_ids), table_name))

--- a/volttrontesting/services/historian/test_dbdriver.py
+++ b/volttrontesting/services/historian/test_dbdriver.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*- {{{
+# vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
+#
+# Copyright 2018, 8minutenergy Renewables
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# }}}
+
+"""
+pytest test cases for historian database drivers.
+
+Prerequisites:
+
+ 1. Server process should be running
+ 2. Test database and user should exist
+ 3. Test user should have all privileges on test database
+ 4. Refer to the parameters passed to the historian fixture for the
+    server configuration
+
+This test case is a generic test case that all historian drivers should
+satisfy. To test a specific historian implementation through this test
+suite do the following:
+
+ 1. Create a Test<DriverType> class that subclasses Suite
+ 2. Implement the transact method as a context manager that can perform
+    any setup before yielding the tuple (DriverClass, connection_params)
+    and cleans up afterward.
+"""
+
+import contextlib
+import tempfile
+from datetime import datetime, timedelta
+import inspect
+import sqlite3
+
+import pytest
+import pytz
+import shutil
+
+from volttron.platform.dbutils import basedb
+from volttron.platform.dbutils.sqlitefuncts import SqlLiteFuncts
+
+
+def drop_tables(names):
+    '''Marks methods creating additional tables for cleanup'''
+    def wrapper(fn):
+        fn.drop_tables = names
+        return fn
+    return wrapper
+
+
+@pytest.mark.historian
+class Suite(object):
+    #@pytest.fixture(scope='class', params=['', 'test'])
+    @pytest.fixture(scope='class', params=[''])
+    def state(self, request):
+        prefix = request.param
+        pre = prefix + '_' if prefix else ''
+        table_names = {
+            'data_table': pre + 'data',
+            'topics_table': pre + 'topics',
+            'meta_table': pre + 'meta',
+            'agg_topics_table': pre + 'aggregate_topics',
+            'agg_meta_table': pre + 'aggregate_meta',
+        }
+        tables_def = table_names.copy()
+        tables_def['table_prefix'] = prefix
+        meta_table_name = pre + 'volttron_table_definitions'
+        state = type('State', (object,), {
+            'meta_table_name': meta_table_name,
+            'table_names': table_names,
+        })
+        truncate_tables = table_names.values() + [meta_table_name]
+        drop_tables = []
+        for _, method in inspect.getmembers(self, inspect.ismethod):
+            drop_tables.extend(getattr(method, 'drop_tables', []))
+        with self.transact(truncate_tables, drop_tables) as (cls, params), \
+                contextlib.closing(cls(params, tables_def)) as state.driver:
+            yield state
+
+    @pytest.fixture
+    def driver(self, state):
+        driver = state.driver
+        driver.setup_historian_tables()
+        driver.record_table_definitions(
+            state.table_names, state.meta_table_name)
+        return driver
+
+    @contextlib.contextmanager
+    def transact(self, truncate_tables, drop_tables):
+        pass
+
+    def test_setup_tables(self, driver, state):
+        assert driver.read_tablenames_from_db(
+            state.meta_table_name) == state.table_names
+
+    def test_add_data(self, driver):
+        id_map = {}
+        name_map = {}
+        id_name_map = {}
+        values = {}
+        for topic in ['Building/LAB/Device/OutsideAirTemperature',
+                      'Building/LAB/Device/MixedAirTemperature',
+                      'Building/LAB/Device/DamperSignal']:
+            name = topic.lower()
+            topic_id = driver.insert_topic(topic)
+            assert topic_id
+            id_map[name] = topic_id
+            name_map[name] = topic
+            id_name_map[topic_id] = topic
+            driver.insert_meta(topic_id, {
+                'units': 'X', 'tz': 'UTC', 'type': 'float'})
+            ts = datetime(year=2015, month=3, day=14, hour=9, minute=26,
+                          second=53, microsecond=59, tzinfo=pytz.UTC)
+            for value in range(3):
+                value = float(value)
+                driver.insert_data(ts, topic_id, value)
+                try:
+                    values[topic].append((ts.isoformat(), value))
+                except KeyError:
+                    values[topic] = [(ts.isoformat(), value)]
+                ts += timedelta(seconds=1)
+        assert driver.get_topic_map() == (id_map, name_map)
+        assert driver.query(id_name_map.keys(), id_name_map) == values
+        start = datetime(year=2015, month=3, day=14, hour=9, minute=26,
+                         second=0, microsecond=0, tzinfo=pytz.UTC)
+        end = datetime(year=2015, month=3, day=14, hour=9, minute=27,
+                         second=0, microsecond=0, tzinfo=pytz.UTC)
+        assert driver.query(id_name_map.keys(), id_name_map, start, end) == values
+
+    def test_topic_name_case_change(self, driver):
+        topic_id = driver.insert_topic('This/is/some/Topic')
+        assert topic_id
+        id_map1, name_map1 = driver.get_topic_map()
+        driver.update_topic('This/is/some/topic', topic_id)
+        id_map2, name_map2 = driver.get_topic_map()
+        assert id_map1 == id_map2
+        assert name_map1.pop('this/is/some/topic') == 'This/is/some/Topic'
+        assert name_map2.pop('this/is/some/topic') == 'This/is/some/topic'
+        assert name_map1 == name_map2
+
+    def test_query_topic_pattern(self, driver):
+        topics = {'This/is/a/pattern/topic',
+                  'This/is/another/pattern/topic',
+                  'This/is/some/pattern/topic'}
+        for topic in topics:
+            topic_id = driver.insert_topic(topic)
+            assert topic_id
+        driver.commit()
+        assert len(set(driver.query_topics_by_pattern('this/is/a.*/pattern/topic').keys()) & topics) == 2
+        assert len(set(driver.query_topics_by_pattern('this/is/some/.*/topic').keys()) & topics) == 1
+        assert len(set(driver.query_topics_by_pattern('.*').keys()) & topics) == 3
+
+    def test_curser_for_closed_connection(self, driver):
+        cursor = driver.cursor()
+        assert cursor is not None
+        cursor.connection.close()
+        cursor = driver.cursor()
+        assert cursor is not None
+
+
+class AggregationSuite(Suite):
+    @pytest.fixture
+    def driver(self, state):
+        driver = super(AggregationSuite, self).driver(state)
+        driver.setup_aggregate_historian_tables(state.meta_table_name)
+        return driver
+
+    @pytest.mark.aggregator
+    def test_create_agg_table(self, driver, state):
+        driver.create_aggregate_store('sum', '1m')
+
+    @pytest.mark.aggregator
+    @drop_tables(['sum_1m', 'max_1m'])
+    def test_aggregation(self, driver):
+        ts = start = datetime(year=2015, month=4, day=14, hour=9, minute=26,
+                              second=53, microsecond=59, tzinfo=pytz.UTC)
+        delta = timedelta(seconds=1)
+        for i in range(100):
+            value = float(i)
+            for topic_id in range(1, 4):
+                driver.insert_data(ts, topic_id, value)
+            ts += delta
+        driver.commit()
+        assert driver.collect_aggregate(range(1, 4), 'sum', start, ts) == (14850.0, 300)
+        assert driver.collect_aggregate(range(1, 4), 'avg', start, ts) == (49.5, 300)
+        assert driver.collect_aggregate([1, 6], 'sum', start, ts) == (4950, 100)
+        assert driver.collect_aggregate([1, 6], 'avg', start, ts) == (49.5, 100)
+        start += delta
+        ts = start + delta
+        assert driver.collect_aggregate(range(1, 4), 'sum', start, ts) == (3.0, 3)
+        assert driver.collect_aggregate(range(1, 4), 'avg', start, ts) == (1, 3)
+        driver.create_aggregate_store('max', '1m')
+        topic_id = driver.insert_agg_topic('aggregate/max/1m/topic', 'max', '1m')
+        assert topic_id
+        driver.insert_agg_meta(topic_id, {'units': 'X', 'tz': 'UTC', 'type': 'float'})
+        driver.insert_aggregate(topic_id, 'max', '1m', ts, '12.345', [1, 2, 3])
+
+
+class TestSqlite(AggregationSuite):
+    @contextlib.contextmanager
+    def transact(self, truncate_tables, drop_tables):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            params = {'database': '{}/test.sqlite'.format(tmpdir)}
+            def cleanup():
+                with contextlib.closing(sqlite3.connect(**params)) as connection, \
+                        connection:
+                    cursor = connection.cursor()
+                    def clean(query, tables):
+                        for table in tables:
+                            try:
+                                cursor.execute('{} "{}"'.format(
+                                    query, table.replace('"', '""')))
+                            except sqlite3.OperationalError as exc:
+                                if not exc.message.startswith('no such table'):
+                                    raise
+                    clean('DELETE FROM', truncate_tables)
+                    clean('DROP TABLE', drop_tables)
+            cleanup()
+            yield SqlLiteFuncts, params
+            cleanup()
+        finally:
+            shutil.rmtree(tmpdir, True)
+
+
+class FauxConnection:
+    def __init__(self, exc_class):
+        self.exc_class = exc_class
+
+    def close(self):
+        raise self.exc_class
+
+
+class TestClosing:
+    def test_closing_standarderror(self):
+        with pytest.raises(StandardError), basedb.closing(FauxConnection(StandardError)):
+            pass
+
+    def test_closing_exception(self):
+        with basedb.closing(FauxConnection(Exception)):
+            pass
+
+    def test_closing_standarderror_builtin_subclass(self):
+        with pytest.raises(ValueError), basedb.closing(FauxConnection(ValueError)):
+            pass
+
+    def test_closing_standarderror_subclass(self):
+        class SubclassedError(StandardError):
+            pass
+        with basedb.closing(FauxConnection(SubclassedError)):
+            pass

--- a/volttrontesting/services/historian/test_historian.py
+++ b/volttrontesting/services/historian/test_historian.py
@@ -1172,7 +1172,7 @@ def test_invalid_time(request, historian, publish_agent, query_agent,
                                  order="LAST_TO_FIRST").get(timeout=10)
     except RemoteError as error:
         print ("exception: {}".format(error))
-        assert 'hour must be in 0..23' == error.message
+        assert 'Syntax Error in Query' == error.message
 
 
 @pytest.mark.historian


### PR DESCRIPTION
# Description
If a database connection is closed, perhaps by the remote end or due to an unhandled exception, an exception will be raised when creating a cursor using the connection's cursor() method. Because there doesn't seem to be consensus between the different database drivers about the exact exception raised, any non-standard exception should be logged and ignored while forcing the connection to be recreated.

It is also important to ensure cursors are closed for autocommit features to work properly. A context manager will ensure proper closure.

Fixes #1732 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the change against yet-to-be-published PostgreSQL and Redshift drivers as well as the sqlite3 version of the SQLHistorian using the included unit tests.

- [ ] volttrontesting/services/historian/test_dbdriver.py

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1733?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1733'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>