### PR TITLE
Fix historian tests

### DIFF
--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -74,7 +74,7 @@ def do_publish(agent1):
     agent1.vip.pubsub.publish(
         'pubsub', DEVICES_ALL_TOPIC, headers, all_message).get(timeout=10)
     publishedmessages.append(all_message)
-    gevent.sleep(1)
+    gevent.sleep(1.5)
 
 
 def onmessage(peer, sender, bus, topic, headers, message):
@@ -107,7 +107,7 @@ def test_reconnect_forwarder(get_volttron_instances):
     print('Before Subscribing')
     receiver.vip.pubsub.subscribe('pubsub', '', callback=onmessage)
     publisher.vip.pubsub.publish('pubsub', 'stuff', message='Fuzzy')
-    gevent.sleep(.2)
+    gevent.sleep(3)
 
     num_messages = 5
     for i in range(num_messages):

--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -114,4 +114,7 @@ def test_reconnect_forwarder(get_volttron_instances):
         do_publish(publisher)
 
     for i in range(len(publishedmessages)):
-        assert allforwardedmessage[i] == publishedmessages[i]
+        # We need to compensate for float differences through the bus.
+        forwarded = "{{0:{0}f}}".format(allforwardedmessage[i])
+        published = "{{0:{0}f}}".format(publishedmessages[i])
+        assert forwarded[:8] == published[:8]

--- a/services/core/VolttronCentral/tests/test_vc.py
+++ b/services/core/VolttronCentral/tests/test_vc.py
@@ -2,6 +2,8 @@ import pytest
 
 from volttron.platform.web import DiscoveryInfo
 
+import gevent
+
 
 def validate_instances(wrapper1, wrapper2):
     assert wrapper1.bind_web_address
@@ -42,6 +44,7 @@ def test_publickey_retrieval(vc_instance, pa_instance):
     """
     vc_wrapper, vc_uuid, jsonrpc = vc_instance
     pa_wrapper, pa_uuid = pa_instance
+    gevent.sleep(1)
 
     vc_info = DiscoveryInfo.request_discovery_info(
         vc_wrapper.bind_web_address)


### PR DESCRIPTION
# Description

Differences in floats through the message bus depending upon the underlying operating system/python versions are causing comparison issues
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1776?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1776'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>