### PR TITLE
Rabbitmq volttron

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ python volttron/utils/rmq_setup.py single
 ```
 This command will install rabbitmq server and run it as the current user. When
 prompted provide path to an existing rabbitmq-server directory or a writeable
-directory under which rabbitmq-server would get installed.
+directory under which rabbitmq-server would get installed.Rabbitmq will be
+installed under <provided install dir>/rabbitmq_server-3.7.7 Rest of the
+documentation refers to this directory as $RABBITMQ_HOME
 
 User can choose to run with or without ssl authentication by choosing Y/N when
 prompted. Description below explains the steps when user chooses to run the
@@ -400,8 +402,9 @@ upstream servers on the downstream server and make the VOLTTRON exchange
     virtualhost of the upstream rabbitmq server.
 
         ```sh
-        sudo rabbitmqctl add_user <username> <password>
-        sudo rabbitmqctl set_permissions -p volttron <username> ".*" ".*" ".*"
+        cd $RABBITMQ_HOME
+        ./sbin/rabbitmqctl add_user <username> <password>
+        ./sbin/rabbitmqctl set_permissions -p volttron <username> ".*" ".*" ".*"
         ```
 3. Test the federation setup.
    a. On the downstream server run a listener agent which subscribes to messages

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ http://ryanstutorials.net/linuxtutorial/
   .ubuntu.com) and install them using dpkg -i command. For example,
 
   ```sh
-  sudo dpkp -i ibwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
+  sudo dpkp -i libwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
   ```
 
   Install Erlang: Grab the right package for your OS version from

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ http://ryanstutorials.net/linuxtutorial/
   .ubuntu.com) and install them using dpkg -i command. For example,
 
   ```sh
-  lsudo dbkp -i ibwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
+  sudo dpkp -i ibwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
   ```
 
   Install Erlang: Grab the right package for your OS version from

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ Distributed Control System Platform.
 |Releases 4.1| ![image](https://travis-ci.org/VOLTTRON/volttron.svg?branch=releases/4.1)|
 |develop| ![image](https://travis-ci.org/VOLTTRON/volttron.svg?branch=develop)|
 
-VOLTTRONTM is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data.
+VOLTTRONTM is an open source platform for distributed sensing and control. The
+platform provides services for collecting and storing data from buildings and
+devices and provides an environment for developing applications which interact
+with that data.
 
-# NOTE: This is an experiment branch to test and collaborate on Message Bus Refactor effort. VOLTTRON message bus now works with both ZeroMQ and RabbitMQ messaging libraries.
+# NOTE: This is an experiment branch to test and collaborate on Message Bus
+\Refactor effort. VOLTTRON message bus now works with both ZeroMQ and RabbitMQ
+\messaging libraries.
 ## Features
 
 * [Message Bus](https://volttron.readthedocs.io/en/latest/core_services/messagebus/index.html#messagebus-index) allows agents to subcribe to data sources and publish results and messages
@@ -24,7 +29,8 @@ VOLTTRONTM is an open source platform for distributed sensing and control. The p
 
 ## Background
 
-VOLTTRONTM is written in Python 2.7 and runs on Linux Operating Systems. For users unfamiliar with those technologies, the following resources are recommended:
+VOLTTRONTM is written in Python 2.7 and runs on Linux Operating Systems. For
+users unfamiliar with those technologies, the following resources are recommended:
 
 https://docs.python.org/2.7/tutorial/
 http://ryanstutorials.net/linuxtutorial/
@@ -48,36 +54,43 @@ http://ryanstutorials.net/linuxtutorial/
  ```
 
 
-**2. Install RabbitMQ**
+**2. Install Erlang version 21 packages.**
 
 
  For RabbitMQ based VOLTTRON, some of the RabbitMQ specific software packages have to be installed.
 
- **a. Install Erlang packages.**
-
-  Please refer to [rabbitmq website](https://www.rabbitmq.com/which-erlang.html) to find the right version of Erlang to be installed for the version of RabbitMQ you intend to install. Also please note, RabbitMQ does not support Erlang versions older than 19.3 and newer than 20.3.x (including 21.0)
-
   **On Debian based systems:**
+  Install pre-requisites for Erlang: libwxbase, libwxgtk, and libsctpl. Search
+  and download these packages using [Ubuntu package search](https://packages
+  .ubuntu.com) and install them using dpkg -i command. For example,
 
-  Grab the right package for your OS version from https://packages.erlang-solutions.com/erlang/#tabs-debian.
+  ```sh
+  lsudo dbkp -i ibwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
+  ```
+
+  Install Erlang: Grab the right package for your OS version from
+  https://packages.erlang-solutions.com/erlang/#tabs-debian.
   Example install commands for Ubuntu artful 64 bit is given below
  
   ```sh
-  wget http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_20.3-1~ubuntu~xenial_amd64.deb
-  sudo dpkg -i esl-erlang_20.3-1~ubuntu~artful_amd64.deb
+  wget https://packages.erlang-solutions.com/erlang/esl-erlang/FLAVOUR_1_general/esl-erlang_21.0-1~ubuntu~artful_amd64.deb
+  sudo dpkg -i esl-erlang_21.0-1~ubuntu~artful_amd64.deb
   ```
 
   **On Redhat based systems:**
 
   Easiest way to install Erlang for use with Rabbitmq is to use [Zero dependency
   Erlang RPM](https://github.com/rabbitmq/erlang-rpm). This included only the components required for RabbitMQ.
-  Copy the contents of the repo file provided into /etc/yum.repos.d/rabbitmq-erlang.repo and then run yum install erlang. You would need to do both these as root user. below is a example rabbitmq-erlang.repo file for centos 7 and erlang 20.7
+  Copy the contents of the repo file provided into /etc/yum.repos.d/rabbitmq-erlang.repo and then run yum install erlang. 
+  You would need to do both these as root user. Below is a example
+  rabbitmq-erlang.repo file for centos 7 and erlang 21.
+
   
   ```sh
 # In /etc/yum.repos.d/rabbitmq-erlang.repo
 [rabbitmq-erlang]
 name=rabbitmq-erlang
-baseurl=https://dl.bintray.com/rabbitmq/rpm/erlang/20/el/7
+baseurl=https://dl.bintray.com/rabbitmq/rpm/erlang/21/el/7
 gpgcheck=1
 gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 repo_gpgcheck=0
@@ -90,50 +103,25 @@ enabled=1
   
   
  Alternatively,
-  You can also download and install Erlang from [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html). Please include OTP/components - ssl, public_key, asn1, and crypto. Also lock version of Erlang using the [yum-plugin-versionlock](https://access.redhat.com/solutions/98873)
+  You can also download and install Erlang from [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html).
+  Please include OTP/components - ssl, public_key, asn1, and crypto.
+  Also lock version of Erlang using the [yum-plugin-versionlock](https://access.redhat.com/solutions/98873)
 
-  **b. Install RabbitMQ server package**
+**3. Configure hostname**
 
-On Debian based systems:
+Make sure that your hostname is correctly configured in /etc/hosts.
+See (https://stackoverflow.com/questions/24797947/os-x-and-rabbitmq-error-epmd-error-for-host-xxx-address-cannot-connect-to-ho)
 
-```sh
- sudo apt-get install init-system-helpers socat adduser logrotate
- wget https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.6/rabbitmq-server_3.7.6-1_all.deb
- dpkg -i rabbitmq-server_3.7.6-1_all.deb
- ```
+Hostname should be resolvable to a valid ip. Rabbitmq checks for this during
+initial boot. Without this (for example, when running on a VM in NAT mode)
+rabbitmq  start would fail with the error "unable to connect to empd (
+port 4369) on <hostname>."
 
-On Redhat based systems:
-
-Download the appropriate rpm from [rabbitmq site](https://www.rabbitmq.com/install-rpm.html) and install using  "yum install <name>.rpm" command
-```sh
-# following commands are for CentOS 7 and rabbitmq-server 3.7.4
-wget https://dl.bintray.com/rabbitmq/all/rabbitmq-server/3.7.4/rabbitmq-server-3.7.4-1.el7.noarch.rpm
-sudo yum install rabbitmq-server-3.7.4-1.el7.noarch.rpm
-```
-**b. Start rabbitmq server**
-	
-Make sure that your hostname is correctly configured in /etc/hosts. See (https://stackoverflow.com/questions/24797947/os-x-and-rabbitmq-error-epmd-error-for-host-xxx-address-cannot-connect-to-ho)
-
-Hostname should be resolvable to a valid ip. Rabbitmq checks for this during inital boot. Without this (for example, when running on a VM in NAT mode) rabbitmq  start would fail with the error "unable to connect to empd (port 4369) on <hostname>. 
-
-Note: rabbitmq startup error would show up in syslog (/var/log/messages) file and not in rabbitmq logs (/var/log/rabbitmq/rabbitmq@hostname.log)
-	
-Start rabbitmq-server
-```sh
-sudo service rabbitmq-server start
-```
+Note: rabbitmq startup error would show up in syslog (/var/log/messages) file
+and not in rabbitmq logs (/var/log/rabbitmq/rabbitmq@hostname.log)
 
 
-**c. Enable RabbitMQ management, federation, shovel and auth_mechanism_ssl plugins**
-```sh
-sudo rabbitmq-plugins enable rabbitmq_management
-sudo rabbitmq-plugins enable rabbitmq_federation
-sudo rabbitmq-plugins enable rabbitmq_federation_management
-sudo rabbitmq-plugins enable rabbitmq_shovel
-sudo rabbitmq-plugins enable rabbitmq_auth_mechanism_ssl
-```
-
-**3. Download VOLTTRON code from experimental branch**
+**4. Download VOLTTRON code from experimental branch**
 ```sh
 git clone -b rabbitmq-volttron https://github.com/VOLTTRON/volttron.git
 cd volttron
@@ -151,6 +139,9 @@ also install the dependencies for rabbimq.  Activate the environment :
 ```sh
 python volttron/utils/rmq_setup.py single
 ```
+This command will install rabbitmq server and run it as the current user. When
+prompted provide path to an existing rabbitmq-server directory or a writeable
+directory under which rabbitmq-server would get installed.
 
 User can choose to run with or without ssl authentication by choosing Y/N when
 prompted. Description below explains the steps when user chooses to run the
@@ -215,23 +206,17 @@ Creating new USER: volttron1
 
 Create READ, WRITE and CONFIGURE permissions for the user: volttron1
 
-What is the admin user name: [volttron1]:
+Created CA cert
+**Stopped rmq server
+Warning: PID file not written; -detached was passed.
+**Started rmq server
 
-Please do the following to complete setup
+#######################
+Setup complete. A new admin user was created with user name: volttron1-admin and password=default_passwd.
+You could change this user's password by logging into https://cs_cbox.pnl.gov:15671/
+#######################
 
-1. Move the rabbitmq.conf filein VOLTTRON_HOME directory into your rabbitmq
-configuration directory (/etc/rabbitmq in RPM/Debian systems)
 
-2.On production setup: Restrict access to private key files in
-VOLTTRON_HOME/certificates/ to only rabbitmq user and admin. By default private
-key files generated have read access to all.
-
-3. For custom ssl ports: Generated configuration uses default rabbitmq ssl
-   ports. Modify both rabbitmq.conf and VOLTTRON_HOME/rabbitmq_config.json if
-   using different ports.
-
-4. Restart rabbitmq-server.
-	sudo service rabbitmq-server restart
 ```
 
 Example inputs for 'python rmq_setup.py single' command for a volttron instance
@@ -268,29 +253,18 @@ Enter path to private key file for this instance CA: /home/velo/volttron1-instan
 Creating new USER: volttron1
 
 Create READ, WRITE and CONFIGURE permissions for the user: volttron1
+Created CA cert
+**Stopped rmq server
+Warning: PID file not written; -detached was passed.
+**Started rmq server
 
-What is the admin user name: [volttron1]:
-Please do the following to complete setup
-
-1. Move the rabbitmq.conf filein VOLTTRON_HOME directory into your rabbitmq
-configuration directory (/etc/rabbitmq in RPM/Debian systems)
-
-2.On production setup: Restrict access to private key files in
-VOLTTRON_HOME/certificates/ to only rabbitmq user and admin. By default private
-key files generated have read access to all.
-
-3. For custom ssl ports: Generated configuration uses default rabbitmq ssl
-   ports. Modify both rabbitmq.conf and VOLTTRON_HOME/rabbitmq_config.json if
-   using different ports.
-
-4. Restart rabbitmq-server.
-	sudo service rabbitmq-server restart
+#######################
+Setup complete. A new admin user was created with user name: volttron1-admin and password=default_passwd.
+You could change this user's password by logging into https://cs_cbox.pnl.gov:15671/
+#######################
 ```
-**5. Update RabbitMQ configuration file and restart RabbitMQ server**
-Follow the instructions provided as output of 'python rmq_setup.py single' command to create the rabbitmq.conf, change permissions for ssl private key files and restart rabbitmq-server
 
-**6. Test**
-
+**5. Test**
 
 We are now ready to start VOLTTRON with RabbitMQ message bus. If we need to revert back to ZeroMQ based VOLTTRON, we
 will have to either remove "message-bus" parameter or set it to default "zmq" in $VOLTTRON\_HOME/config.
@@ -325,8 +299,9 @@ volttron-ctl shutdown --platform
 ```
 
 ## VOLTTRON RabbitMQ control and management utility
-Some of the important native RabbitMQ control and management commands are now integrated with "volttron-ctl" utility. Using
-volttron-ctl rabbitmq management utility, we can control and monitor the status of RabbitMQ message bus.
+Some of the important native RabbitMQ control and management commands are now
+integrated with "volttron-ctl" utility. Using volttron-ctl rabbitmq management
+utility, we can control and monitor the status of RabbitMQ message bus.
 
 ```sh
 volttron-ctl rabbitmq --help
@@ -396,8 +371,7 @@ Created files:
        second volttron instance and make sure that the files have read access to
        rabbitmq user
 
-    c. Do the initial setup of Erlang, Rabbitmq, Rabbitmq plugins, and volttron
-       using the steps above
+    c. Do the initial setup of Erlang, and volttron using the steps above
 
     d. Run "python volttron/utils/rmq_setup.py single" command but when prompted
        for creation of root certificate choose N. The script will now prompt you

--- a/examples/ListenerAgent/listener/agent.py
+++ b/examples/ListenerAgent/listener/agent.py
@@ -97,7 +97,7 @@ class ListenerAgent(Agent):
             self.vip.heartbeat.start_with_period(self._heartbeat_period)
             self.vip.health.set_status(STATUS_GOOD, self._message)
 
-    @PubSub.subscribe('pubsub', '')
+    @PubSub.subscribe('pubsub', '',all_platforms=True)
     def on_match(self, peer, sender, bus,  topic, headers, message):
         """Use match_all to receive all messages and print them out."""
         if sender == 'pubsub.compat':

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ PyYAML==3.12
 cryptography==2.2.2
 service-identity==17.0.0
 git+git://github.com/shwethanidd/pika.git@gevent_connection_adapter#egg=pika
+wget

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ PyYAML==3.12
 cryptography==2.2.2
 service-identity==17.0.0
 git+git://github.com/shwethanidd/pika.git@gevent_connection_adapter#egg=pika
-wget
+wget==3.2

--- a/volttron/platform/certs.py
+++ b/volttron/platform/certs.py
@@ -558,7 +558,7 @@ class Certs(object):
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
                 encryption_algorithm=encryption
             ))
-        os.chmod(key_file, 0o644)
+        os.chmod(key_file, 0o600)
 
     def update_ca_db(self, cert, ca_name, serial):
         """

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -152,7 +152,8 @@ def _set_initial_rabbit_config(instance_name):
                    "should have write access to user")
 
     rmq_home = os.path.join(rmq_install_dir, rabbitmq_server)
-    if os.path.exists(rmq_home):
+    if os.path.exists(rmq_home) and \
+            os.path.exists(os.path.join(rmq_home, 'sbin/rabbitmq-server')):
         print("Given directory already contains {}. "
               "Skipping rabbitmq server install".format(rabbitmq_server))
         # if existing server attempt to stop
@@ -245,10 +246,13 @@ def prompt_port(config_opts, config_key, default_port, prompt):
     valid_port = False
     while not valid_port:
         port = prompt_response(prompt, default=port)
-        valid_port = is_valid_amqp_port(port)
+        if config_key == 'amqp-port':
+            valid_port = is_valid_amqp_port(port)
+        elif config_key == 'mgmt-port':
+            valid_port = is_valid_mgmt_port(port)
         if not valid_port:
             print("Port is not valid")
-    config_opts['amqp-port'] = str(port)
+    config_opts[config_key] = str(port)
 
 
 def _get_upstream_servers():

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -43,8 +43,12 @@
 import argparse
 import logging
 import os
+import subprocess
+import time
 from socket import getfqdn
 
+import gevent
+import wget
 
 from volttron.platform import certs
 from volttron.platform import get_home
@@ -71,7 +75,7 @@ local_user = "guest"
 local_password = "guest"
 admin_user = None  # User to prompt for if we go the docker route
 admin_password = None
-
+rabbitmq_server = 'rabbitmq_server-3.7.7'
 
 def _load_rmq_config(volttron_home=None):
     """
@@ -129,6 +133,54 @@ def _set_initial_rabbit_config(instance_name):
     """
     global config_opts
     _load_rmq_config()
+
+    rmq_home = config_opts.get("rmq-home")
+    default_dir = os.path.join(os.path.expanduser("~"), "rabbitmq_server")
+    if rmq_home:
+        rmq_install_dir = os.path.dirname(rmq_home)
+    else:
+        rmq_install_dir = default_dir
+    valid_dir = False
+    while not valid_dir:
+        prompt = 'Rabbitmq install directory:'
+        rmq_install_dir = prompt_response(prompt, default=rmq_install_dir)
+        if rmq_install_dir == default_dir and not os.path.exists(default_dir):
+            os.mkdir(default_dir)
+        valid_dir = os.access(rmq_install_dir, os.W_OK)
+        if not valid_dir:
+            print ("Invalid install directory. Directory should exist and "
+                   "should have write access to user")
+
+    rmq_home = os.path.join(rmq_install_dir, rabbitmq_server)
+    if os.path.exists(rmq_home):
+        print("Given directory already contains {}. "
+              "Skipping rabbitmq server install".format(rabbitmq_server))
+        # if existing server attempt to stop
+        stop_rabbit(rmq_home, quite=True)
+        # mv any existing conf file to backup
+        conf = os.path.join(rmq_home, "etc/rabbitmq/rabbitmq.conf")
+        if os.path.exists(conf):
+            os.rename(conf, os.path.join(rmq_home,
+                                         "etc/rabbitmq/rabbitmq.conf_"+
+                                         time.strftime("%Y%m%d-%H%M%S")
+                                         ))
+    else:
+        filename = wget.download(
+            "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.7/rabbitmq-server-generic-unix-3.7.7.tar.xz",
+            out=os.path.expanduser("~"))
+        print("\nDownloaded rabbbitmq server")
+        print("\nExtracting {} to {}".format(filename, rmq_install_dir))
+        cmd = ["tar",
+               "-xf",
+               filename,
+               "--directory="+rmq_install_dir]
+
+        subprocess.check_call(cmd)
+
+    config_opts['rmq-home'] = rmq_home
+
+
+
     # Get vhost
     vhost = config_opts.get('virtual-host', 'volttron')
     prompt = 'What is the name of the virtual ' \
@@ -142,51 +194,61 @@ def _set_initial_rabbit_config(instance_name):
         config_opts['ssl'] = "true"
     else:
         config_opts['ssl'] = "false"
-    prompt = prompt_response('\nUse default rabbitmq configuration ',
+    config_opts['user'] = "guest"
+    config_opts['pass'] = "guest"
+    config_opts['host'] = 'localhost'
+
+    prompt = prompt_response('\nUse default rabbitmq ports ',
                              valid_answers=y_or_n,
                              default='Y')
     if prompt in y:
-        config_opts['user'] = "guest"
-        config_opts['pass'] = "guest"
-        config_opts['host'] = 'localhost'
         config_opts['amqp-port'] = '5672'
         config_opts['mgmt-port'] = '15672'
         config_opts['rmq-address'] = build_rmq_address(ssl_auth=False,
                                                        config=config_opts)
         config_opts.sync()
     else:
-        config_opts['user'] = "guest"
-        prompt = 'What is the password for RabbitMQ default guest user?'
-        new_pass = prompt_response(prompt, default="guest")
-        config_opts['pass'] = "guest"
-
-        prompt = 'What is the hostname of system?'
-        new_host = prompt_response(prompt, default='locahost')
-        config_opts['host'] = new_host
-        # TODO - How to configure port other than 5671 for ssl - validate should
-        # check if port is not 5672.
-        port = config_opts.get('amqp-port', 5672)
         prompt = 'What is the instance port for the RabbitMQ address?'
-        valid_port = False
-        while not valid_port:
-            port = prompt_response(prompt, default=port)
-            valid_port = is_valid_amqp_port(port)
-            if not valid_port:
-                print("Port is not valid")
-        config_opts['amqp-port'] = str(port)
+        prompt_port(config_opts, 'amqp-port', 5672, prompt)
 
-        port = config_opts.get('mgmt-port', 15672)
         prompt = 'What is the instance port for the RabbitMQ management plugin?'
+        prompt_port(config_opts, 'mgmt-port', 15672, prompt)
         valid_port = False
-        while not valid_port:
-            port = prompt_response(prompt, default=port)
-            valid_port = is_valid_mgmt_port(port)
-            if not valid_port:
-                print("Port is not valid")
-        config_opts['mgmt-port'] = str(port)
 
         config_opts.sync()
-        #print config_opts
+        new_conf = """listeners.tcp.default = {}
+        management.listener.port = {}""".format(config_opts['amqp-port'],
+                                                config_opts['mgmt-port'])
+        with open(os.path.join(config_opts['rmq-home'],
+                               "etc/rabbitmq", "rabbitmq.conf"),
+                  'w+') as r_conf:
+            r_conf.write(new_conf)
+
+
+    # Start rabbitmq server
+    start_rabbit(config_opts['rmq-home'])
+
+    #enable plugins
+    cmd =[os.path.join(config_opts['rmq-home'], "sbin/rabbitmq-plugins"),
+                       "enable", "rabbitmq_management",
+                       "rabbitmq_federation",
+                       "rabbitmq_federation_management",
+                       "rabbitmq_shovel", "rabbitmq_auth_mechanism_ssl"]
+    subprocess.check_call(cmd)
+    print("**enabled plugins")
+
+
+def prompt_port(config_opts, config_key, default_port, prompt):
+    # TODO - How to configure port other than 5671 for ssl - validate should
+    # check if port is not 5672.
+    port = config_opts.get(config_key, default_port)
+    valid_port = False
+    while not valid_port:
+        port = prompt_response(prompt, default=port)
+        valid_port = is_valid_amqp_port(port)
+        if not valid_port:
+            print("Port is not valid")
+    config_opts['amqp-port'] = str(port)
 
 
 def _get_upstream_servers():
@@ -357,7 +419,6 @@ def wizard(type):
     :return:
     """
     global instance_name
-    # TODO check if rabbitmq-server is running
     # First things first. Confirm VOLTTRON_HOME
     print('\nYour VOLTTRON_HOME currently set to: {}'.format(get_home()))
     prompt = '\nIs this the volttron instance you are attempting to ' \
@@ -378,7 +439,7 @@ def wizard(type):
         _set_initial_rabbit_config(instance_name)
         # Create local RabbitMQ setup
         response = init_rabbitmq_setup() #should be called after config
-        # chanes are written to disk.
+        # changes are written to disk.
         ssl_auth = config_opts.get('ssl', "true")
         if response and ssl_auth in ('true', 'True', 'TRUE'):
             _setup_for_ssl_auth(instance_name)
@@ -455,25 +516,43 @@ management.listener.ssl_opts.keyfile = {server_key}""".format(
     config_opts['mgmt-port'] = '15671'
     config_opts.sync()
 
+    # Stop server, move new config file with ssl params, start server
+    stop_rabbit(config_opts['rmq-home'])
 
-    print("\n\n Please do the following to complete setup"
-          "\n  1. Move the rabbitmq.conf file"
-          "in VOLTTRON_HOME directory into your rabbitmq configuration "
-          "directory (/etc/rabbitmq in RPM/Debian systems) "
-          "\n  2. Optional Setps:"
-          "\n       a. On production setup: Restrict access to "
-          "private key files in VOLTTRON_HOME/certificates/private to "
-          "only rabbitmq user and admin. By default private key files "
-          "generated have read access to all."
-          "\n       b. For custom ssl ports: Generated configuration uses "
-          "default rabbitmq ssl ports. Modify both rabbitmq.conf and "
-          "VOLTTRON_HOME/rabbitmq_config.json if using different ports. "
-          "\n       c. A new admin user was created with user name: {} and "
-          "password={}. Please change this user's password by logging into "
-          "https://{}:{}/"
-          "\n  3. Restart rabbitmq-server. (sudo service rabbitmq-server "
-          "restart)".format(config_opts['user'], default_pass,
-                            config_opts['host'], config_opts['mgmt-port']))
+    os.rename(os.path.join(get_home(), "rabbitmq.conf"),
+              os.path.join(config_opts.get("rmq-home"),
+                           "etc/rabbitmq/rabbitmq.conf"))
+    start_rabbit(config_opts['rmq-home'])
+    print("\n#######################"
+          "\nSetup complete. A new admin user was created with user name: "
+          "{} and password={}.\nYou could change this user's password by "
+          "logging into https://{}:{}/"
+          "\n#######################".format(config_opts['user'],
+                                             default_pass, config_opts['host'],
+                                             config_opts['mgmt-port']))
+
+
+def stop_rabbit(rmq_home, quite=False):
+    try:
+        cmd = [os.path.join(rmq_home, "sbin/rabbitmqctl"),
+               "stop"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        gevent.sleep(2)
+        if not quite:
+            print("**Stopped rmq server")
+    except subprocess.CalledProcessError as e:
+        if not quite:
+            raise e
+
+
+def start_rabbit(rmq_home):
+    cmd = [os.path.join(rmq_home, "sbin/rabbitmq-server"),
+           "-detached"]
+    subprocess.check_call(cmd)
+    gevent.sleep(4)
+    print("**Started rmq server")
 
 
 def _create_certs(client_cert_name, instance_ca_name, server_cert_name):


### PR DESCRIPTION
Initial implementation of non sudo user install of rabbitmq server. All logic is in rmq_setup.py for now so that  Nate can test with it.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shwethanidd%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23issuecomment-411156216%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-08-07T18%3A29%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200a4a9ccfd3df94109d0def0c8c21456cf60d01a9%20README.md%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208284617%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Typo.%20It%20should%20be%20%5Cr%5Cnsudo%20dpkg%20-i%20libwxbase3.0-0v5_3.0.4%2Bdfsg-3_amd64.deb%22%2C%20%22created_at%22%3A%20%222018-08-07T15%3A47%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222018-08-07T16%3A59%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20README.md%3AL54-97%22%7D%2C%20%22Pull%200a4a9ccfd3df94109d0def0c8c21456cf60d01a9%20volttron/utils/rmq_setup.py%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208281681%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20if%20the%20directory%20exists%2C%20but%20rabbit-server%20is%20uninstalled%3F%20We%20can%20check%20the%20status%2C%20if%20it%20reports%20not%20installed%2C%20then%20try%20to%20reinstall%20again.%22%2C%20%22created_at%22%3A%20%222018-08-07T15%3A39%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20generic%20install%20there%20is%20no%20concept%20of%20install%20and%20uninstall.%20only%20unzip%20or%20delete%20the%20whole%20directory.%20%20So%20some%20one%20does%20something%20like%20unzip%20and%20removed%20the%20contents%20of%20the%20directory%20instead%20of%20the%20directory%20itself%20then%20all%20subsequent%20rabbitmq%20commands%20would%20fail.%20status%20command%20wouldn%27t%20work%20either.%20%20I%20guess%20I%20could%20check%20if%20the%20rabbitmq-server%20file%20exists%20in%20rmq_home/sbin%20but%20I%20can%27t%20think%20of%20what%20else%20to%20do.%20%22%2C%20%22created_at%22%3A%20%222018-08-07T16%3A58%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20I%20just%20did%20a%20non-sudo%20rabbitmq%20installation%20just%20now%2C%20so%20I%20get%20your%20point.%22%2C%20%22created_at%22%3A%20%222018-08-07T18%3A29%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20volttron/utils/rmq_setup.py%3AL133-187%22%7D%2C%20%22Pull%200a4a9ccfd3df94109d0def0c8c21456cf60d01a9%20requirements.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208280479%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20we%20need%20to%20provide%20a%20version%20number%20for%20wget%20as%20well.%20The%20latest%20is%203.2.%22%2C%20%22created_at%22%3A%20%222018-08-07T15%3A35%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22Its%20not%20mandatory.%20It%20grabs%20the%20latest%20and%20I%20do%20only%20the%20basic%20download%20without%20any%20additional%20parameters.%20But%20added%20it%20anyway%22%2C%20%22created_at%22%3A%20%222018-08-07T16%3A56%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20requirements.txt%3AL26-30%22%7D%2C%20%22Pull%200a4a9ccfd3df94109d0def0c8c21456cf60d01a9%20volttron/utils/rmq_setup.py%20163%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208283990%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%2C%20only%20amqp%20port%20is%20checked%2C%20what%20about%20management%20port%3F%22%2C%20%22created_at%22%3A%20%222018-08-07T15%3A45%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222018-08-07T17%3A26%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20volttron/utils/rmq_setup.py%3AL194-255%22%7D%2C%20%22Pull%200a4a9ccfd3df94109d0def0c8c21456cf60d01a9%20volttron/utils/rmq_setup.py%20166%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208284265%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20should%20be%20updated%20based%20on%20config%20key%22%2C%20%22created_at%22%3A%20%222018-08-07T15%3A46%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222018-08-07T17%3A27%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20volttron/utils/rmq_setup.py%3AL194-255%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23issuecomment-411156216%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208280479%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208281681%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208283990%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208284265%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208284617%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208307535%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208308363%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208308623%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208317138%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208317582%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1760%23discussion_r208338159%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shwethanidd'><img src='https://avatars2.githubusercontent.com/u/19616893?v=4' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 0a4a9ccfd3df94109d0def0c8c21456cf60d01a9 requirements.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1760#discussion_r208280479'>File: requirements.txt:L26-30</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> I think we need to provide a version number for wget as well. The latest is 3.2.
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> Its not mandatory. It grabs the latest and I do only the basic download without any additional parameters. But added it anyway
- [ ] <a href='#crh-comment-Pull 0a4a9ccfd3df94109d0def0c8c21456cf60d01a9 volttron/utils/rmq_setup.py 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1760#discussion_r208281681'>File: volttron/utils/rmq_setup.py:L133-187</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> What if the directory exists, but rabbit-server is uninstalled? We can check the status, if it reports not installed, then try to reinstall again.
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> In generic install there is no concept of install and uninstall. only unzip or delete the whole directory.  So some one does something like unzip and removed the contents of the directory instead of the directory itself then all subsequent rabbitmq commands would fail. status command wouldn't work either.  I guess I could check if the rabbitmq-server file exists in rmq_home/sbin but I can't think of what else to do.
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> Ok. I just did a non-sudo rabbitmq installation just now, so I get your point.
- [ ] <a href='#crh-comment-Pull 0a4a9ccfd3df94109d0def0c8c21456cf60d01a9 volttron/utils/rmq_setup.py 163'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1760#discussion_r208283990'>File: volttron/utils/rmq_setup.py:L194-255</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> Here, only amqp port is checked, what about management port?
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> Fixed
- [ ] <a href='#crh-comment-Pull 0a4a9ccfd3df94109d0def0c8c21456cf60d01a9 volttron/utils/rmq_setup.py 166'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1760#discussion_r208284265'>File: volttron/utils/rmq_setup.py:L194-255</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> It should be updated based on config key
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> fixed
- [ ] <a href='#crh-comment-Pull 0a4a9ccfd3df94109d0def0c8c21456cf60d01a9 README.md 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1760#discussion_r208284617'>File: README.md:L54-97</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> Typo. It should be
sudo dpkg -i libwxbase3.0-0v5_3.0.4+dfsg-3_amd64.deb
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> Fixed.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1760?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1760?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1760?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1760'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>