### PR TITLE
Updated yaml config file parsing

### DIFF
--- a/examples/ListenerAgent/config
+++ b/examples/ListenerAgent/config
@@ -1,4 +1,5 @@
 {
+	
 
     "agentid": "listener1",
     "message": "hello",

--- a/scripts/install-agent.py
+++ b/scripts/install-agent.py
@@ -10,6 +10,7 @@ import sys
 
 import yaml
 
+
 logging.basicConfig(level=logging.WARN)
 log = logging.getLogger(os.path.basename(__file__))
 
@@ -118,14 +119,15 @@ def install_agent(opts, package, config):
     else:
         cfg = tempfile.NamedTemporaryFile()
         with open(cfg.name, 'w') as fout:
-            fout.write(yaml.dump(config))  #jsonapi.dumps(config))
+            fout.write(yaml.safe_dump(config)) # jsonapi.dumps(config))
         config_file = cfg.name
 
     try:
         with open(config_file) as fp:
-            data = yaml.safe_load(fp.read())  # json.load(fp)
+            data = yaml.safe_load(fp)
+            # data = json.load(fp)
     except:
-        log.error("Invalid json/yaml config file.")
+        log.error("Invalid yaml/json config file.")
         sys.exit(-10)
 
     # Configure the whl file before installing.
@@ -337,18 +339,46 @@ if __name__ == '__main__':
         sys.exit(-10)
 
     jsonobj = None
+    # At this point if we have opts.config, it will be an open reference to the
+    # passed config file.
     if opts.config:
-        tmpconfigfile = tempfile.NamedTemporaryFile()
-
-        with open(tmpconfigfile.name, 'w') as fout:
-            for line in opts.config:
-                fout.write(line)
-        config_file = tmpconfigfile.name
+        # Attempt to use the yaml parser directly first
         try:
-            with open(tmpconfigfile.name) as f:
-                opts.config = yaml.safe_load(f.read())
-        finally:
-            tmpconfigfile.close()
+            tmp_cfg_load = yaml.safe_load(opts.config.read())
+            opts.config = tmp_cfg_load
+
+        except yaml.scanner.ScannerError:
+            sys.stderr.write("Invalid yaml file detect, attempting to parser using json parser.\n")
+            opts.config.seek(0)
+            should_parse_json = False
+            for line in opts.config:
+                line = line.partition('#')[0]
+                if line.rstrip():
+                    if line.rstrip()[0] in ('{', '['):
+                        should_parse_json = True
+                        break
+            if not should_parse_json:
+                sys.stderr.write("Invalid json file detected, must start with { or [ character.\n")
+                sys.exit(1)
+
+            # Yaml failed for some reason, could be invalid yaml or could
+            # have embedded invalid character in a json file.  So now we
+            # are going to try to deal with json here.
+
+            tmpconfigfile = tempfile.NamedTemporaryFile()
+            opts.config.seek(0)
+            with open(tmpconfigfile.name, 'w') as fout:
+
+                for line in opts.config:
+                    line = line.partition('#')[0]
+                    if line.rstrip():
+                        fout.write(line.rstrip() + "\n")
+            config_file = tmpconfigfile.name
+            try:
+                with open(tmpconfigfile.name) as f:
+                    opts.config = jsonapi.loads(f.read())
+            finally:
+                tmpconfigfile.close()
 
     if opts.config:
         install_agent(opts, opts.package, opts.config)

--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -144,12 +144,18 @@ def load_config(config_path):
         _log.info("Config file specified by AGENT_CONFIG does not exist. load_config returning empty configuration.")
         return {}
 
+    # First attempt parsing the file with a yaml parser (allows comments natively)
+    # Then if that fails we fallback to our modified json parser.
     try:
         with open(config_path) as f:
             return yaml.safe_load(f.read())
     except StandardError as e:
-        _log.error("Problem parsing agent configuration")
-        raise
+        try:
+            with open(config_path) as f:
+                return parse_json_config(f.read())
+        except StandardError as e:
+            _log.error("Problem parsing agent configuration")
+            raise
 
 def update_kwargs_with_config(kwargs, config):
     """

--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -149,7 +149,7 @@ def load_config(config_path):
     try:
         with open(config_path) as f:
             return yaml.safe_load(f.read())
-    except StandardError as e:
+    except yaml.scanner.ScannerError as e:
         try:
             with open(config_path) as f:
                 return parse_json_config(f.read())


### PR DESCRIPTION
# Description

This pull request updates the install-agent.py script to be more robust in error handling of parsing json as well as yaml configuration files.  It handles the \t parse error in yaml parser.

Fixes #1713, #1700 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against config file with tab characters in json file.  Testing with invalid json file and with yaml file.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1735?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1735'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>