### PR TITLE
Issue #1771

### DIFF
--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -64,7 +64,7 @@ try:
 except ImportError:
     raise RuntimeError('PyYAML must be installed before running this script ')
 
-logging.basicConfig(level=logging.INFO)
+#logging.basicConfig(level=logging.INFO)
 _log = logging.getLogger(os.path.basename(__file__))
 
 


### PR DESCRIPTION
When platform was started with command 
"volttron -vv -l l1.log&" 
Info and debug statements were getting redirected to stdout. Logging level was set to info in rmq_setup.py which was getting called from instance_setup.py which was causing the problem
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1775?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1775'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>