### PR TITLE
Rabbitmq volttron auth

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -188,7 +188,7 @@ def get_platform_instance_name(prompt=False):
                            "$VOLTTRON_HOME/config")
     return instance_name
 
-def create_vagent_cert(identity):
+def create_vagent_cert(rmq_user):
     """
     Create certs for agent
     :param identity: identity of agent
@@ -197,10 +197,10 @@ def create_vagent_cert(identity):
     crts = certs.Certs()
     instance_name = get_platform_instance_name()
     instance_ca, server, admin = certs.Certs.get_cert_names(instance_name)
+    _log.debug("create_vagent_cert: {}".format(rmq_user))
     # If no certs for this agent, create a new one
-    if not crts.cert_exists(identity):
-        crts.create_ca_signed_cert(identity, ca_name=instance_ca)
-
+    if not crts.cert_exists(rmq_user):
+        crts.create_ca_signed_cert(rmq_user, ca_name=instance_ca)
 
 
 def get_messagebus():

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -61,7 +61,8 @@ try:
 except ImportError:
     import json as jsonapi
 
-from .agent.utils import is_valid_identity, get_messagebus
+from .agent.utils import is_valid_identity, get_messagebus, \
+    get_platform_instance_name
 from .packages import UnpackedPackage
 from .vip.agent import Agent
 from .keystore import KeyStore
@@ -661,15 +662,17 @@ class AIPplatform(object):
         # auth only cert created is used
         msg_bus = get_messagebus()
         if msg_bus == 'rmq':
-            config_access = "{identity}|{identity}.pubsub.*|{identity}.zmq.*".format(identity=agent_vip_identity)
+            instance_name = get_platform_instance_name()
+            rmq_user = instance_name + '.' + agent_vip_identity
+            config_access = "{user}|{user}.pubsub.*|{user}.zmq.*".format(user=rmq_user)
             read_access = "volttron|{}".format(config_access)
             write_access = "volttron|{}".format(config_access)
             permissions = dict(configure=config_access, read=read_access, write=write_access)
             ssl = is_ssl_connection()
             if ssl:
                 _log.info("Created agent cert")
-                create_vagent_cert(agent_vip_identity)
-            create_rmq_user_with_permissions(agent_vip_identity, permissions)
+                create_vagent_cert(rmq_user)
+            create_rmq_user_with_permissions(rmq_user, permissions)
 
         module, _, func = module.partition(':')
         if func:

--- a/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
@@ -114,7 +114,7 @@ class RMQPubSub(BasePubSub):
                     routing_key = self._form_routing_key(prefix, all_platforms=all_platforms)
                     # If not named queue, add queue name
                     if not queue:
-                        queue = "{identity}.pubsub.{uid}".format(identity=self.core().identity, uid=bytes(uuid.uuid4()))
+                        queue = "{user}.pubsub.{uid}".format(user=self.core().rmq_user, uid=bytes(uuid.uuid4()))
                     self._add_subscription(routing_key, member, queue)
                     # _log.debug("SYNC: all_platforms {}".format(self._my_subscriptions['internal'][bus][prefix]))
 
@@ -207,7 +207,7 @@ class RMQPubSub(BasePubSub):
             durable = True
             auto_delete = False
         else:
-            queue = "{0}.pubsub.{1}".format(self.core().identity, str(uuid.uuid4()))
+            queue = "{user}.pubsub.{uid}".format(user=self.core().rmq_user, uid=str(uuid.uuid4()))
         # Store subscriptions for later use
         self._add_subscription(routing_key, callback, queue)
 

--- a/volttron/platform/vip/proxy_zmq_router.py
+++ b/volttron/platform/vip/proxy_zmq_router.py
@@ -67,8 +67,9 @@ class ZMQProxyRouter(Agent):
         super(ZMQProxyRouter, self).__init__(identity, address, **kwargs)
         self.zmq_router = zmq_router
         self._routing_key = self.core.instance_name + '.' + 'proxy'
-        self._outbound_queue = "{identity}.zmq.outbound".format(identity=identity) #'proxy_outbound'
-        self._external_pubsub_rpc_queue = "{identity}.zmq.inbound".format(identity=identity) #'proxy_inbound'
+        rmq_user = self.core.instance_name + '.' + identity
+        self._outbound_queue = "{user}.zmq.outbound".format(user=rmq_user) #'proxy_outbound'
+        self._external_pubsub_rpc_queue = "{user}.zmq.inbound".format(user=rmq_user) #'proxy_inbound'
 
     @Core.receiver('onstart')
     def startup(self, sender, **kwargs):
@@ -266,7 +267,7 @@ class ZMQProxyRouter(Agent):
         # Fit VIP frames into the PIKA properties dictionary
         # VIP format - [SENDER, RECIPIENT, PROTO, USER_ID, MSG_ID, SUBSYS, ARGS...]
         dct = {
-            'user_id': self.core.identity,
+            'user_id': self.core.instance_name + '.' + self.core.identity,
             'app_id': app_id,  # Routing key of SOURCE AGENT
             'headers': dict(sender=bytes(sender),  # SENDER
                             recipient=destination_routing_key,  # RECEIVER

--- a/volttron/platform/vip/rmq_router.py
+++ b/volttron/platform/vip/rmq_router.py
@@ -116,9 +116,10 @@ class RMQRouter(BaseRouter):
             # Check if RabbitMQ user and certs exists for Router, if not create a new one.
             # Add permissions if necessary
             ssl_auth = is_ssl_connection()
+            user = self._instance_name + '.' + self._identity
             if ssl_auth:
-                create_vagent_cert(self._identity)
-            create_user_with_permissions(self._identity, permissions, ssl_auth=ssl_auth)
+                create_vagent_cert(user)
+            create_user_with_permissions(user, permissions, ssl_auth=ssl_auth)
             param = build_connection_param(self._identity, self._instance_name, ssl_auth)
             if ssl_auth:
                 _log.debug("connection param: {}".format(param.ssl_options))

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -183,7 +183,6 @@ def _load_rmq_config(volttron_home=None):
         volttron_rmq_config = os.path.join(volttron_home, 'rabbitmq_config.yml')
         with open(volttron_rmq_config, 'r') as yaml_file:
             config_opts = yaml.load(yaml_file)
-        print config_opts
     except yaml.YAMLError as exc:
         return exc
 
@@ -841,25 +840,24 @@ def delete_multiplatform_parameter(component, parameter_name, vhost=None):
     global config_opts
     if not config_opts:
         _load_rmq_config()
-    # delete_parameter(component, parameter_name, vhost,
-    #                  ssl_auth=is_ssl_connection())
 
-    # Delete entry in config
-    try:
-        params = config_opts[component]  # component can be shovels or
-        print params
-        # federation
-        del_list = [x for x in params if parameter_name == x]
+    delete_parameter(component, parameter_name, vhost,
+                     ssl_auth=is_ssl_connection())
 
-        for elem in del_list:
-            params.pop(elem)
-        config_opts[component] = params
-        if not params:
-            del config_opts[component]
-        config_opts.async_sync()
-    except KeyError as ex:
-        print("Parameter not found: {}".format(ex))
-        return
+    # # Delete entry in config
+    # try:
+    #     params = config_opts[component]  # component can be shovels or federation
+    #     del_list = [x for x in params if parameter_name == x]
+    #
+    #     for elem in del_list:
+    #         params.pop(elem)
+    #     config_opts[component] = params
+    #     if not params:
+    #         del config_opts[component]
+    #     config_opts.async_sync()
+    # except KeyError as ex:
+    #     print("Parameter not found: {}".format(ex))
+    #     return
 
 
 def build_connection_param(identity, instance_name, ssl_auth=None):

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -95,6 +95,9 @@ def _load_rmq_config(volttron_home=None):
         volttron_rmq_config = os.path.join(volttron_home, 'rabbitmq_config.yml')
         with open(volttron_rmq_config, 'r') as yaml_file:
             config_opts = yaml.load(yaml_file)
+    except IOError as exc:
+        print "Error opening {}".format(volttron_rmq_config)
+        return exc
     except yaml.YAMLError as exc:
         return exc
 
@@ -105,7 +108,9 @@ def _check_basic_rabbit_config():
     :return:
     """
     global config_opts
-    _load_rmq_config()
+    error = _load_rmq_config()
+    if error:
+        return error
     rmq_home = config_opts.get("rmq-home")
     if not rmq_home:
         rmq_home = os.path.join(os.path.expanduser("~"), "rabbitmq_server/rabbitmq_server-3.7.7")
@@ -551,7 +556,7 @@ def setup_rabbitmq_volttron(type):
     """
     global instance_name
 
-    instance_name = get_platform_instance_name(prompt=False)
+    instance_name = get_platform_instance_name(prompt=True)
     # Store config this is checked at startup
     store_message_bus_config(message_bus='rmq', instance_name=instance_name)
 

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -63,7 +63,10 @@ from rmq_mgmt import is_ssl_connection, get_vhost, http_put_request, \
     is_valid_mgmt_port, init_rabbitmq_setup, get_ssl_url_params, create_user, \
     set_user_permissions, set_parameter
 
-#disable_warnings(exceptions.SecurityWarning)
+try:
+    import yaml
+except ImportError:
+    raise RuntimeError('PyYAML must be installed before running this script ')
 
 _log = logging.getLogger(__name__)
 
@@ -77,6 +80,7 @@ admin_user = None  # User to prompt for if we go the docker route
 admin_password = None
 rabbitmq_server = 'rabbitmq_server-3.7.7'
 
+
 def _load_rmq_config(volttron_home=None):
     """
     Load RabbitMQ config from VOLTTRON_HOME
@@ -87,389 +91,206 @@ def _load_rmq_config(volttron_home=None):
     global config_opts, volttron_rmq_config
     if not volttron_home:
         volttron_home = get_home()
-    if not os.path.exists(volttron_home):
-        os.makedirs(volttron_home)
-    volttron_rmq_config = os.path.join(volttron_home, 'rabbitmq_config.json')
-    config_opts = PersistentDict(filename=volttron_rmq_config, flag='c',
-                                 format='json')
+    try:
+        volttron_rmq_config = os.path.join(volttron_home, 'rabbitmq_config.yml')
+        with open(volttron_rmq_config, 'r') as yaml_file:
+            config_opts = yaml.load(yaml_file)
+    except yaml.YAMLError as exc:
+        return exc
 
 
-def _create_federation_setup():
+def _check_basic_rabbit_config():
     """
-    Creates a RabbitMQ federation of multiple VOLTTRON instances.
-    That means it creates upstream servers and sets "volttron" exchange to be "federated".
-
-    :return:
-    """
-    global config_opts
-    if not config_opts:
-        _load_rmq_config()
-
-    federation = config_opts['federation-upstream']
-
-    for name, address in federation.iteritems():
-
-        property = dict(vhost='volttron',
-                        component="federation-upstream",
-                        name=name,
-                        value={"uri":address})
-        set_parameter('federation-upstream', name, property,
-                      config_opts['virtual-host'])
-
-    policy_name = 'volttron-federation'
-    policy_value = {"pattern":"^volttron",
-                    "definition": {"federation-upstream-set":"all"},
-                    "priority":0,
-                    "apply-to": "exchanges"}
-    set_policy(policy_name, policy_value,
-               config_opts['virtual-host'])
-
-
-def _set_initial_rabbit_config(instance_name):
-    """
-    Build rabbitmq config for a single instance based on user input
-    :param instance_name:
+    Check if basic rabbitmq configuration is available.
     :return:
     """
     global config_opts
     _load_rmq_config()
-
     rmq_home = config_opts.get("rmq-home")
-    default_dir = os.path.join(os.path.expanduser("~"), "rabbitmq_server")
-    if rmq_home:
-        rmq_install_dir = os.path.dirname(rmq_home)
-    else:
-        rmq_install_dir = default_dir
-    valid_dir = False
-    while not valid_dir:
-        prompt = 'Rabbitmq install directory:'
-        rmq_install_dir = prompt_response(prompt, default=rmq_install_dir)
-        if rmq_install_dir == default_dir and not os.path.exists(default_dir):
-            os.mkdir(default_dir)
-        valid_dir = os.access(rmq_install_dir, os.W_OK)
-        if not valid_dir:
-            print ("Invalid install directory. Directory should exist and "
-                   "should have write access to user")
+    if not rmq_home:
+        rmq_home = os.path.join(os.path.expanduser("~"), "rabbitmq_server/rabbitmq_server-3.7.7")
+        if os.path.exists(rmq_home):
+            config_opts.setdefault("rmq-home", rmq_home)
+        else:
+            print("Missing Key in RabbitMQ config. RabbitMQ is not installed in default path: \n"
+                  "~/rabbitmq_server/rabbitmq_server-3.7.7 \n"
+                  "Set the correct RabbitMQ installation path")
+            return False
 
-    rmq_home = os.path.join(rmq_install_dir, rabbitmq_server)
+    # Check if basic configuration is available in the config file, if not set default.
+    config_opts.setdefault("host","localhost")
+    config_opts.setdefault("ssl", "true")
+    config_opts["amqp-port"] = amqp_port = 5672 # TODO - If user defined port, this needs to change
+    config_opts["mgmt-port"] = mgmt_port = 15672 # TODO - If user defined port, this needs to change
+    config_opts.setdefault("virtual-host", "volttron")
+
+    with open("{vhome}/rabbitmq_config.yml".format(vhome=get_home()), 'w') as yaml_file:
+        yaml.dump(config_opts, yaml_file, default_flow_style=False)
+
     if os.path.exists(rmq_home) and \
             os.path.exists(os.path.join(rmq_home, 'sbin/rabbitmq-server')):
-        print("Given directory already contains {}. "
-              "Skipping rabbitmq server install".format(rabbitmq_server))
         # if existing server attempt to stop
         stop_rabbit(rmq_home, quite=True)
         # mv any existing conf file to backup
         conf = os.path.join(rmq_home, "etc/rabbitmq/rabbitmq.conf")
         if os.path.exists(conf):
             os.rename(conf, os.path.join(rmq_home,
-                                         "etc/rabbitmq/rabbitmq.conf_"+
+                                         "etc/rabbitmq/rabbitmq.conf_" +
                                          time.strftime("%Y%m%d-%H%M%S")
                                          ))
-    else:
-        filename = wget.download(
-            "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.7/rabbitmq-server-generic-unix-3.7.7.tar.xz",
-            out=os.path.expanduser("~"))
-        print("\nDownloaded rabbbitmq server")
-        print("\nExtracting {} to {}".format(filename, rmq_install_dir))
-        cmd = ["tar",
-               "-xf",
-               filename,
-               "--directory="+rmq_install_dir]
 
-        subprocess.check_call(cmd)
-
-    config_opts['rmq-home'] = rmq_home
-
-
-
-    # Get vhost
-    vhost = config_opts.get('virtual-host', 'volttron')
-    prompt = 'What is the name of the virtual ' \
-             'host under which Rabbitmq VOLTTRON will be running?'
-    new_vhost = prompt_response(prompt, default=vhost)
-    config_opts['virtual-host'] = new_vhost
-    prompt = prompt_response('\nDo you want SSL Authentication',
-                             valid_answers=y_or_n,
-                             default='Y')
-    if prompt in y:
-        config_opts['ssl'] = "true"
-    else:
-        config_opts['ssl'] = "false"
-    config_opts['user'] = "guest"
-    config_opts['pass'] = "guest"
-    config_opts['host'] = 'localhost'
-
-    prompt = prompt_response('\nUse default rabbitmq ports ',
-                             valid_answers=y_or_n,
-                             default='Y')
-    if prompt in y:
-        config_opts['amqp-port'] = '5672'
-        config_opts['mgmt-port'] = '15672'
-        config_opts['rmq-address'] = build_rmq_address(ssl_auth=False,
-                                                       config=config_opts)
-        config_opts.sync()
-    else:
-        prompt = 'What is the instance port for the RabbitMQ address?'
-        prompt_port(config_opts, 'amqp-port', 5672, prompt)
-
-        prompt = 'What is the instance port for the RabbitMQ management plugin?'
-        prompt_port(config_opts, 'mgmt-port', 15672, prompt)
-        valid_port = False
-
-        config_opts.sync()
-        new_conf = """listeners.tcp.default = {}
-        management.listener.port = {}""".format(config_opts['amqp-port'],
-                                                config_opts['mgmt-port'])
+    if is_valid_amqp_port(amqp_port) and is_valid_mgmt_port(mgmt_port):
+        # If ports are valid, add them to the rabbitmq conf
+        new_conf = """listeners.tcp.default = 5672
+            management.listener.port = 15672"""
         with open(os.path.join(config_opts['rmq-home'],
                                "etc/rabbitmq", "rabbitmq.conf"),
                   'w+') as r_conf:
             r_conf.write(new_conf)
 
-
-    # Start rabbitmq server
-    start_rabbit(config_opts['rmq-home'])
-
-    #enable plugins
-    cmd =[os.path.join(config_opts['rmq-home'], "sbin/rabbitmq-plugins"),
-                       "enable", "rabbitmq_management",
-                       "rabbitmq_federation",
-                       "rabbitmq_federation_management",
-                       "rabbitmq_shovel", "rabbitmq_auth_mechanism_ssl"]
-    subprocess.check_call(cmd)
-    print("**enabled plugins")
+        # Start rabbitmq server
+        start_rabbit(config_opts['rmq-home'])
+    else:
+        return False
 
 
-def prompt_port(config_opts, config_key, default_port, prompt):
-    # TODO - How to configure port other than 5671 for ssl - validate should
-    # check if port is not 5672.
-    port = config_opts.get(config_key, default_port)
-    valid_port = False
-    while not valid_port:
-        port = prompt_response(prompt, default=port)
-        if config_key == 'amqp-port':
-            valid_port = is_valid_amqp_port(port)
-        elif config_key == 'mgmt-port':
-            valid_port = is_valid_mgmt_port(port)
-        if not valid_port:
-            print("Port is not valid")
-    config_opts[config_key] = str(port)
-
-
-def _get_upstream_servers():
+def _create_federation_setup():
     """
-    Build AMQP/S URIs for upstream servers
+    Creates a RabbitMQ federation of multiple VOLTTRON instances based on rabbitmq config.
+        - Builds AMQP/S address for each upstream server
+        - Creates upstream servers
+        - Adds policy to make "volttron" exchange "federated".
+
     :return:
     """
-    global config_opts, instance_name
+    global instance_name, config_opts
     if not config_opts:
         _load_rmq_config()
-    federation = config_opts.get('federation-upstream', dict())
-    multi_platform = True
-    ssl_params = get_ssl_url_params()
-    prompt = 'How many upstream servers do you want to configure?'
-    count = prompt_response(prompt, default=1)
-    count = int(count)
-    i = 0
-    is_ssl = is_ssl_connection()
-    for i in range(0, count):
-        prompt = 'Name of the upstream server {}: '.format(i+1)
-        default_name = 'upstream-' + str(i+1)
-        name = prompt_response(prompt, default=default_name)
-        prompt = 'Hostname of the upstream server: '
-        host = prompt_response(prompt, default='localhost')
-        prompt = 'Port of the upstream server: '
-        port = prompt_response(prompt, default=5671)
-        prompt = 'Virtual host of the upstream server: '
-        vhost = prompt_response(prompt, default='volttron')
+
+    federation = config_opts.get('federation-upstream')
+    if federation:
+        is_ssl = is_ssl_connection()
         if is_ssl:
-            address = "amqps://{host}:{port}/{vhost}?" \
-                  "{ssl_params}&server_name_indication={host}".format(
-                    host=host, port=port, vhost=vhost, ssl_params=ssl_params)
-        else:
-            address = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
-                user=instance_name, pwd=instance_name, host=host, port=port,
-                vhost=vhost)
-        federation[name] = address
-    config_opts['federation-upstream'] = federation
-    config_opts.sync()
-    return multi_platform
+            ssl_params = get_ssl_url_params()
+        try:
+            for upstreams in federation:
+                name = "upstream-{host}".format(upstreams["host"])
+                if is_ssl:
+                    address = "amqps://{host}:{port}/{vhost}?" \
+                              "{ssl_params}&server_name_indication={host}".format(
+                                host=upstreams["host"],
+                                port=upstreams["port"],
+                                vhost=upstreams["virtual-host"],
+                                ssl_params=ssl_params)
+                else:
+                    address = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
+                                user=config_opts.get("user", instance_name+"-admin"),
+                                pwd=config_opts.get("pass", default_pass),
+                                host=upstreams["host"],
+                                port=upstreams["port"],
+                                vhost=upstreams["virtual-host"])
+                prop = dict(vhost=config_opts['virtual-host'],
+                                component="federation-upstream",
+                                name=name,
+                                value={"uri":address})
+                set_parameter('federation-upstream',
+                              name,
+                              prop,
+                              config_opts['virtual-host'])
 
-
-def _get_shovel_settings():
-    """
-    Prompt user for shovel information
-    :return:
-    """
-    global config_opts
-    if not config_opts:
-        _load_rmq_config()
-
-    platform_config = load_platform_config()
-    try:
-        instance_name = platform_config['instance-name'].strip('"')
-        print(instance_name)
-    except KeyError as exc:
-        print("Unknown instance name. Please set instance-name in VOLTTRON_HOME/config")
-        return
-
-    shovels = config_opts.get('shovels', [])
-    multi_platform = False
-    prompt = prompt_response('\nDo you want a multi-platform shovel setup? ',
-                                         valid_answers=y_or_n,
-                                         default='N')
-    if prompt in y:
-        multi_platform = True
-        prompt = prompt_response('\nDo you want shovels for multi-platform RPC? ',
-                                 valid_answers=y_or_n,
-                                 default='N')
-        if prompt in y:
-            prompt = 'How many RPC shovels do you want to configure? You will need to create one for each remote platform'
-            count = prompt_response(prompt, default=1)
-            for i in range(0, int(count)):
-                name = 'shovel-rpc-{}'.format(i + 1)
-                print("Configuring RPC Shovel {}".format(i+1))
-                prompt = 'Hostname of the destination instance: '
-                host = prompt_response(prompt, default='localhost')
-                prompt = 'Port of the upstream server: '
-                port = prompt_response(prompt, default=5672)
-                prompt = 'Virtual host of the destination server: '
-                vhost = prompt_response(prompt, default='volttron')
-                prompt = 'Username of the destination server: '
-                user = prompt_response(prompt, default='volttron')
-                prompt = 'Password of the destination server: '
-                pwd = prompt_response(prompt, default='volttron')
-                prompt = 'Instance name of the destination server: '
-                platform = prompt_response(prompt, default='')
-                address = "amqp://{0}:{1}@{2}:{3}/{4}".format(user, pwd, host, port, vhost)
-                rpc_key = platform + '.*'
-                shovels.append(dict(name=name, remote_address=address, topics=rpc_key))
-
-        prompt = prompt_response('\nDo you want shovels for multi-platform PUBSUB? ',
-                                 valid_answers=y_or_n,
-                                 default='N')
-        if prompt in y:
-            prompt = 'How many remote instances do you want to publish topic? '
-            count = prompt_response(prompt, default=1)
-            for i in range(0, int(count)):
-                print("Configuring Remote instance {}".format(i + 1))
-                prompt = 'Hostname of the destination instance: '
-                host = prompt_response(prompt, default='localhost')
-                prompt = 'Port of the upstream server: '
-                port = prompt_response(prompt, default=5672)
-                prompt = 'Virtual host of the destination server: '
-                vhost = prompt_response(prompt, default='volttron')
-                prompt = 'Username of the destination server: '
-                user = prompt_response(prompt, default='volttron')
-                prompt = 'Password of the destination server: '
-                pwd = prompt_response(prompt, default='volttron')
-                address = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
-                    user=user, pwd=pwd, host=host, port=port, vhost=vhost)
-                prompt = 'List of PUBSUB topics to publish to this remote instance (comma seperated)'
-                topics = prompt_response(prompt, default="")
-                topics = topics.split(",")
-
-                for topic in topics:
-                    name = "shovel-pubsub-{0}-{1}".format(topic, i+1)
-                    pubsub_key = "__pubsub__.{0}.{1}.#".format(instance_name, topic)
-                    shovels.append(dict(name=name, remote_address=address, topics=pubsub_key))
-        config_opts['shovel'] = shovels
-        config_opts.sync()
-
-    return multi_platform
+                policy_name = 'volttron-federation'
+                policy_value = {"pattern":"^volttron",
+                                "definition":{"federation-upstream-set":"all"},
+                                "priority":0,
+                                "apply-to": "exchanges"}
+                set_policy(policy_name, policy_value, config_opts['virtual-host'])
+        except KeyError as ex:
+            print("Federation setup  did not complete. Missing Key: {}".format(ex))
+            return ex
 
 
 def _create_shovel_setup():
     """
-    Create RabbitMQ shovel based on the information provided by user
+    Create RabbitMQ shovel based on the RabbitMQ config
     :return:
     """
     global instance_name
     if not config_opts:
         _load_rmq_config()
         return
-    platform_config = load_platform_config()
     shovels = config_opts.get('shovel', [])
-    print shovels
-    src_uri = build_rmq_address(ssl_auth=False)
-    for shovel in shovels:
-        name = shovel['name']
-        dest_uri = shovel['remote_address']
-        topics = shovel['topics']
-        if not isinstance(topics, list):
-            topics = [topics]
-        for topic in topics:
-            property = dict(vhost=config_opts['virtual-host'],
-                        component="shovel",
-                        name=name,
-                        value={"src-uri": src_uri,
-                                "src-exchange":  "volttron",
-                                "src-exchange-key": topic,
-                                "dest-uri": dest_uri,
-                                "dest-exchange": "volttron"}
-                            )
-            print("shovel property: {}", property)
-            set_parameter("shovel",
-                          name,
-                          property)
+    is_ssl = is_ssl_connection()
+    src_uri = build_rmq_address(is_ssl)
+    if is_ssl:
+        ssl_params = get_ssl_url_params()
+    try:
+        for shovel in shovels:
+            # Build destination address
+            if is_ssl:
+                dest_uri = "amqps://{host}:{port}/{vhost}?" \
+                           "{ssl_params}&server_name_indication={host}".format(
+                           host=shovel["host"],
+                           port=shovel["port"],
+                           vhost=shovel["virtual-host"],
+                           ssl_params=ssl_params)
+            else:
+                dest_uri = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
+                    user=config_opts.get("user", instance_name + "-admin"),
+                    pwd=config_opts.get("pwd", default_pass),
+                    host=shovel["host"],
+                    port=shovel["port"],
+                    vhost=shovel["virtual-host"])
 
+            pubsub_topics = shovel("pubsub-topics", [])
+            agent_ids = shovels("rpc-agent-identities", [])
+            for topic in pubsub_topics:
+                name = "shovel-{host}-{topic}".format(shovel['host'],
+                                                      topic)
+                routing_key = "__pubsub__.{instance}.{topic}.#".format(instance=instance_name,
+                                                                       topic=topic)
+                prop = dict(vhost=config_opts['virtual-host'],
+                                component="shovel",
+                                name=name,
+                                value={"src-uri": src_uri,
+                                        "src-exchange":  "volttron",
+                                        "src-exchange-key": routing_key,
+                                        "dest-uri": dest_uri,
+                                        "dest-exchange": "volttron"}
+                                )
+                print("shovel property: {}", prop)
+                set_parameter("shovel",
+                              name,
+                              prop)
 
-def wizard(type):
-    """
-    Setup VOLTTRON instance to run with RabbitMQ message bus.
-    :param type:
-            single - Setup to run as single instance
-            federation - Setup to connect multiple VOLTTRON instances as a federation
-            shovel - Setup shovels to forward local messages to remote instances
-    :return:
-    """
-    global instance_name
-    # First things first. Confirm VOLTTRON_HOME
-    print('\nYour VOLTTRON_HOME currently set to: {}'.format(get_home()))
-    prompt = '\nIs this the volttron instance you are attempting to ' \
-             'configure rabbitmq for? '
-    if not prompt_response(prompt, valid_answers=y_or_n, default='Y') in y:
-        print(
-            '\nPlease execute with VOLTRON_HOME=/your/path python '
-            'volttron/utils/rmq_mgmt.py to  '
-            'modify VOLTTRON_HOME.\n')
-        return
-
-    instance_name = get_platform_instance_name(prompt=True)
-    # Store config this is checked at startup
-    store_message_bus_config(message_bus='rmq', instance_name=instance_name)
-
-    if type == 'single':
-        # Get vhost from the user
-        _set_initial_rabbit_config(instance_name)
-        # Create local RabbitMQ setup
-        response = init_rabbitmq_setup() #should be called after config
-        # changes are written to disk.
-        ssl_auth = config_opts.get('ssl', "true")
-        if response and ssl_auth in ('true', 'True', 'TRUE'):
-            _setup_for_ssl_auth(instance_name)
-    elif type == 'federation':
-        _load_rmq_config()
-        # Create a federation setup
-        federation_needed = _get_upstream_servers()
-        if federation_needed:
-            _create_federation_setup()
-    elif type == 'shovel':
-        _load_rmq_config()
-        shovel_needed = _get_shovel_settings()
-        if shovel_needed:
-            _create_shovel_setup()
-    else:
-        print "Unknown option. Exiting...."
+            for identity in agent_ids:
+                name = "shovel-{host}-{identity}".format(host=shovel['host'],
+                                                         identity=identity)
+                routing_key = "{instance}.{identity}.#".format(instance=instance_name,
+                                                               identity=identity)
+                prop = dict(vhost=config_opts['virtual-host'],
+                                component="shovel",
+                                name=name,
+                                value={"src-uri": src_uri,
+                                        "src-exchange":  "volttron",
+                                        "src-exchange-key": routing_key,
+                                        "dest-uri": dest_uri,
+                                        "dest-exchange": "volttron"}
+                                )
+                print("shovel property: {}", prop)
+                set_parameter("shovel",
+                              name,
+                              prop)
+    except KeyError as exc:
+        print("Shovel setup  did not complete. Missing Key: {}".format(exc))
 
 
 def _setup_for_ssl_auth(instance_name):
     """
     Utility method to create
     1. Root CA
-    2. instance CA
+    2. Instance CA
     3. RabbitMQ server certificates (public and private)
-    4. RabbitMQ config with SSL setting
-    5. Admin user to connect to RabbitMQ management Web interface
+    4. Admin user to connect to RabbitMQ management web interface
 
     :param instance_name: Instance name
     :return:
@@ -479,13 +300,8 @@ def _setup_for_ssl_auth(instance_name):
     instance_ca_name, server_name, admin_client_name = \
         certs.Certs.get_cert_names(instance_name)
 
-    host = config_opts.get('host', 'localhost')
-    prompt = 'What is the fully qualified domain name of the system?'
-    new_host = prompt_response(prompt, default=getfqdn())
-    config_opts['host'] = new_host
-
     # prompt for host before creating certs as it is needed for server cert
-    _create_certs(admin_client_name, instance_ca_name, server_name)
+    _create_certs_without_prompt(admin_client_name, instance_ca_name, server_name)
 
     # if all was well, create the rabbitmq.conf file for user to copy
     # /etc/rabbitmq and update VOLTTRON_HOME/rabbitmq_config.json
@@ -513,15 +329,18 @@ management.listener.ssl_opts.keyfile = {server_key}""".format(
     with open(os.path.join(get_home(), "rabbitmq.conf"), 'w') as rconf:
         rconf.write(new_conf)
 
-    # updated rabbitmq_config.json
-    config_opts['user'] = admin_client_name
-    config_opts['pass'] = ""
-    config_opts['amqp-port'] = '5671'
-    config_opts['mgmt-port'] = '15671'
-    config_opts.sync()
-
     # Stop server, move new config file with ssl params, start server
     stop_rabbit(config_opts['rmq-home'])
+
+    # Change to SSL ports
+    config_opts["amqp-port"] = amqp_port = 5671 # TODO - If user defined port, this needs to change
+    config_opts["mgmt-port"] = mgmt_port = 15671 # TODO - If user defined port, this needs to change
+    # Add VOLTTRON admin user. This is needed to connect to web interface, multi-platform federation, shovel
+    config_opts["user"] = admin_client_name
+    config_opts["pass"] = default_pass
+
+    with open("{vhome}/rabbitmq_config.yml".format(vhome=get_home()), 'w') as yaml_file:
+        yaml.dump(config_opts, yaml_file, default_flow_style=False)
 
     os.rename(os.path.join(get_home(), "rabbitmq.conf"),
               os.path.join(config_opts.get("rmq-home"),
@@ -532,11 +351,18 @@ management.listener.ssl_opts.keyfile = {server_key}""".format(
           "{} and password={}.\nYou could change this user's password by "
           "logging into https://{}:{}/"
           "\n#######################".format(config_opts['user'],
-                                             default_pass, config_opts['host'],
+                                             default_pass,
+                                             config_opts['host'],
                                              config_opts['mgmt-port']))
 
 
 def stop_rabbit(rmq_home, quite=False):
+    """
+    Stop RabbitMQ Server
+    :param rmq_home: RabbitMQ installation path
+    :param quite:
+    :return:
+    """
     try:
         cmd = [os.path.join(rmq_home, "sbin/rabbitmqctl"),
                "stop"]
@@ -552,11 +378,71 @@ def stop_rabbit(rmq_home, quite=False):
 
 
 def start_rabbit(rmq_home):
+    """
+    Start RabbitMQ server
+    :param rmq_home: RabbitMQ installation path
+    :return:
+    """
     cmd = [os.path.join(rmq_home, "sbin/rabbitmq-server"),
            "-detached"]
     subprocess.check_call(cmd)
-    gevent.sleep(4)
+    gevent.sleep(10)
     print("**Started rmq server")
+
+
+def _create_certs_without_prompt(admin_client_name, instance_ca_name, server_cert_name):
+    """
+    Utility method to create certificates
+    :param client_cert_name: client (agent) cert name
+    :param instance_ca_name: VOLTTRON instance name
+    :param server_cert_name: RabbitMQ sever name
+    :return:
+    """
+    print admin_client_name
+    global config_opts
+    create_instance_ca = False
+    instance_ca_path = config_opts.get("instance_ca_path", None)
+    instance_ca_key = config_opts.get("instance_ca_key", None)
+    # Check if insance ca public and private certs exist and valid
+    found = _verify_and_save_instance_ca(instance_ca_path, instance_ca_key)
+    if found:
+        # get instance cert name
+        filename = os.path.basename(instance_ca_path)
+        instance_ca_name = os.path.splitext(filename)[0]
+    else:
+        # create ca cert in default dir if needed
+        if crts.ca_exists():
+            print('\n Root CA Found {}'.format(crts.cert_file(ROOT_CA_NAME)))
+            create_instance_ca = True
+        else:
+            print('\n Root CA NOT Found {}'.format(crts.cert_file(ROOT_CA_NAME)))
+            create_ca(override=False)
+            create_instance_ca = True
+
+        if crts.cert_exists(instance_ca_name):
+            create_instance_ca = False
+            instance_ca_path = crts.cert_file(instance_ca_name)
+            instance_ca_key = crts.private_key_file(instance_ca_name)
+        # create instance CA (intermediate CA) if root CA exists and instance cert
+        # doesn't exist
+        if create_instance_ca:
+            crts.create_instance_ca(instance_ca_name)
+        else:
+            found = _verify_and_save_instance_ca(instance_ca_path, instance_ca_key)
+            if found:
+                # get instance cert name
+                filename = os.path.basename(instance_ca_path)
+                instance_ca_name = os.path.splitext(filename)[0]
+
+    crts.create_ca_signed_cert(server_cert_name, type='server',
+                               ca_name=instance_ca_name,
+                               fqdn=config_opts.get('host'))
+
+    crts.create_ca_signed_cert(admin_client_name, type='client',
+                               ca_name=instance_ca_name)
+    create_user(admin_client_name, ssl_auth=False)
+    permissions = dict(configure=".*", read=".*", write=".*")
+    set_user_permissions(permissions, admin_client_name, ssl_auth=False)
 
 
 def _create_certs(client_cert_name, instance_ca_name, server_cert_name):
@@ -649,15 +535,53 @@ def _verify_and_save_instance_ca(instance_ca_path, instance_ca_key):
     return found
 
 
+def setup_rabbitmq_volttron(type):
+    """
+    Setup VOLTTRON instance to run with RabbitMQ message bus.
+    :param type:
+            single - Setup to run as single instance
+            federation - Setup to connect multiple VOLTTRON instances as a federation
+            shovel - Setup shovels to forward local messages to remote instances
+    :return:
+    """
+    global instance_name
+    if type == "all" or "single":
+        instance_name = get_platform_instance_name(prompt=False)
+        # Store config this is checked at startup
+        store_message_bus_config(message_bus='rmq', instance_name=instance_name)
+        error = _check_basic_rabbit_config()
+        if not error:
+            # Create local RabbitMQ setup
+            success = init_rabbitmq_setup() # should be called after check basic config
+            # changes are written to disk.
+            ssl_auth = config_opts.get('ssl', "true")
+            if success and ssl_auth in ('true', 'True', 'TRUE'):
+                _setup_for_ssl_auth(instance_name)
+            if type == "all":
+                # Create a multi-platform federation setup
+                error = _create_federation_setup()
+                if not error:
+                    # Create shovel setup
+                    _create_shovel_setup()
+    elif type == "federation":
+        # Create a multi-platform federation setup
+        _create_federation_setup()
+    elif type == "shovel":
+        # Create shovel setup
+        _create_shovel_setup()
+    else:
+        print "Unknown option. Exiting...."
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('type',
-                        help='Instance type: single, federation or shovel')
+                        help='Instance type: all, single, federation or shovel')
     args = parser.parse_args()
     type = args.type
     try:
-        wizard(type)
+        setup_rabbitmq_volttron(type)
     except KeyboardInterrupt:
         print "Exiting setup process"
 

--- a/volttron/utils/rmq_setup_with_prompt.py
+++ b/volttron/utils/rmq_setup_with_prompt.py
@@ -1,0 +1,674 @@
+# -*- coding: utf-8 -*- {{{
+# vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
+#
+# Copyright 2017, Battelle Memorial Institute.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This material was prepared as an account of work sponsored by an agency of
+# the United States Government. Neither the United States Government nor the
+# United States Department of Energy, nor Battelle, nor any of their
+# employees, nor any jurisdiction or organization that has cooperated in the
+# development of these materials, makes any warranty, express or
+# implied, or assumes any legal liability or responsibility for the accuracy,
+# completeness, or usefulness or any information, apparatus, product,
+# software, or process disclosed, or represents that its use would not infringe
+# privately owned rights. Reference herein to any specific commercial product,
+# process, or service by trade name, trademark, manufacturer, or otherwise
+# does not necessarily constitute or imply its endorsement, recommendation, or
+# favoring by the United States Government or any agency thereof, or
+# Battelle Memorial Institute. The views and opinions of authors expressed
+# herein do not necessarily state or reflect those of the
+# United States Government or any agency thereof.
+#
+# PACIFIC NORTHWEST NATIONAL LABORATORY operated by
+# BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY
+# under Contract DE-AC05-76RL01830
+# }}}
+
+"""
+    Rabbitmq setup script to setup single instance, federation and shovel
+"""
+
+import argparse
+import logging
+import os
+import subprocess
+import time
+from socket import getfqdn
+
+import gevent
+import wget
+
+from volttron.platform import certs
+from volttron.platform import get_home
+from volttron.platform.agent.utils import load_platform_config, \
+    store_message_bus_config, get_platform_instance_name
+from volttron.platform.packaging import create_ca
+from volttron.utils.persistance import PersistentDict
+from volttron.utils.prompt import prompt_response, y, n, y_or_n
+from volttron.platform.certs import ROOT_CA_NAME
+from rmq_mgmt import is_ssl_connection, get_vhost, http_put_request, \
+    set_policy, build_rmq_address, is_valid_amqp_port, \
+    is_valid_mgmt_port, init_rabbitmq_setup, get_ssl_url_params, create_user, \
+    set_user_permissions, set_parameter
+
+#disable_warnings(exceptions.SecurityWarning)
+
+_log = logging.getLogger(__name__)
+
+config_opts = {}
+default_pass = "default_passwd"
+crts = certs.Certs()
+instance_name = None
+local_user = "guest"
+local_password = "guest"
+admin_user = None  # User to prompt for if we go the docker route
+admin_password = None
+rabbitmq_server = 'rabbitmq_server-3.7.7'
+
+def _load_rmq_config(volttron_home=None):
+    """
+    Load RabbitMQ config from VOLTTRON_HOME
+    :param volttron_home: VOLTTRON_HOME path
+    :return:
+    """
+    """Loads the config file if the path exists."""
+    global config_opts, volttron_rmq_config
+    if not volttron_home:
+        volttron_home = get_home()
+    if not os.path.exists(volttron_home):
+        os.makedirs(volttron_home)
+    volttron_rmq_config = os.path.join(volttron_home, 'rabbitmq_config.json')
+    config_opts = PersistentDict(filename=volttron_rmq_config, flag='c',
+                                 format='json')
+
+
+def _create_federation_setup():
+    """
+    Creates a RabbitMQ federation of multiple VOLTTRON instances.
+    That means it creates upstream servers and sets "volttron" exchange to be "federated".
+
+    :return:
+    """
+    global config_opts
+    if not config_opts:
+        _load_rmq_config()
+
+    federation = config_opts['federation-upstream']
+
+    for name, address in federation.iteritems():
+
+        property = dict(vhost='volttron',
+                        component="federation-upstream",
+                        name=name,
+                        value={"uri":address})
+        set_parameter('federation-upstream', name, property,
+                      config_opts['virtual-host'])
+
+    policy_name = 'volttron-federation'
+    policy_value = {"pattern":"^volttron",
+                    "definition": {"federation-upstream-set":"all"},
+                    "priority":0,
+                    "apply-to": "exchanges"}
+    set_policy(policy_name, policy_value,
+               config_opts['virtual-host'])
+
+
+def _set_initial_rabbit_config(instance_name):
+    """
+    Build rabbitmq config for a single instance based on user input
+    :param instance_name:
+    :return:
+    """
+    global config_opts
+    _load_rmq_config()
+
+    rmq_home = config_opts.get("rmq-home")
+    default_dir = os.path.join(os.path.expanduser("~"), "rabbitmq_server")
+    if rmq_home:
+        rmq_install_dir = os.path.dirname(rmq_home)
+    else:
+        rmq_install_dir = default_dir
+    valid_dir = False
+    while not valid_dir:
+        prompt = 'Rabbitmq install directory:'
+        rmq_install_dir = prompt_response(prompt, default=rmq_install_dir)
+        if rmq_install_dir == default_dir and not os.path.exists(default_dir):
+            os.mkdir(default_dir)
+        valid_dir = os.access(rmq_install_dir, os.W_OK)
+        if not valid_dir:
+            print ("Invalid install directory. Directory should exist and "
+                   "should have write access to user")
+
+    rmq_home = os.path.join(rmq_install_dir, rabbitmq_server)
+    if os.path.exists(rmq_home) and \
+            os.path.exists(os.path.join(rmq_home, 'sbin/rabbitmq-server')):
+        print("Given directory already contains {}. "
+              "Skipping rabbitmq server install".format(rabbitmq_server))
+        # if existing server attempt to stop
+        stop_rabbit(rmq_home, quite=True)
+        # mv any existing conf file to backup
+        conf = os.path.join(rmq_home, "etc/rabbitmq/rabbitmq.conf")
+        if os.path.exists(conf):
+            os.rename(conf, os.path.join(rmq_home,
+                                         "etc/rabbitmq/rabbitmq.conf_"+
+                                         time.strftime("%Y%m%d-%H%M%S")
+                                         ))
+    else:
+        filename = wget.download(
+            "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.7/rabbitmq-server-generic-unix-3.7.7.tar.xz",
+            out=os.path.expanduser("~"))
+        print("\nDownloaded rabbbitmq server")
+        print("\nExtracting {} to {}".format(filename, rmq_install_dir))
+        cmd = ["tar",
+               "-xf",
+               filename,
+               "--directory="+rmq_install_dir]
+
+        subprocess.check_call(cmd)
+
+    config_opts['rmq-home'] = rmq_home
+
+
+    # Get vhost
+    vhost = config_opts.get('virtual-host', 'volttron')
+    prompt = 'What is the name of the virtual ' \
+             'host under which Rabbitmq VOLTTRON will be running?'
+    new_vhost = prompt_response(prompt, default=vhost)
+    config_opts['virtual-host'] = new_vhost
+    prompt = prompt_response('\nDo you want SSL Authentication',
+                             valid_answers=y_or_n,
+                             default='Y')
+    if prompt in y:
+        config_opts['ssl'] = "true"
+    else:
+        config_opts['ssl'] = "false"
+    config_opts['user'] = "guest"
+    config_opts['pass'] = "guest"
+    config_opts['host'] = 'localhost'
+
+    prompt = prompt_response('\nUse default rabbitmq ports ',
+                             valid_answers=y_or_n,
+                             default='Y')
+    if prompt in y:
+        config_opts['amqp-port'] = '5672'
+        config_opts['mgmt-port'] = '15672'
+        config_opts['rmq-address'] = build_rmq_address(ssl_auth=False,
+                                                       config=config_opts)
+        config_opts.sync()
+    else:
+        prompt = 'What is the instance port for the RabbitMQ address?'
+        prompt_port(config_opts, 'amqp-port', 5672, prompt)
+
+        prompt = 'What is the instance port for the RabbitMQ management plugin?'
+        prompt_port(config_opts, 'mgmt-port', 15672, prompt)
+        valid_port = False
+
+        config_opts.sync()
+        new_conf = """listeners.tcp.default = {}
+        management.listener.port = {}""".format(config_opts['amqp-port'],
+                                                config_opts['mgmt-port'])
+        with open(os.path.join(config_opts['rmq-home'],
+                               "etc/rabbitmq", "rabbitmq.conf"),
+                  'w+') as r_conf:
+            r_conf.write(new_conf)
+
+
+    # Start rabbitmq server
+    start_rabbit(config_opts['rmq-home'])
+
+    #enable plugins
+    cmd =[os.path.join(config_opts['rmq-home'], "sbin/rabbitmq-plugins"),
+                       "enable", "rabbitmq_management",
+                       "rabbitmq_federation",
+                       "rabbitmq_federation_management",
+                       "rabbitmq_shovel",
+                       "rabbitmq_auth_mechanism_ssl"]
+    subprocess.check_call(cmd)
+    print("**enabled plugins")
+
+
+def prompt_port(config_opts, config_key, default_port, prompt):
+    # TODO - How to configure port other than 5671 for ssl - validate should
+    # check if port is not 5672.
+    port = config_opts.get(config_key, default_port)
+    valid_port = False
+    while not valid_port:
+        port = prompt_response(prompt, default=port)
+        if config_key == 'amqp-port':
+            valid_port = is_valid_amqp_port(port)
+        elif config_key == 'mgmt-port':
+            valid_port = is_valid_mgmt_port(port)
+        if not valid_port:
+            print("Port is not valid")
+    config_opts[config_key] = str(port)
+
+
+def _get_upstream_servers():
+    """
+    Build AMQP/S URIs for upstream servers
+    :return:
+    """
+    global config_opts, instance_name
+    if not config_opts:
+        _load_rmq_config()
+    federation = config_opts.get('federation-upstream', dict())
+    multi_platform = True
+    ssl_params = get_ssl_url_params()
+    prompt = 'How many upstream servers do you want to configure?'
+    count = prompt_response(prompt, default=1)
+    count = int(count)
+    i = 0
+    is_ssl = is_ssl_connection()
+    for i in range(0, count):
+        prompt = 'Name of the upstream server {}: '.format(i+1)
+        default_name = 'upstream-' + str(i+1)
+        name = prompt_response(prompt, default=default_name)
+        prompt = 'Hostname of the upstream server: '
+        host = prompt_response(prompt, default='localhost')
+        prompt = 'Port of the upstream server: '
+        port = prompt_response(prompt, default=5671)
+        prompt = 'Virtual host of the upstream server: '
+        vhost = prompt_response(prompt, default='volttron')
+        if is_ssl:
+            address = "amqps://{host}:{port}/{vhost}?" \
+                  "{ssl_params}&server_name_indication={host}".format(
+                    host=host, port=port, vhost=vhost, ssl_params=ssl_params)
+        else:
+            address = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
+                user=instance_name, pwd=instance_name, host=host, port=port,
+                vhost=vhost)
+        federation[name] = address
+    config_opts['federation-upstream'] = federation
+    config_opts.sync()
+    return multi_platform
+
+
+def _get_shovel_settings():
+    """
+    Prompt user for shovel information
+    :return:
+    """
+    global config_opts
+    if not config_opts:
+        _load_rmq_config()
+
+    platform_config = load_platform_config()
+    try:
+        instance_name = platform_config['instance-name'].strip('"')
+        print(instance_name)
+    except KeyError as exc:
+        print("Unknown instance name. Please set instance-name in VOLTTRON_HOME/config")
+        return
+
+    shovels = config_opts.get('shovels', [])
+    multi_platform = False
+    prompt = prompt_response('\nDo you want a multi-platform shovel setup? ',
+                                         valid_answers=y_or_n,
+                                         default='N')
+    if prompt in y:
+        is_ssl = is_ssl_connection()
+        multi_platform = True
+        prompt = prompt_response('\nDo you want shovels for multi-platform RPC? ',
+                                 valid_answers=y_or_n,
+                                 default='N')
+        if prompt in y:
+            prompt = 'How many RPC shovels do you want to configure? You will need to create one for each remote platform'
+            count = prompt_response(prompt, default=1)
+            for i in range(0, int(count)):
+                name = 'shovel-rpc-{}'.format(i + 1)
+                print("Configuring RPC Shovel {}".format(i+1))
+                prompt = 'Hostname of the destination instance: '
+                host = prompt_response(prompt, default='localhost')
+                prompt = 'Port of the upstream server: '
+                port = prompt_response(prompt, default=5672)
+                prompt = 'Virtual host of the destination server: '
+                vhost = prompt_response(prompt, default='volttron')
+                prompt = 'Username of the destination server: '
+                user = prompt_response(prompt, default='volttron')
+                prompt = 'Password of the destination server: '
+                pwd = prompt_response(prompt, default='volttron')
+                prompt = 'Instance name of the destination server: '
+                platform = prompt_response(prompt, default='')
+                if is_ssl:
+                    ssl_params = get_ssl_url_params()
+                    address = "amqps://{host}:{port}/{vhost}?" \
+                    "{ssl_params}&server_name_indication={host}".format(
+                        host=host, port=port, vhost=vhost, ssl_params=ssl_params)
+                else:
+                    address = "amqp://{0}:{1}@{2}:{3}/{4}".format(user, pwd, host, port, vhost)
+                rpc_key = platform + '.*'
+                shovels.append(dict(name=name, remote_address=address, topics=rpc_key))
+
+        prompt = prompt_response('\nDo you want shovels for multi-platform PUBSUB? ',
+                                 valid_answers=y_or_n,
+                                 default='N')
+        if prompt in y:
+            prompt = 'How many remote instances do you want to publish topic? '
+            count = prompt_response(prompt, default=1)
+            for i in range(0, int(count)):
+                print("Configuring Remote instance {}".format(i + 1))
+                prompt = 'Hostname of the destination instance: '
+                host = prompt_response(prompt, default='localhost')
+                prompt = 'Port of the upstream server: '
+                port = prompt_response(prompt, default=5672)
+                prompt = 'Virtual host of the destination server: '
+                vhost = prompt_response(prompt, default='volttron')
+                prompt = 'Username of the destination server: '
+                user = prompt_response(prompt, default='volttron')
+                prompt = 'Password of the destination server: '
+                pwd = prompt_response(prompt, default='volttron')
+                if is_ssl:
+                    ssl_params = get_ssl_url_params()
+                    address = "amqps://{host}:{port}/{vhost}?" \
+                              "{ssl_params}&server_name_indication={host}".format(
+                        host=host, port=port, vhost=vhost, ssl_params=ssl_params)
+                else:
+                    address = "amqp://{user}:{pwd}@{host}:{port}/{vhost}".format(
+                    user=user, pwd=pwd, host=host, port=port, vhost=vhost)
+                prompt = 'List of PUBSUB topics to publish to this remote instance (comma seperated)'
+                topics = prompt_response(prompt, default="")
+                topics = topics.split(",")
+                name = "shovel-pubsub-{host}".format(host=host)
+                subkeys = []
+                for topic in topics:
+                    subkeys.append("__pubsub__.{0}.{1}.#".format(instance_name, topic))
+                pubsub_key = "|".join(subkeys)
+                shovels.append(dict(name=name, remote_address=address, topics=pubsub_key))
+        config_opts['shovel'] = shovels
+        config_opts.sync()
+
+    return multi_platform
+
+
+def _create_shovel_setup():
+    """
+    Create RabbitMQ shovel based on the information provided by user
+    :return:
+    """
+    global instance_name
+    if not config_opts:
+        _load_rmq_config()
+        return
+    platform_config = load_platform_config()
+    shovels = config_opts.get('shovel', [])
+    print shovels
+    src_uri = build_rmq_address()
+    for shovel in shovels:
+        name = shovel['name']
+        dest_uri = shovel['remote_address']
+        pubsub_keys = shovel['topics']
+        property = dict(vhost=config_opts['virtual-host'],
+                        component="shovel",
+                        name=name,
+                        value={"src-uri": src_uri,
+                                "src-exchange":  "volttron",
+                                "src-exchange-key": pubsub_keys,
+                                "dest-uri": dest_uri,
+                                "dest-exchange": "volttron"}
+                            )
+        print("shovel property: {}", property)
+        set_parameter("shovel",
+                      name,
+                      property)
+
+
+def wizard(type):
+    """
+    Setup VOLTTRON instance to run with RabbitMQ message bus.
+    :param type:
+            single - Setup to run as single instance
+            federation - Setup to connect multiple VOLTTRON instances as a federation
+            shovel - Setup shovels to forward local messages to remote instances
+    :return:
+    """
+    global instance_name
+    # First things first. Confirm VOLTTRON_HOME
+    print('\nYour VOLTTRON_HOME currently set to: {}'.format(get_home()))
+    prompt = '\nIs this the volttron instance you are attempting to ' \
+             'configure rabbitmq for? '
+    if not prompt_response(prompt, valid_answers=y_or_n, default='Y') in y:
+        print(
+            '\nPlease execute with VOLTRON_HOME=/your/path python '
+            'volttron/utils/rmq_mgmt.py to  '
+            'modify VOLTTRON_HOME.\n')
+        return
+
+    instance_name = get_platform_instance_name(prompt=True)
+    # Store config this is checked at startup
+    store_message_bus_config(message_bus='rmq', instance_name=instance_name)
+
+    if type == 'single':
+        # Get vhost from the user
+        _set_initial_rabbit_config(instance_name)
+        # Create local RabbitMQ setup
+        response = init_rabbitmq_setup() #should be called after config
+        # changes are written to disk.
+        ssl_auth = config_opts.get('ssl', "true")
+        if response and ssl_auth in ('true', 'True', 'TRUE'):
+            _setup_for_ssl_auth(instance_name)
+    elif type == 'federation':
+        _load_rmq_config()
+        # Create a federation setup
+        federation_needed = _get_upstream_servers()
+        if federation_needed:
+            _create_federation_setup()
+    elif type == 'shovel':
+        _load_rmq_config()
+        shovel_needed = _get_shovel_settings()
+        if shovel_needed:
+            _create_shovel_setup()
+    else:
+        print "Unknown option. Exiting...."
+
+
+def _setup_for_ssl_auth(instance_name):
+    """
+    Utility method to create
+    1. Root CA
+    2. instance CA
+    3. RabbitMQ server certificates (public and private)
+    4. RabbitMQ config with SSL setting
+    5. Admin user to connect to RabbitMQ management Web interface
+
+    :param instance_name: Instance name
+    :return:
+    """
+    global config_opts
+    print('\nChecking for CA certificate\n')
+    instance_ca_name, server_name, admin_client_name = \
+        certs.Certs.get_cert_names(instance_name)
+
+    host = config_opts.get('host', 'localhost')
+    prompt = 'What is the fully qualified domain name of the system?'
+    new_host = prompt_response(prompt, default=getfqdn())
+    config_opts['host'] = new_host
+
+    # prompt for host before creating certs as it is needed for server cert
+    _create_certs(admin_client_name, instance_ca_name, server_name)
+
+    # if all was well, create the rabbitmq.conf file for user to copy
+    # /etc/rabbitmq and update VOLTTRON_HOME/rabbitmq_config.json
+    new_conf = """listeners.ssl.default = 5671
+ssl_options.cacertfile = {instance_ca}
+ssl_options.certfile = {server_cert}
+ssl_options.keyfile = {server_key}
+ssl_options.verify = verify_peer
+ssl_options.fail_if_no_peer_cert = true
+ssl_options.depth = 1
+auth_mechanisms.1 = EXTERNAL
+ssl_cert_login_from = common_name
+ssl_options.versions.1 = tlsv1.2
+ssl_options.versions.2 = tlsv1.1
+ssl_options.versions.3 = tlsv1
+management.listener.port = 15671
+management.listener.ssl = true
+management.listener.ssl_opts.cacertfile = {instance_ca}
+management.listener.ssl_opts.certfile = {server_cert}
+management.listener.ssl_opts.keyfile = {server_key}""".format(
+        instance_ca=crts.cert_file(instance_ca_name),
+        server_cert=crts.cert_file(server_name),
+        server_key=crts.private_key_file(server_name)
+    )
+    with open(os.path.join(get_home(), "rabbitmq.conf"), 'w') as rconf:
+        rconf.write(new_conf)
+
+    # updated rabbitmq_config.json
+    config_opts['user'] = admin_client_name
+    config_opts['pass'] = ""
+    config_opts['amqp-port'] = '5671'
+    config_opts['mgmt-port'] = '15671'
+    config_opts.sync()
+
+    # Stop server, move new config file with ssl params, start server
+    stop_rabbit(config_opts['rmq-home'])
+
+    os.rename(os.path.join(get_home(), "rabbitmq.conf"),
+              os.path.join(config_opts.get("rmq-home"),
+                           "etc/rabbitmq/rabbitmq.conf"))
+    start_rabbit(config_opts['rmq-home'])
+    print("\n#######################"
+          "\nSetup complete. A new admin user was created with user name: "
+          "{} and password={}.\nYou could change this user's password by "
+          "logging into https://{}:{}/"
+          "\n#######################".format(config_opts['user'],
+                                             default_pass, config_opts['host'],
+                                             config_opts['mgmt-port']))
+
+
+def stop_rabbit(rmq_home, quite=False):
+    try:
+        cmd = [os.path.join(rmq_home, "sbin/rabbitmqctl"),
+               "stop"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        gevent.sleep(2)
+        if not quite:
+            print("**Stopped rmq server")
+    except subprocess.CalledProcessError as e:
+        if not quite:
+            raise e
+
+
+def start_rabbit(rmq_home):
+    cmd = [os.path.join(rmq_home, "sbin/rabbitmq-server"),
+           "-detached"]
+    subprocess.check_call(cmd)
+    gevent.sleep(4)
+    print("**Started rmq server")
+
+
+def _create_certs(client_cert_name, instance_ca_name, server_cert_name):
+    """
+    Utility method to create certificates
+    :param client_cert_name:
+    :param instance_ca_name:
+    :param server_cert_name:
+    :return:
+    """
+    global config_opts
+    create_instance_ca = False
+    # create ca cert in default dir if needed
+    if crts.ca_exists():
+        print('\n Found {}'.format(crts.cert_file(ROOT_CA_NAME)))
+        r = prompt_response('\n Is this the root CA used to sign all volttron '
+                            'instances\' CA in this setup:',
+                            valid_answers=y_or_n, default='Y')
+        if r in y:
+            create_instance_ca = True
+    else:
+        r = prompt_response("Do you want to create a self-signed root CA "
+                            "certificate that can sign all volttron instance "
+                            "CA in your setup:", valid_answers=y_or_n,
+                            default='N')
+        if r in y:
+            create_ca(override=False)
+            create_instance_ca = True
+    instance_ca_path = None
+    instance_ca_key = None
+    if crts.cert_exists(instance_ca_name):
+        r = prompt_response(
+            '\n Found {}. Is this the instance CA signed by '
+            'volttron root CA:'.format(crts.cert_file(instance_ca_name)),
+            valid_answers=y_or_n, default='Y')
+        if r in y:
+            create_instance_ca = False
+            instance_ca_path = crts.cert_file(instance_ca_name)
+            instance_ca_key = crts.private_key_file(instance_ca_name)
+    # create instance CA (intermediate CA) if root CA exists and instance cert
+    # doesn't exist
+    if create_instance_ca:
+        crts.create_instance_ca(instance_ca_name)
+    else:
+
+        found = _verify_and_save_instance_ca(instance_ca_path, instance_ca_key)
+        while not found:
+            if instance_ca_path is not None or instance_ca_key is not None:
+                print("\nInvalid instance CA certificate or instance CA "
+                      "private key file")
+            instance_ca_path = prompt_response('\n Enter path to intermediate '
+                                               'CA certificate of this '
+                                               'volttron instance:')
+            instance_ca_key = prompt_response('\n Enter path to private key '
+                                              'file for this instance CA:')
+            found = _verify_and_save_instance_ca(instance_ca_path,
+                                                 instance_ca_key)
+            # get instance cert name
+            filename = os.path.basename(instance_ca_path)
+            instance_ca_name = os.path.splitext(filename)[0]
+    crts.create_ca_signed_cert(server_cert_name, type='server',
+                               ca_name=instance_ca_name,
+                               fqdn=config_opts.get('host'))
+    # permissions = dict(configure=".*", read=".*", write=".*")
+    # set_user_permissions(permissions, server_cert_name)
+    crts.create_ca_signed_cert(client_cert_name, type='client',
+                               ca_name=instance_ca_name)
+    create_user(client_cert_name, ssl_auth=False)
+    permissions = dict(configure=".*", read=".*", write=".*")
+    set_user_permissions(permissions, client_cert_name, ssl_auth=False)
+
+
+def _verify_and_save_instance_ca(instance_ca_path, instance_ca_key):
+    """
+    Save instance CA in VOLTTRON HOME
+    :param instance_ca_path:
+    :param instance_ca_key:
+    :return:
+    """
+    found = False
+    if instance_ca_path and os.path.exists(instance_ca_path) and \
+            instance_ca_key and os.path.exists(instance_ca_key):
+        found = True
+        # TODO: check content of file
+        # openssl crl2pkcs7 -nocrl -certfile volttron2-ca.crt | openssl pkcs7 -print_certs  -noout
+        # this should list subject, issuer of both root CA and
+        # intermediate CA
+        crts.save_cert(instance_ca_path)
+        crts.save_key(instance_ca_key)
+    return found
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('type',
+                        help='Instance type: single, federation or shovel')
+    args = parser.parse_args()
+    type = args.type
+    try:
+        wizard(type)
+    except KeyboardInterrupt:
+        print "Exiting setup process"
+


### PR DESCRIPTION
# Description
Initial configuration of VOLTTRON instance to run RabbitMQ can now be read from a yaml file. The contents of the yaml shal be something like this.

cat ~/.volttron/rabbitmq_config.yml

host: volttron-VirtualBox # Fully qualified host name
rmq-home: /home/volttron/rabbitmq_server/rabbitmq_server-3.7.7 # RabbitMQ installation path
virtual-host: volttron1 # Virtual host within which VOLTTRON instance will be running
ssl: 'true' # Flag to indicate if RabbitMQ VOLTTRON needs to run with SSL or not
# Federation upstream server configuration. 
# This should be configured in the downstream server (collector box)
federation-upstream: 
- host: rabbit-4 # Hostname of upstream server. 
  port: 5671
  virtual-host: volttron4 # Virtual host of upstream server
- host: rabbit-5
  port: 5671
  virtual-host: volttron5
- host: rabbit-6
  port: 5671
  virtual-host: volttron6
- host: rabbit-7
  port: 5671
  virtual-host: volttron7
 # Shovel configuration to forward messages from local instance to remote instance
shovel:
- host: rabbit-3 # Hostname of destination VOLTTRON instance 
  port: 5671 # Port of destination VOLTTRON instance 
  pubsub-topics: # List of topics to forward to remote instance
  - devices
  - heartbeat
  rpc-agent-identities: # List of Agent identities participating in RPC 
  - prosumer
  virtual-host: volttron3 # Virtual host of VOLTTRON instance  

