### PR TITLE
Rabbitmq volttron auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,12 +368,11 @@ sudo rabbitmqctl set_permissions -p volttron <username> ".*" ".*" ".*"
 ```
 
 ## Next Steps
-We request you to explore and contribute towards development of VOLTTRON message bus refactor task. This is an ongoing task and we
- are working towards completing the below:
-* Adding authentication and authorization feature to RabbitMQ message bus.
-* Authenticated connection amongst multiple platform instances.
-* Creation of Each agent has to have a unique RabbitMQ user id.
-* Testing of RabbitMQ shovel for multi-platform over NAT setup
+We request you to explore and contribute towards development of VOLTTRON message bus refactor task. This is an ongoing task and we are working towards completing the following:
+* Integrating Volttron Central, forwarder, data mover and other agents which connect to remote instances to use RabbitMQ message bus with SSL.
+* Streamlining the installation steps.
+* Test scripts for RabbitMQ message bus.
+* Scalability tests for large scale VOLTTRON deployment.
 
 ## Acquiring Third Party Agent Code
 Third party agents are available under volttron-applications repository. In order to use those agents, add volttron-applications repository under the volttron/applications directory by using following command:
@@ -382,12 +381,7 @@ Third party agents are available under volttron-applications repository. In orde
 git subtree add –prefix applications https://github.com/VOLTTRON/volttron-applications.git develop –squash
 ```
 
-## Next Steps
-We request you to explore and contribute towards development of VOLTTRON message bus refactor task. This is an ongoing task and we are working towards completing the following:
-* Integrating Volttron Central, forwarder, data mover and other agents which connect to remote instances to use RabbitMQ message bus with SSL.
-* Streamlining the installation steps.
-* Test scripts for RabbitMQ message bus.
-* Scalability tests for large scale VOLTTRON deployment.
+
 
 
 ## Acquiring Third Party Agent Code

--- a/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
@@ -137,10 +137,9 @@ def revert_devices(request, publish_agent):
     return cleanup_parameters
 
 
-# Repeat test for volttron 2.0 agent and volttron 3.0 agents
+# VOLTTRON 2.0 agents will deprecated from VOLTTRON 6.0 release. So running it for only volttron 3.0 agents
 @pytest.fixture(scope="module",
                 params=['volttron_3'])
-                #params=['volttron_2', 'volttron_3'])
 def publish_agent(request, volttron_instance):
     """
     Fixture used for setting up the environment.

--- a/services/core/MasterDriverAgent/tests/test_global_override.py
+++ b/services/core/MasterDriverAgent/tests/test_global_override.py
@@ -133,10 +133,10 @@ def setup_config(config_store, config_name, config_string, **kwargs):
 def test_agent(request, volttron_instance1):
     test_agent = volttron_instance1.build_agent(identity=TEST_AGENT)
     def stop_agent():
-        result = test_agent.vip.rpc.call(
-            PLATFORM_DRIVER,  # Target agent
-            'clear_overrides'  # Method
-        ).get(timeout=10)
+        # result = test_agent.vip.rpc.call(
+        #     PLATFORM_DRIVER,  # Target agent
+        #     'clear_overrides'  # Method
+        # ).get(timeout=10)
         test_agent.core.stop()
     #Add a tear down method to stop test agent
     request.addfinalizer(stop_agent)
@@ -673,14 +673,10 @@ def test_indefinite_override_after_restart(config_store, test_agent, volttron_in
     gevent.sleep(0.5)
     global master_uuid
     volttron_instance1.stop_agent(master_uuid)
-    volttron_instance1.remove_agent(master_uuid)
-    gevent.sleep(1)
+    gevent.sleep(0.5)
     # Start the master driver agent which would in turn start the fake driver
     #  using the configs created above
-    master_uuid = volttron_instance1.install_agent(
-        agent_dir=get_services_core("MasterDriverAgent"),
-        config_file={},
-        start=True)
+    volttron_instance1.start_agent(master_uuid)
     gevent.sleep(1)  # wait for the agent to start and start the devices
 
     point = 'SampleWritableFloat1'

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -667,10 +667,10 @@ class AIPplatform(object):
             permissions = dict(configure=config_access, read=read_access, write=write_access)
             ssl = is_ssl_connection()
             if ssl:
+                _log.info("Created agent cert")
                 create_rmq_user_certs(agent_vip_identity)
             create_rmq_user_with_permissions(agent_vip_identity, permissions)
 
-        _log.info("Created agent cert")
         module, _, func = module.partition(':')
         if func:
             code = '__import__({0!r}, fromlist=[{1!r}]).{1}()'.format(module, func)

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -66,8 +66,10 @@ from .packages import UnpackedPackage
 from .vip.agent import Agent
 from .keystore import KeyStore
 from .auth import AuthFile, AuthEntry, AuthFileEntryAlreadyExists
-from volttron.utils.rmq_mgmt import create_user_certs, \
-    delete_user as delete_rmq_user
+from volttron.utils.rmq_mgmt import create_user_certs as create_rmq_user_certs, \
+    delete_user as delete_rmq_user, \
+    create_user_with_permissions as create_rmq_user_with_permissions, \
+    is_ssl_connection
 try:
     from volttron.restricted import auth
     from volttron.restricted.resmon import ResourceError
@@ -663,7 +665,10 @@ class AIPplatform(object):
             read_access = "volttron|{}".format(config_access)
             write_access = "volttron|{}".format(config_access)
             permissions = dict(configure=config_access, read=read_access, write=write_access)
-            create_user_certs(agent_vip_identity, permissions)
+            ssl = is_ssl_connection()
+            if ssl:
+                create_rmq_user_certs(agent_vip_identity)
+            create_rmq_user_with_permissions(agent_vip_identity, permissions)
 
         _log.info("Created agent cert")
         module, _, func = module.partition(':')

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -88,6 +88,11 @@ _stderr = sys.stderr
 _log = logging.getLogger(os.path.basename(sys.argv[0])
                          if __name__ == '__main__' else __name__)
 
+message_bus = utils.get_messagebus()
+rmq_auth = False
+if message_bus == 'rmq':
+    rmq_auth = is_ssl_connection()
+
 CHUNK_SIZE = 4096
 
 class ControlService(BaseAgent):
@@ -2094,7 +2099,7 @@ def main(argv=sys.argv):
     stats.set_defaults(func=do_stats, op='status')
 
 #==============================================================================
-    message_bus = utils.get_messagebus()
+    global message_bus
     if message_bus == 'rmq':
         # Add commands
         rabbitmq_cmds = add_parser("rabbitmq", help="manage rabbitmq")

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -880,9 +880,9 @@ class RMQCore(BasicCore):
             is_ssl = is_ssl_connection()
             if is_ssl:
                 create_user_certs(self.identity)
-            create_rmq_user_with_permissions(self.identity, permissions, is_ssl=is_ssl)
+            create_rmq_user_with_permissions(self.identity, permissions, ssl_auth=is_ssl)
 
-            param = build_rmq_connection_param(self.identity, self.instance_name, ssl=is_ssl)
+            param = build_rmq_connection_param(self.identity, self.instance_name, ssl_auth=is_ssl)
 
         return param
 

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -73,9 +73,10 @@ from ..rmq_connection import RMQConnection
 from ..socket import Message
 from gevent.queue import Queue
 from volttron.platform.agent.utils import load_platform_config
-from volttron.platform import certs
 from volttron.utils.rmq_mgmt import create_user_certs, \
-    build_connection_param as build_rmq_connection_param
+    build_connection_param as build_rmq_connection_param, \
+    is_ssl_connection, \
+    create_user_with_permissions as create_rmq_user_with_permissions
 
 __all__ = ['BasicCore', 'Core', 'RMQCore', 'ZMQCore', 'killing']
 
@@ -871,9 +872,13 @@ class RMQCore(BasicCore):
             read_access = "volttron|{}".format(config_access)
             write_access = "volttron|{}".format(config_access)
             permissions = dict(configure=config_access, read=read_access, write=write_access)
-            create_user_certs(self.identity, permissions)
 
-            param = build_rmq_connection_param(self.identity, self.instance_name)
+            is_ssl = is_ssl_connection()
+            if is_ssl:
+                create_user_certs(self.identity)
+            create_rmq_user_with_permissions(self.identity, permissions, is_ssl=is_ssl)
+
+            param = build_rmq_connection_param(self.identity, self.instance_name, ssl=is_ssl)
 
         return param
 

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -462,6 +462,8 @@ class ZMQCore(BasicCore):
         self.messagebus = messagebus
         self._set_keys()
 
+        _log.debug("AGENT RUNNING on ZMQ Core {}".format(self.identity))
+
         _log.debug('address: %s', address)
         _log.debug('identity: %s', identity)
         _log.debug('agent_uuid: %s', agent_uuid)
@@ -824,8 +826,10 @@ class RMQCore(BasicCore):
         _log.debug("instance:{}".format(self.instance_name))
         self._event_queue = gevent.queue.Queue
 
+        _log.debug("AGENT RUNNING on RMQ Core {}".format(self.identity))
+
         _log.debug('address: %s', address)
-        _log.debug('identity: %s', identity)
+        _log.debug('identity: %s', self.identity)
         _log.debug('agent_uuid: %s', agent_uuid)
         _log.debug('serverkey: %s', serverkey)
 
@@ -960,7 +964,7 @@ class RMQCore(BasicCore):
                     subsystem = bytes(message.subsystem)
                     # _log.debug("Received new message {0}, {1}, {2}, {3}".format(subsystem,
                     #                                                              message.id,
-                    #                                                              len(message.args),
+                    #                                                              state.ident,
                     #                                                              message.args[0]))
                     if subsystem == b'hello':
                         if (subsystem == b'hello' and

--- a/volttron/platform/vip/rmq_router.py
+++ b/volttron/platform/vip/rmq_router.py
@@ -114,12 +114,12 @@ class RMQRouter(BaseRouter):
             permissions = dict(configure=".*", read=".*", write=".*")
             # Check if RabbitMQ user and certs exists for Router, if not create a new one.
             # Add permissions if necessary
-            is_ssl = is_ssl_connection()
-            if is_ssl:
+            ssl_auth = is_ssl_connection()
+            if ssl_auth:
                 create_user_certs(self._identity)
-            create_user_with_permissions(self._identity, permissions, is_ssl=is_ssl)
-            param = build_connection_param(self._identity, self._instance_name, is_ssl)
-            if is_ssl:
+            create_user_with_permissions(self._identity, permissions, ssl_auth=ssl_auth)
+            param = build_connection_param(self._identity, self._instance_name, ssl_auth)
+            if ssl_auth:
                 _log.debug("connection param: {}".format(param.ssl_options))
         return param
 
@@ -212,6 +212,7 @@ class RMQRouter(BaseRouter):
         subsystem = message.subsystem
         self._add_peer(sender)
         if subsystem == b'hello':
+            _log.debug("RMQ Router received hello message from {}".format(message))
             self.authenticate(sender)
             # send welcome message back
             message.args = [b'welcome', b'1.0', self._identity, sender]

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -57,6 +57,7 @@
 import argparse
 import logging
 import os
+import ssl
 from socket import getfqdn
 
 import grequests
@@ -93,11 +94,11 @@ admin_password= None
 #volttron_rmq_config = os.path.join(get_home(), 'rabbitmq_config.json')
 
 
-def call_grequest(method_name, url_suffix, ssl=True, **kwargs):
+def call_grequest(method_name, url_suffix, ssl_auth=True, **kwargs):
     global crts, instance_name
-    url = get_url_prefix(ssl) + url_suffix
+    url = get_url_prefix(ssl_auth) + url_suffix
     kwargs["headers"] = {"Content-Type": "application/json"}
-    auth_args = get_authentication_args(ssl)
+    auth_args = get_authentication_args(ssl_auth)
     kwargs.update(auth_args)
     try:
         fn = getattr(grequests, method_name)
@@ -119,17 +120,17 @@ def call_grequest(method_name, url_suffix, ssl=True, **kwargs):
     return response
 
 
-def get_authentication_args(ssl):
+def get_authentication_args(ssl_auth):
     '''
     Return authentication kwargs for request/greqeust
-    :param ssl: if True returns cert and verify parameters in addition to auth
+    :param ssl_auth: if True returns cert and verify parameters in addition to auth
     :return: dictionary containing auth/cert args need to pass to
     request/grequest methods
     '''
     global local_user, local_password, admin_user, admin_password, \
         instance_name,config_opts
 
-    if ssl:
+    if ssl_auth:
         instance_ca, server_cert, client_cert = get_cert_names(instance_name)
         admin_user = get_user()
         if admin_password is None:
@@ -151,19 +152,19 @@ def get_authentication_args(ssl):
         return {'auth': (user, password)}
 
 
-def http_put_request(url_suffix, body=None, ssl=True):
+def http_put_request(url_suffix, body=None, ssl_auth=True):
     if body:
-        return call_grequest('put', url_suffix, ssl, data=jsonapi.dumps(body))
+        return call_grequest('put', url_suffix, ssl_auth, data=jsonapi.dumps(body))
     else:
-        return call_grequest('put', url_suffix, ssl)
+        return call_grequest('put', url_suffix, ssl_auth)
 
 
-def http_delete_request(url, ssl=True):
-    return call_grequest('delete',url, ssl)
+def http_delete_request(url, ssl_auth=True):
+    return call_grequest('delete',url, ssl_auth)
 
 
-def http_get_request(url, ssl=True):
-    response = call_grequest('get', url, ssl)
+def http_get_request(url, ssl_auth=True):
+    response = call_grequest('get', url, ssl_auth)
     if response and isinstance(response, list):
         response = response[0].json()
     return response
@@ -219,32 +220,32 @@ def get_password():
     return config_opts['pass']
 
 
-def create_vhost(vhost='volttron', ssl=None):
+def create_vhost(vhost='volttron', ssl_auth=None):
     """
     Create a new virtual host
     :param vhost: virtual host
     :return:
     """
     print "Creating new VIRTUAL HOST: {}".format(vhost)
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth in [True, False] else is_ssl_connection()
     url = '/api/vhosts/{vhost}'.format(vhost=vhost)
-    response = http_put_request(url, body={}, ssl=ssl)
+    response = http_put_request(url, body={}, ssl_auth=ssl_auth)
     return response
 
-def get_virtualhost(new_vhost, ssl=None):
+def get_virtualhost(new_vhost, ssl_auth=None):
     """
     Get properties for this virtual host
     :param new_vhost:
-    :param ssl: Flag indicating ssl based connection
+    :param ssl_auth: Flag indicating ssl based connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/vhosts/{vhost}'.format(vhost=new_vhost)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
-def delete_vhost(vhost, ssl=None):
+def delete_vhost(vhost, ssl_auth=None):
     """
     Delete a virtual host
     :param vhost: virtual host
@@ -252,20 +253,20 @@ def delete_vhost(vhost, ssl=None):
     :param password: password
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/vhosts/{vhost}'.format(vhost=vhost)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
-def get_virtualhosts(ssl=None):
+def get_virtualhosts(ssl_auth=None):
     """
 
-    :param ssl:
+    :param ssl_auth:
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/vhosts'
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     vhosts = []
     if response:
         vhosts = [v['name'] for v in response]
@@ -273,45 +274,45 @@ def get_virtualhosts(ssl=None):
 
 
 # USER - CREATE, GET, DELETE user, SET/GET Permissions
-def create_user(user, password=default_pass, tags="administrator", ssl=None):
+def create_user(user, password=default_pass, tags="administrator", ssl_auth=None):
     """
     Create a new RabbitMQ user
     :param user: Username
     :param password: Password
     :param tags: "adminstrator/management"
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     #print "Creating new USER: {}, ssl {}".format(user, ssl)
 
     body = dict(password=password, tags=tags)
     url = '/api/users/{user}'.format(user=user)
-    response = http_put_request(url, body, ssl)
+    response = http_put_request(url, body, ssl_auth)
 
 
-def get_users(ssl=None):
+def get_users(ssl_auth=None):
     """
     Get list of all users
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/users/'
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     users = []
     if response:
         users = [u['name'] for u in response]
     return users
 
 
-def get_url_prefix(ssl):
+def get_url_prefix(ssl_auth):
     """
     Get URL for http or https based on flag
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for ssl_auth connection
     :return:
     """
-    if ssl:
+    if ssl_auth:
         prefix = 'https://{host}:{port}'.format(host=get_hostname(),
                                                 port=get_mgmt_port())
     else:
@@ -319,269 +320,271 @@ def get_url_prefix(ssl):
     return prefix
 
 
-def get_user_props(user, ssl=None):
+def get_user_props(user, ssl_auth=None):
     """
     Get properties of the user
     :param user: username
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/users/{user}'.format(user=user)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
-def delete_user(user, ssl=None):
+def delete_user(user, ssl_auth=None):
     """
     Delete specific user
     :param user: user
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/users/{user}'.format(user=user)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
-def delete_users_in_bulk(users, ssl=None):
+def delete_users_in_bulk(users, ssl_auth=None):
     """
     Delete a list of users at once
     :param users:
-    :param ssl:
+    :param ssl_auth:
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/users/bulk-delete'
     if users and isinstance(users, list):
         body = dict(users=users)
-        response = http_put_request(url, body=body, ssl=ssl)
+        response = http_put_request(url, body=body, ssl_auth=ssl)
 
-def get_user_permissions(user, vhost=None, ssl=None):
+def get_user_permissions(user, vhost=None, ssl_auth=None):
     """
     Get permissions (configure, read, write) for the user
     :param user: user
     :param password: password
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/permissions/{vhost}/{user}'.format(vhost=vhost,
                                                    user=user)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
 # {"configure":".*","write":".*","read":".*"}
-def set_user_permissions(permissions, user, vhost=None, ssl=None):
+def set_user_permissions(permissions, user, vhost=None, ssl_auth=None):
     """
     Set permissions for the user
     :param permissions: dict containing configure, read and write settings
     :param user: username
     :param password: password
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     _log.debug("Create READ, WRITE and CONFIGURE permissions for the user: " \
           "{}".format(user))
     url = '/api/permissions/{vhost}/{user}'.format(vhost=vhost, user=user)
-    response = http_put_request(url, body=permissions, ssl=ssl)
+    response = http_put_request(url, body=permissions, ssl_auth=ssl_auth)
 
 
-def set_topic_permissions_for_user(permissions, user, vhost=None, ssl=None):
+def set_topic_permissions_for_user(permissions, user, vhost=None, ssl_auth=None):
     """
     Set read, write permissions for a topic and user
     :param permissions: dict containing exchange name and read/write permissions
     {"exchange":"volttron", read: ".*", write: "^__pubsub__"}
     :param user: username
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/topic-permissions/{vhost}/{user}'.format(vhost=vhost,
                                                          user=user)
-    response = http_put_request(url, body=permissions, ssl=ssl)
+    response = http_put_request(url, body=permissions, ssl_auth=ssl_auth)
 
 
-def get_topic_permissions_for_user(user, vhost=None, ssl=None):
+def get_topic_permissions_for_user(user, vhost=None, ssl_auth=None):
     """
     Get permissions for all topics
     :param user: user
     :param vhost:
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/topic-permissions/{vhost}/{user}'.format(vhost=vhost, user=user)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
 # GET/SET parameter on a component for example, federation-upstream
-def get_parameter(component, vhost=None, ssl=None):
+def get_parameter(component, vhost=None, ssl_auth=None):
     """
     Get component parameters, namely federation-upstream
     :param component: component name
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/parameters/{component}/{vhost}'.format(component=component,
                                                        vhost=vhost)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
 def set_parameter(component, parameter_name, parameter_properties,
-                  vhost=None, ssl=None):
+                  vhost=None, ssl_auth=None):
     """
     Set parameter on a component
     :param component: component name (for example, federation-upstream)
     :param parameter_name: parameter name
     :param parameter_properties: parameter properties
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/parameters/{component}/{vhost}/{param}'.format(
         component=component, vhost=vhost, param=parameter_name)
-    response = http_put_request(url, body=parameter_properties, ssl=ssl)
+    response = http_put_request(url, body=parameter_properties, ssl_auth=ssl_auth)
 
 
-def delete_parameter(component, parameter_name, vhost=None, ssl=None):
+def delete_parameter(component, parameter_name, vhost=None, ssl_auth=None):
     """
     Delete a component parameter
     :param component: component name
     :param parameter_name: parameter
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/parameters/{component}/{vhost}/{parameter}'.format(
         component=component, vhost=vhost, parameter=parameter_name)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
     return response
 
 
 # Get all policies, Get/Set/Delete a specific property
-def get_policies(vhost=None, ssl=None):
+def get_policies(vhost=None, ssl_auth=None):
     """
     Get all policies
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth_auth: Flag for ssl_auth connection
     :return:
     """
     # TODO: check -  this is the only request call.. others ar grequest calls
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
-    prefix = get_url_prefix(ssl)
+    prefix = get_url_prefix(ssl_auth)
 
     url = '{prefix}/api/policies/{vhost}'.format(prefix=prefix,
                                                  vhost=vhost)
-    kwargs = get_authentication_args(ssl)
+    kwargs = get_authentication_args(ssl_auth)
     response = requests.get(url, **kwargs)
     return response.json() if response else response
 
 
-def get_policy(name, vhost=None, ssl=None):
+def get_policy(name, vhost=None, ssl_auth=None):
     """
     Get a specific policy
     :param name: policy name
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
     vhost = vhost if vhost else get_vhost()
     url = '/api/policies/{vhost}/{name}'.format(vhost=vhost, name=name)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response.json() if response else response
 
 
 # value = {"pattern":"^amq.", "definition": {"federation-upstream-set":"all"}, "priority":0, "apply-to": "all"}
-def set_policy(name, value, vhost=None, ssl=None):
+def set_policy(name, value, vhost=None, ssl_auth=None):
     """
     Set a policy. For example a federation policy
     :param name: policy name
     :param value: policy value
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/policies/{vhost}/{name}'.format(vhost=vhost, name=name)
-    response = http_put_request(url, body=value, ssl=ssl)
+    response = http_put_request(url, body=value, ssl_auth=ssl_auth)
 
-def delete_policy(name, vhost=None, ssl=None):
+def delete_policy(name, vhost=None, ssl_auth=None):
     """
     Delete a policy
     :param name: policy name
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/policies/{vhost}/{name}'.format(vhost=vhost, name=name)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
 # Exchanges - Create/delete/List exchanges
 # properties = dict(durable=False, type='topic', auto_delete=True, arguments={"alternate-exchange": "aexc"})
 # properties = dict(durable=False, type='direct', auto_delete=True)
-def create_exchange(exchange, properties, vhost=None, ssl=None):
+def create_exchange(exchange, properties, vhost=None, ssl_auth=None):
     """
     Create a new exchange
     :param exchange: exchange name
     :param properties: dict containing properties
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
     vhost = vhost if vhost else get_vhost()
     _log.debug("Create new exchange: {}".format(exchange))
     url = '/api/exchanges/{vhost}/{exchange}'.format(vhost=vhost,
                                                      exchange=exchange)
-    response = http_put_request(url, body=properties, ssl=ssl)
+    response = http_put_request(url, body=properties, ssl_auth=ssl_auth)
 
 
-def delete_exchange(exchange, vhost=None, ssl=None):
+def delete_exchange(exchange, vhost=None, ssl_auth=None):
     """
     Delete a exchange
     :param exchange: exchange name
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/exchanges/{vhost}/{exchange}'.format(vhost=vhost,
                                                      exchange=exchange)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
-def get_exchanges(vhost=None, ssl=None):
+def get_exchanges(vhost=None, ssl_auth=None):
     """
     List all exchanges
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/exchanges/{vhost}'.format(vhost=vhost)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     exchanges = []
 
     if response:
@@ -589,49 +592,49 @@ def get_exchanges(vhost=None, ssl=None):
     return exchanges
 
 
-def get_exchanges_with_props(vhost=None, ssl=None):
+def get_exchanges_with_props(vhost=None, ssl_auth=None):
     """
     List all exchanges with properties
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/exchanges/{vhost}'.format(vhost=vhost)
-    return http_get_request(url, ssl)
+    return http_get_request(url, ssl_auth)
 
 
 # Queues - Create/delete/List queues
 # properties = dict(durable=False, auto_delete=True)
-def create_queue(queue, properties, vhost=None, ssl=None):
+def create_queue(queue, properties, vhost=None, ssl_auth=None):
     """
     Create a new queue
     :param queue: queue
     :param properties: dict containing properties
     :param vhost: virtual host
-    :param ssl: Flag for SSL connection
+    :param ssl_auth: Flag for SSL connection
     :return:
     """
     vhost = vhost if vhost else get_vhost()
     url = '/api/queues/{vhost}/{queue}'.format(vhost=vhost, queue=queue)
-    response = http_put_request(url, body=properties, ssl=ssl)
+    response = http_put_request(url, body=properties, ssl_auth=ssl_auth)
 
 
-def delete_queue(queue, user=None, password=None, vhost=None, ssl=None):
+def delete_queue(queue, user=None, password=None, vhost=None, ssl_auth=None):
     """
     Delete a queue
     :param queue: queue
     :param vhost: virtual host
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/queues/{vhost}/{queue}'.format(vhost=vhost, queue=queue)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
-def get_queues(user=None, password=None, vhost=None, ssl=None):
+def get_queues(user=None, password=None, vhost=None, ssl_auth=None):
     """
     Get list of queues
     :param user: username
@@ -640,7 +643,7 @@ def get_queues(user=None, password=None, vhost=None, ssl=None):
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/queues/{vhost}'.format(vhost=vhost)
     response = http_get_request(url, ssl)
@@ -650,21 +653,21 @@ def get_queues(user=None, password=None, vhost=None, ssl=None):
     return queues
 
 
-def get_queues_with_props(vhost=None, ssl=None):
+def get_queues_with_props(vhost=None, ssl_auth=None):
     """
     Get properties of all queues
     :param vhost: virtual host
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/queues/{vhost}'.format(vhost=vhost)
-    return http_get_request(url, ssl)
+    return http_get_request(url, ssl_auth)
 
 
 # List all open connections
-def get_connections(vhost=None, ssl=None):
+def get_connections(vhost=None, ssl_auth=None):
     """
     Get all connections
     :param user: username
@@ -672,74 +675,74 @@ def get_connections(vhost=None, ssl=None):
     :param vhost: virtual host
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     vhost = vhost if vhost else get_vhost()
     url = '/api/vhosts/{vhost}/connections'.format(vhost=vhost)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
-def get_connection(name, ssl=None):
+def get_connection(name, ssl_auth=None):
     """
     Get status of a connection
     :param name: connection name
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/connections/{name}'.format(name=name)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response.json() if response else response
 
 
-def delete_connection(name, ssl=None):
+def delete_connection(name, ssl_auth=None):
     """
     Delete open connection
     :param name: connection name
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/connections/{name}'.format(name=name)
-    response = http_delete_request(url, ssl)
+    response = http_delete_request(url, ssl_auth)
 
 
-def list_channels_for_connection(connection, ssl=None):
+def list_channels_for_connection(connection, ssl_auth=None):
     """
     List all open channels for a given channel
     :param connection: connnection name
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/connections/{conn}/channels'.format(conn=connection)
-    return http_get_request(url, ssl)
+    return http_get_request(url, ssl_auth)
 
 
-def list_channels_for_vhost(vhost=None, ssl=None):
+def list_channels_for_vhost(vhost=None, ssl_auth=None):
     """
     List all open channels for a given vhost
     :param vhost: virtual host
     :param ssl: Flag for SSL connection
     :return:
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/vhosts/{vhost}/channels'.format(vhost=vhost)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response.json() if response else response
 
 
-def get_bindings(exchange, ssl=None):
+def get_bindings(exchange, ssl_auth=None):
     """
     List all bindings in which a given exchange is the source
     :param exchange: source exchange
     :param ssl: Flag for SSL connection
     :return: list of bindings
     """
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     url = '/api/exchanges/{vhost}/{exchange}/bindings/source'.format(
         vhost=get_vhost(), exchange=exchange)
-    response = http_get_request(url, ssl)
+    response = http_get_request(url, ssl_auth)
     return response
 
 
@@ -758,7 +761,7 @@ def init_rabbitmq_setup():
         _load_rmq_config()
     vhost = config_opts['virtual-host']
     # Create a new "volttron" vhost
-    response = create_vhost(vhost, ssl=False)
+    response = create_vhost(vhost, ssl_auth=False)
     if not response:
         print("Remove /etc/rabbitmq/rabbitmq.conf, restart rabbitmq-server and try again")
         return response
@@ -768,14 +771,14 @@ def init_rabbitmq_setup():
     # all unroutable messages
     properties = dict(durable=True, type='topic',
                       arguments={"alternate-exchange": alternate_exchange})
-    create_exchange(exchange, properties=properties, vhost=vhost, ssl=False)
+    create_exchange(exchange, properties=properties, vhost=vhost, ssl_auth=False)
 
     # Create alternate exchange to capture all unroutable messages.
     # Note: Pubsub messages with no subscribers are also captured which is
     # unavoidable with this approach
     properties = dict(durable=True, type='fanout')
     create_exchange(alternate_exchange, properties=properties, vhost=vhost,
-                    ssl=False)
+                    ssl_auth=False)
     return True
 
 
@@ -895,7 +898,7 @@ def set_initial_rabbit_config(instance_name):
         config_opts['host'] = 'localhost'
         config_opts['amqp-port'] = '5672'
         config_opts['mgmt-port'] = '15672'
-        config_opts['rmq-address'] = build_rmq_address(ssl=False)
+        config_opts['rmq-address'] = build_rmq_address(ssl_auth=False)
         config_opts.sync()
     else:
         config_opts['user'] = "guest"
@@ -928,12 +931,12 @@ def set_initial_rabbit_config(instance_name):
                 print("Port is not valid")
         config_opts['mgmt-port'] = str(port)
 
-        config_opts['rmq-address'] = build_rmq_address(ssl=False)
+        config_opts['rmq-address'] = build_rmq_address(ssl_auth=False)
         config_opts.sync()
         #print config_opts
 
 
-def build_connection_param(identity, instance_name, ssl=None):
+def build_connection_param(identity, instance_name, ssl_auth=None):
     """
     Build Pika Connection parameters
     :param identity:
@@ -945,9 +948,10 @@ def build_connection_param(identity, instance_name, ssl=None):
     if not config_opts:
         _load_rmq_config()
 
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
+
     try:
-        if ssl:
+        if ssl_auth:
             ssl_options = dict(
                                 ssl_version=ssl.PROTOCOL_TLSv1,
                                 ca_certs=os.path.join(certs.DEFAULT_CERTS_DIR,
@@ -978,12 +982,12 @@ def build_connection_param(identity, instance_name, ssl=None):
     return conn_params
 
 
-def build_rmq_address(ssl=None):
+def build_rmq_address(ssl_auth=None):
     global config_opts
     if not config_opts:
         _load_rmq_config()
 
-    ssl = ssl if ssl else is_ssl_connection()
+    ssl_auth = ssl_auth if ssl_auth is not None else is_ssl_connection()
     user = get_user()
     pwd = get_password()
     rmq_address = None
@@ -1021,7 +1025,7 @@ def create_user_certs(identity):
         crts.create_ca_signed_cert(identity)
 
 
-def create_user_with_permissions(identity, permissions, is_ssl=None):
+def create_user_with_permissions(identity, permissions, ssl_auth=None):
     """
     Create RabbitMQ user for an agent and set permissions for it.
     :param identity: Identity of agent
@@ -1030,18 +1034,18 @@ def create_user_with_permissions(identity, permissions, is_ssl=None):
     :return:
     """
     # If user does not exist, create a new one
-    if not is_ssl:
-        is_ssl = is_ssl_connection()
-    if identity not in get_users(is_ssl):
-        create_user(identity, identity, ssl=is_ssl)
-    perms = get_user_permissions(identity, ssl=is_ssl)
+    if not ssl_auth:
+        ssl_auth = is_ssl_connection()
+    if identity not in get_users(ssl_auth):
+        create_user(identity, identity, ssl_auth=ssl_auth)
+    perms = get_user_permissions(identity, ssl_auth=ssl_auth)
     # Add user permissions if missing
     if not perms:
         perms = dict(configure=permissions['configure'],
                            read=permissions['read'],
                            write=permissions['write'])
         _log.debug("permissions: {}".format(perms))
-        set_user_permissions(perms, identity, ssl=is_ssl)
+        set_user_permissions(perms, identity, ssl_auth=ssl_auth)
 
 
 def _is_valid_rmq_url():
@@ -1159,7 +1163,7 @@ def create_shovel_setup():
         return
     platform_config = load_platform_config()
     shovels = config_opts.get('shovels', [])
-    src_uri = build_rmq_address(ssl=True)
+    src_uri = build_rmq_address(ssl_auth=True)
     for shovel in shovels:
         name = shovel['shovel_name']
         dest_uri = shovel['remote_address']
@@ -1274,7 +1278,7 @@ management.listener.ssl_opts.keyfile = {server_key}""".format(
     config_opts['pass'] = ""
     config_opts['amqp-port'] = '5671'
     config_opts['mgmt-port'] = '15671'
-    config_opts['rmq-address'] = build_rmq_address(ssl=True)
+    config_opts['rmq-address'] = build_rmq_address(ssl_auth=True)
     config_opts.sync()
 
 
@@ -1349,9 +1353,9 @@ def create_certs(client_cert_name, instance_ca_name, server_cert_name):
     # set_user_permissions(permissions, server_cert_name)
     crts.create_ca_signed_cert(client_cert_name, type='client',
                                ca_name=instance_ca_name)
-    create_user(client_cert_name, ssl=False)
+    create_user(client_cert_name, ssl_auth=False)
     permissions = dict(configure=".*", read=".*", write=".*")
-    set_user_permissions(permissions, client_cert_name, ssl=False)
+    set_user_permissions(permissions, client_cert_name, ssl_auth=False)
 
 
 def verify_and_save_instance_ca(instance_ca_path, instance_ca_key):
@@ -1378,7 +1382,7 @@ def create_rmq_volttron_test_setup(volttron_home, host='localhost'):
     global config_opts
     _load_rmq_config(volttron_home)
     #print(config_opts)
-    is_ssl = False
+    ssl_auth = False
     # Set vhost, username, password, hostname and port
     config_opts['virtual-host'] = 'volttron_test'
     config_opts['user'] = 'test_user'
@@ -1386,11 +1390,11 @@ def create_rmq_volttron_test_setup(volttron_home, host='localhost'):
     config_opts['host'] = host
     config_opts['amqp-port'] = str(5672)
     config_opts['mgmt-port'] = str(15672)
-    config_opts['ssl'] = str(is_ssl)
-    config_opts['rmq-address'] = build_rmq_address(ssl=False)
+    config_opts['ssl'] = str(ssl_auth)
+    config_opts['rmq-address'] = build_rmq_address(ssl_auth=False)
     config_opts.async_sync()
     init_rabbitmq_setup()
-    create_user_with_permissions('test_user', dict(configure=".*", read=".*", write=".*"), is_ssl=is_ssl)
+    create_user_with_permissions('test_user', dict(configure=".*", read=".*", write=".*"), ssl_auth=ssl_auth)
 
 
 def cleanup_rmq_volttron_test_setup(volttron_home):
@@ -1398,11 +1402,11 @@ def cleanup_rmq_volttron_test_setup(volttron_home):
     _load_rmq_config(volttron_home)
     try:
         vhost = config_opts.get('virtual-host', 'volttron_test')
-        users = get_users(ssl=False)
+        users = get_users(ssl_auth=False)
         users.remove('guest')
         users_to_remove = []
         for user in users:
-            perm = get_user_permissions(user, vhost, ssl=False)
+            perm = get_user_permissions(user, vhost, ssl_auth=False)
             print perm
             if perm:
                 users_to_remove.append(user)

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -169,7 +169,7 @@ def volttron_instance_module_web(request):
 # Use this fixture when you want a single instance of volttron platform for
 # test
 @pytest.fixture(scope="module",
-                params=['rmq'])
+                params=['zmq', 'rmq'])
 def volttron_instance(request):
     """Fixture that returns a single instance of volttron platform for testing
 
@@ -244,3 +244,26 @@ def get_volttron_instances(request):
     request.addfinalizer(cleanup)
 
     return get_n_volttron_instances
+
+
+# Use this fixture when you want a single instance of volttron platform for zmq message bus
+# test
+@pytest.fixture(scope="module")
+def volttron_instance_zmq(request):
+    """Fixture that returns a single instance of volttron platform for testing
+
+    @param request: pytest request object
+    @return: volttron platform instance
+    """
+    wrapper = None
+    address = get_rand_vip()
+
+    wrapper = build_wrapper(address)
+
+
+    def cleanup():
+        print('Shutting down instance: {}'.format(wrapper.volttron_home))
+        wrapper.shutdown_platform()
+
+    request.addfinalizer(cleanup)
+    return wrapper

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -49,7 +49,8 @@ def get_rand_ipc_vip():
 
 
 def build_wrapper(vip_address, **kwargs):
-    wrapper = PlatformWrapper()
+    message_bus = kwargs.pop('message_bus', None)
+    wrapper = PlatformWrapper(message_bus)
     print('BUILD_WRAPPER: {}'.format(vip_address))
     wrapper.startup_platform(vip_address=vip_address, **kwargs)
     return wrapper
@@ -65,10 +66,12 @@ def cleanup_wrappers(platforms):
     for p in platforms:
         cleanup_wrapper(p)
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=['zmq', 'rmq'])
 def volttron_instance1(request):
-    wrapper = build_wrapper(get_rand_vip())
+    print("building instance 1")
+
+    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -77,10 +80,12 @@ def volttron_instance1(request):
     return wrapper
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=['zmq', 'rmq'])
 def volttron_instance2(request):
     print("building instance 2")
-    wrapper = build_wrapper(get_rand_vip())
+
+    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -163,7 +168,8 @@ def volttron_instance_module_web(request):
 # Generic fixtures. Ideally we want to use the below instead of
 # Use this fixture when you want a single instance of volttron platform for
 # test
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=['rmq'])
 def volttron_instance(request):
     """Fixture that returns a single instance of volttron platform for testing
 
@@ -172,7 +178,8 @@ def volttron_instance(request):
     """
     wrapper = None
     address = get_rand_vip()
-    wrapper = build_wrapper(address)
+
+    wrapper = build_wrapper(address, message_bus=request.param)
 
 
     def cleanup():

--- a/volttrontesting/multiplatform/test_multiplatform_pubsub.py
+++ b/volttrontesting/multiplatform/test_multiplatform_pubsub.py
@@ -229,8 +229,6 @@ def five_platform_connection(request, get_volttron_instances):
     return agent1, agent2, agent3, agent4, agent5
 
 @pytest.mark.multiplatform
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 def test_multiplatform_pubsub(request, multi_platform_connection):
     p1_publisher, p2_listener, p3_listener = multi_platform_connection
 
@@ -272,8 +270,6 @@ def test_multiplatform_pubsub(request, multi_platform_connection):
     gevent.sleep(5)
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_2_publishers(request, five_platform_connection):
     subscription_results2 = {}
@@ -343,8 +339,6 @@ def test_multiplatform_2_publishers(request, five_platform_connection):
         assert message == [{'result': 'pass'}]
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_subscribe_unsubscribe(request, multi_platform_connection):
     subscription_results2 = {}
@@ -397,8 +391,6 @@ def test_multiplatform_subscribe_unsubscribe(request, multi_platform_connection)
     assert message == [{'point': 'value2'}]
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_stop_subscriber(request, multi_platform_connection):
     subscription_results2 = {}
@@ -451,8 +443,6 @@ def test_multiplatform_stop_subscriber(request, multi_platform_connection):
     assert message == [{'point': 'value2'}]
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_missing_address_file(request, get_volttron_instances):
     p1 = get_volttron_instances(1, address_file=False)
@@ -460,8 +450,6 @@ def test_missing_address_file(request, get_volttron_instances):
     p1.shutdown_platform()
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_without_setup_mode(request, build_instances):
     subscription_results1 = {}
@@ -516,8 +504,6 @@ def test_multiplatform_without_setup_mode(request, build_instances):
             pass
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_local_subscription(request, build_instances):
     subscription_results1 = {}
@@ -557,8 +543,6 @@ def test_multiplatform_local_subscription(request, build_instances):
             pass
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
 @pytest.mark.multiplatform
 def test_multiplatform_bad_discovery_file(request, build_instances):
     p1, p2, p3 = build_instances(3, bad_config=True)
@@ -568,8 +552,7 @@ def test_multiplatform_bad_discovery_file(request, build_instances):
     p3.shutdown_platform()
 
 
-@pytest.mark.skipif((os.environ.get("MESSAGEBUS") == "rmq"),
-                    reason="Works only in zeromq message bus")
+
 @pytest.mark.multiplatform
 def test_multiplatform_rpc(request, get_volttron_instances):
     p1, p2 = get_volttron_instances(2)

--- a/volttrontesting/platform/connection_test.py
+++ b/volttrontesting/platform/connection_test.py
@@ -24,7 +24,6 @@ def setup_control_connection(request, get_volttron_instances):
     # Connect using keys
     ks = KeyStore()
     ks.generate()
-    message_bus = os.environ.get('MESSAGE_BUS', 'zmq')
 
     control_connection = build_connection(identity="foo",
                                           address=wrapper.vip_address,
@@ -33,7 +32,7 @@ def setup_control_connection(request, get_volttron_instances):
                                           publickey=ks.public,
                                           secretkey=ks.secret,
                                           instance_name=wrapper.instance_name,
-                                          message_bus=message_bus)
+                                          message_bus=wrapper.message_bus)
 
     # Sleep a couple seconds to wait for things to startup
     gevent.sleep(2)

--- a/volttrontesting/platform/control_test.py
+++ b/volttrontesting/platform/control_test.py
@@ -69,7 +69,7 @@ def test_can_get_publickey(volttron_instance):
     """
     listener_identity = "listener_test"
     volttron_instance.is_running()
-    message_bus = os.environ.get('MESSAGE_BUS', 'zmq')
+    message_bus = os.environ.get('MESSAGEBUS', 'zmq')
 
     cn = volttron_instance.build_connection(peer='control')
     assert cn.is_peer_connected()

--- a/volttrontesting/testutils/test_single_instance.py
+++ b/volttrontesting/testutils/test_single_instance.py
@@ -2,7 +2,6 @@ import pytest
 
 from volttron.platform import get_examples
 
-
 @pytest.fixture(scope="module")
 def single_instance(request, get_volttron_instances):
     wrapper = get_volttron_instances(1, True)
@@ -37,5 +36,34 @@ def test_can_install_listeners(single_instance):
         for x in uuids:
             try:
                 single_instance.remove_agent(x)
+            except:
+                print('COULDN"T REMOVE AGENT')
+
+@pytest.mark.wrapper
+def test_can_install_listeners_vi(volttron_instance):
+    assert volttron_instance.is_running()
+    uuids = []
+    num_listeners = 5
+
+    try:
+        for x in range(num_listeners):
+            identity = "listener_" + str(x)
+            auuid = volttron_instance.install_agent(
+                agent_dir=get_examples("ListenerAgent"),
+                start=True,
+                config_file={
+                    "agentid": identity,
+                    "message": "So Happpy"})
+            assert auuid
+            uuids.append(auuid)
+
+        agent = volttron_instance.build_agent()
+        agent_list = agent.vip.rpc('control', 'list_agents').get(timeout=5)
+        print('Agent List: {}'.format(agent_list))
+        assert len(agent_list) == num_listeners
+    finally:
+        for x in uuids:
+            try:
+                volttron_instance.remove_agent(x)
             except:
                 print('COULDN"T REMOVE AGENT')

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -30,6 +30,8 @@ from volttron.platform.vip.agent.connection import Connection
 from volttrontesting.utils.utils import get_rand_http_address
 from volttrontesting.utils.utils import get_rand_tcp_address
 from volttron.platform.agent import json as jsonapi
+from volttron.utils.rmq_mgmt import create_rmq_volttron_test_setup, \
+    cleanup_rmq_volttron_test_setup
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -155,7 +157,7 @@ def start_wrapper_platform(wrapper, with_http=False, with_tcp=True,
 
 
 class PlatformWrapper:
-    def __init__(self):
+    def __init__(self, message_bus=None):
         """ Initializes a new VOLTTRON instance
 
         Creates a temporary VOLTTRON_HOME directory with a packaged directory
@@ -223,6 +225,8 @@ class PlatformWrapper:
         keystorefile = os.path.join(self.volttron_home, 'keystore')
         self.keystore = KeyStore(keystorefile)
         self.keystore.generate()
+        self.message_bus = message_bus if message_bus else 'zmq'
+
 
     def logit(self, message):
         print('{}: {}'.format(self.volttron_home, message))
@@ -267,6 +271,8 @@ class PlatformWrapper:
 
         conn = Connection(address=address, peer=peer, publickey=publickey,
                           secretkey=secretkey, serverkey=serverkey,
+                          instance_name=self.instance_name,
+                          message_bus=self.message_bus,
                           volttron_home=self.volttron_home)
 
         return conn
@@ -308,28 +314,31 @@ class PlatformWrapper:
             address = self.vip_address
 
         if publickey and not serverkey:
-            self.logit('using instance serverkey: {}'.format(self.publickey))
-            serverkey = self.publickey
-
+            self.logit('using instance serverkey: {}'.format(publickey))
+            serverkey = publickey
+        self.logit("BUILD agent VOLTTRON HOME: {}".format(self.volttron_home))
         agent = agent_class(address=address, identity=identity,
                             publickey=publickey, secretkey=secretkey,
                             serverkey=serverkey,
+                            instance_name=self.instance_name,
                             volttron_home=self.volttron_home,
+                            message_bus = self.message_bus,
                             **kwargs)
         self.logit('platformwrapper.build_agent.address: {}'.format(address))
 
         # Automatically add agent's credentials to auth.json file
         if publickey:
             self.logit('Adding publickey to auth.json')
-            gevent.spawn(self._append_allow_curve_key, publickey)
-            gevent.sleep(0.1)
+            self._append_allow_curve_key(publickey)
+            # gevent.spawn(self._append_allow_curve_key, publickey)
+            # gevent.sleep(0.1)
 
         if should_spawn:
             self.logit('platformwrapper.build_agent spawning')
             event = gevent.event.Event()
             gevent.spawn(agent.core.run, event)  # .join(0)
             event.wait(timeout=2)
-
+            gevent.sleep(0.5)
             hello = agent.vip.hello().get(timeout=.5)
             self.logit('Got hello response {}'.format(hello))
         agent.publickey = publickey
@@ -386,7 +395,7 @@ class PlatformWrapper:
                          volttron_central_serverkey=None,
                          msgdebug=False,
                          setupmode=False,
-                         instance_name=''):
+                         instance_name=None):
 
         # if not isinstance(vip_address, list):
         #     self.vip_address = [vip_address]
@@ -413,6 +422,12 @@ class PlatformWrapper:
         if not debug_mode:
             debug_mode = self.env.get('DEBUG', False)
         self.skip_cleanup = self.env.get('SKIP_CLEANUP', False)
+        if self.message_bus == 'rmq':
+            self.logit("Setting up volttron test environemnt {}".format(self.volttron_home))
+            create_rmq_volttron_test_setup(self.volttron_home)
+            if not instance_name:
+                self.instance_name = instance_name = 'volttron_test'
+
         if debug_mode:
             self.skip_cleanup = True
             enable_logging = True
@@ -471,6 +486,11 @@ class PlatformWrapper:
         if instance_name:
             parser.set('volttron', 'instance-name',
                        instance_name)
+        if self.message_bus:
+            parser.set('volttron', 'message-bus',
+                       self.message_bus)
+        self.logit(
+            "Platform will run on message bus type {} ".format(self.message_bus))
         if self.mode == UNRESTRICTED:
             with open(pconfig, 'wb') as cfg:
                 parser.write(cfg)
@@ -521,6 +541,7 @@ class PlatformWrapper:
             times += 1
             try:
                 has_control = agent.vip.peerlist().get(timeout=.2)
+                self.logit("Has control? {}".format(has_control))
             except gevent.Timeout:
                 pass
 
@@ -955,7 +976,7 @@ class PlatformWrapper:
             pid = self.agent_pid(agnt['uuid'])
             if pid is not None and int(pid) > 0:
                 running_pids.append(int(pid))
-
+        gevent.sleep(0.05)
         # First try and nicely shutdown the platform, which should clean all
         # of the agents up automatically.
         cmd = ['volttron-ctl']
@@ -997,9 +1018,12 @@ class PlatformWrapper:
                 print("######################### No Log Exists: {}".format(
                     logpath
                 ))
+        if not self.skip_cleanup and self.message_bus == 'rmq':
+            cleanup_rmq_volttron_test_setup(self.volttron_home)
         if not self.skip_cleanup:
             self.logit('Removing {}'.format(self.volttron_home))
             shutil.rmtree(self.volttron_home, ignore_errors=True)
+
         self._instance_shutdown = True
 
     def __repr__(self):


### PR DESCRIPTION
# Description
The platform should now run properly with
1. ZMQ message bus
2. RMQ message bus without authentication
3. RMQ message bus with SSL based authentication

Some of the text fixtures were updated to run existing test scripts with both ZMQ and RMQ message bus. Here's the current status.

Module                | (pass/fail/error status)
actuator               | passed
actuator_pubsub | passed
agent                   | passed
auth                     | errors
control                 | passed
config_store         | passed
forwarder             | passed
gevent                  | passed
historian               | passed
keystore               | passed
mongodb             | skipped
pa                         | passed
driver                    | passed
subsystems           | passed
web                       | passed
wrapper                | passed
vc                          | passed
vcp                        | passed
zmq                       | passed
aggregator            | failed
packaging             | passed
market                   | skipped
tagging                  | failed
multiplatform        | passed


Fixes # (issue)
1739 and 1740
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1741?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1741'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>