### PR TITLE
Updates master driver/base historian to include synchronized timestamp

### DIFF
--- a/docs/source/core_services/historians/Historian-Topic-Syntax.rst
+++ b/docs/source/core_services/historians/Historian-Topic-Syntax.rst
@@ -54,10 +54,14 @@ topics with pattern "devices/*/all"):
         # python code to get this is
         # from datetime import datetime
         # from volttron.platform.messaging import headers as header_mod
+        # from volttron.platform.agent import utils
+        # now = utils.format_timestamp( datetime.utcnow())
         # {
-        #     headers_mod.DATE: datetime.utcnow().isoformat() + 'Z'
+        #     headers_mod.DATE: now,
+        #     headers_mod.TIMESTAMP: now
         # }
-        "Date": "2015-11-17T21:24:10.189393Z"
+        "Date": "2015-11-17 21:24:10.189393+00:00",
+        "TimeStamp": "2015-11-17 21:24:10.189393+00:00"
     }
 
     # Message Format:

--- a/examples/ExampleDrivenControlAgent/example/drivenagent.py
+++ b/examples/ExampleDrivenControlAgent/example/drivenagent.py
@@ -148,9 +148,11 @@ def DrivenAgent(config_path, **kwargs):
                                 f.close()
             # publish to message bus.
             if len(results.table_output.keys()) > 0:
+                now = utils.format_timestamp(self.received_input_datetime)
                 headers = {
                     headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.JSON,
-                    headers_mod.DATE: str(self.received_input_datetime),
+                    headers_mod.DATE: now,
+                    headers_mod.TIMESTAMP: now
                 }
 
                 for _, v in results.table_output.items():

--- a/examples/ExampleSubscriber/subscriber/subscriber_agent.py
+++ b/examples/ExampleSubscriber/subscriber/subscriber_agent.py
@@ -195,9 +195,10 @@ def subscriber_agent(config_path, **kwargs):
             damper_message = [damper_reading,{'units': '%', 'tz': 'UTC', 'type': 'float'}]
             
             #Create timestamp
-            now = datetime.utcnow().isoformat(' ') + 'Z'
+            now = utils.format_timestamp(datetime.utcnow())
             headers = {
-                headers_mod.DATE: now
+                headers_mod.DATE: now,
+                headers_mod.TIMESTAMP: now
             }
             
             #Publish messages

--- a/examples/NodeRed/node_red_publisher.py
+++ b/examples/NodeRed/node_red_publisher.py
@@ -30,10 +30,11 @@ if  __name__ == '__main__':
             sys.stdout = os.fdopen(stdout.fileno(), 'w', 1)
 
         agent = Agent(identity='NodeRedPublisher', **agent_kwargs)
-        now = datetime.utcnow().isoformat(' ') + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         headers = {
             headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.PLAIN_TEXT,
             headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         event = gevent.event.Event()
         task = gevent.spawn(agent.core.run, event)

--- a/examples/NodeRed/node_red_subscriber.py
+++ b/examples/NodeRed/node_red_subscriber.py
@@ -29,10 +29,11 @@ class NodeRedSubscriber(Agent):
     # Demonstrate periodic decorator and settings access
     @Core.periodic(heartbeat_period)
     def publish_heartbeat(self):
-        now = datetime.utcnow().isoformat(' ') + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         headers = {
             headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.PLAIN_TEXT,
             headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         result = self.vip.pubsub.publish('pubsub', 'heartbeat/NodeRedSubscriber', headers, now)
         result.get(timeout=10)

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -82,11 +82,12 @@ class StandAloneListener(Agent):
         heartbeat_period is set and can be adjusted in the settings module.
         '''
         sys.stdout.write('publishing heartbeat.\n')
-        now = datetime.utcnow().isoformat(' ') + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         headers = {
             #'AgentID': self._agent_id,
             headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.PLAIN_TEXT,
             headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         self.vip.pubsub.publish(
             'pubsub', 'heartbeat/standalonelistener', headers,

--- a/services/contrib/WeatherAgent/weather/agent.py
+++ b/services/contrib/WeatherAgent/weather/agent.py
@@ -171,10 +171,11 @@ class WeatherAgent(Agent):
             _log.info("Connection timed out!")
 
     def publish_weather_report(self, topic_name, parsed_weather_data):
-        now = datetime.utcnow().isoformat(' ') + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         headers = {
             headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.PLAIN_TEXT,
             headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         self.vip.pubsub.publish('pubsub', topic_name, headers, json.dumps(parsed_weather_data))
 

--- a/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_pubsub.py
@@ -1370,8 +1370,9 @@ def test_get_value_success(publish_agent, cancel_schedules):
     publish_agent.vip.pubsub.publish('pubsub',
                                      get_topic,
                                      headers=header).get(timeout=10)
+    gevent.sleep(0.5)
     print("call args list", publish_agent.callback.call_args_list)
-    assert publish_agent.callback.call_count == 1
+    assert publish_agent.callback.call_count == 2
     print('call args ', publish_agent.callback.call_args[0])
     assert publish_agent.callback.call_args[0][1] == PLATFORM_ACTUATOR
     assert publish_agent.callback.call_args[0][3] == value_topic

--- a/services/core/DataMover/tests/test_datamover.py
+++ b/services/core/DataMover/tests/test_datamover.py
@@ -44,7 +44,7 @@ import gevent
 import pytest
 
 from volttron.platform import get_services_core
-from volttron.platform.agent import PublishMixin
+from volttron.platform.agent import PublishMixin, utils
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.messaging import topics
 from volttron.platform.vip.agent import Agent
@@ -199,9 +199,10 @@ def test_devices_topic(publish_agent, query_agent):
                    {'OutsideAirTemperature': float_meta}]
 
     # Publish messages twice
-    time1 = datetime.utcnow().isoformat(' ')
+    time1 = utils.format_timestamp(datetime.utcnow())
     headers = {
-        headers_mod.DATE: time1
+        headers_mod.DATE: time1,
+        headers_mod.TIMESTAMP: time1
     }
     publish(publish_agent, 'devices/PNNL/BUILDING_1/Device/all', headers, all_message)
     gevent.sleep(3)
@@ -217,7 +218,7 @@ def test_devices_topic(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
 
     assert (len(result['values']) == 1)
-    (time1_date, time1_time) = time1.split(" ")
+    (time1_date, time1_time) = time1.split("T")
     assert (result['values'][0][0] == time1_date + 'T' + time1_time + '+00:00')
     assert (result['values'][0][1] == oat_reading)
     assert set(result['metadata'].items()) == set(float_meta.items())
@@ -242,28 +243,29 @@ def test_record_topic(publish_agent, query_agent):
     """
     # Create timestamp
     print("\n** test_record_topic **")
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = utils.format_timestamp(datetime.utcnow())
     print("now is ", now)
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     # Publish messages
     publish(publish_agent, topics.RECORD, headers, 1)
 
     # sleep so that records gets inserted with unique timestamp
     gevent.sleep(0.5)
-    time2 = datetime.utcnow()
-    time2 = time2.isoformat()
+    time2 = utils.format_timestamp(datetime.utcnow())
     headers = {
-        headers_mod.DATE: time2
+        headers_mod.DATE: time2,
+        headers_mod.TIMESTAMP: time2
     }
     publish(publish_agent, topics.RECORD, headers, 'value0')
     # sleep so that records gets inserted with unique timestamp
     gevent.sleep(0.5)
-    time3 = datetime.utcnow()
-    time3 = time3.isoformat()
+    time3 = utils.format_timestamp(datetime.utcnow())
     headers = {
-        headers_mod.DATE: time3
+        headers_mod.DATE: time3,
+        headers_mod.TIMESTAMP: time3
     }
     publish(publish_agent, topics.RECORD, headers, {'key': 'value'})
     gevent.sleep(0.5)
@@ -364,10 +366,11 @@ def test_analysis_topic(publish_agent, query_agent):
                     }]
 
     # Create timestamp
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = utils.format_timestamp(datetime.utcnow())
     print("now is ", now)
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     # Publish messages
     publish(publish_agent, 'analysis/PNNL/BUILDING_1/Device',
@@ -494,11 +497,12 @@ def test_log_topic(publish_agent, query_agent):
                                        'type': 'float'}}
     # pytest.set_trace()
     # Create timestamp
-    current_time = datetime.utcnow().isoformat() + 'Z'
+    current_time = utils.format_timestamp(datetime.utcnow())
     print("current_time is ", current_time)
     future_time = '2017-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: future_time
+        headers_mod.DATE: future_time,
+        headers_mod.TIMESTAMP: future_time
     }
     print("time in header is ", future_time)
 

--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -7,7 +7,7 @@ import gevent
 import pytest
 
 from volttron.platform import get_services_core
-from volttron.platform.agent import json as jsonapi
+from volttron.platform.agent import json as jsonapi, utils
 
 from volttron.platform.messaging import headers as headers_mod
 
@@ -61,11 +61,12 @@ def do_publish(agent1):
                     }]
 
     # Create timestamp
-    now = datetime.utcnow().isoformat(' ')
+    now = utils.format_timestamp(datetime.utcnow())
 
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     print("Published time in header: " + now)
 

--- a/services/core/ForwardHistorian/tests/test_forwardhistorian.py
+++ b/services/core/ForwardHistorian/tests/test_forwardhistorian.py
@@ -44,7 +44,7 @@ import gevent
 import pytest
 
 from volttron.platform import get_services_core
-from volttron.platform.agent import PublishMixin
+from volttron.platform.agent import PublishMixin, utils
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.messaging import topics
 from volttron.platform.vip.agent import Agent
@@ -196,7 +196,7 @@ def test_devices_topic(publish_agent, query_agent):
                    {'OutsideAirTemperature': float_meta}]
 
     # Publish messages twice
-    time1 = datetime.utcnow().isoformat(' ')
+    time1 = utils.format_timestamp(datetime.utcnow())
     headers = {
         headers_mod.DATE: time1
     }
@@ -214,7 +214,7 @@ def test_devices_topic(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
 
     assert (len(result['values']) == 1)
-    (time1_date, time1_time) = time1.split(" ")
+    (time1_date, time1_time) = time1.split("T")
     assert (result['values'][0][0] == time1_date + 'T' + time1_time + '+00:00')
     assert (result['values'][0][1] == oat_reading)
     assert set(result['metadata'].items()) == set(float_meta.items())
@@ -260,10 +260,11 @@ def test_analysis_topic(publish_agent, query_agent):
                     }]
 
     # Create timestamp
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = utils.format_timestamp(datetime.utcnow())
     print("now is ", now)
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     # Publish messages
     publish(publish_agent, 'analysis/PNNL/BUILDING_1/Device',
@@ -388,11 +389,12 @@ def test_log_topic(publish_agent, query_agent):
                                        'type': 'float'}}
     # pytest.set_trace()
     # Create timestamp
-    current_time = datetime.utcnow().isoformat() + 'Z'
+    current_time = utils.format_timestamp(datetime.utcnow())
     print("current_time is ", current_time)
     future_time = '2017-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: future_time
+        headers_mod.DATE: future_time,
+        headers_mod.TIMESTAMP: future_time
     }
     print("time in header is ", future_time)
 
@@ -603,9 +605,10 @@ def test_nan_value(publish_agent, query_agent):
                    {'nan_value': float_meta}]
 
     # Publish messages twice
-    time1 = datetime.utcnow().isoformat(' ')
+    time1 = utils.format_timestamp(datetime.utcnow())
     headers = {
-        headers_mod.DATE: time1
+        headers_mod.DATE: time1,
+        headers_mod.TIMESTAMP: time1
     }
     publish(publish_agent, 'devices/PNNL/BUILDING_1/Device/all', headers, all_message)
     gevent.sleep(1)
@@ -621,7 +624,7 @@ def test_nan_value(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
 
     assert (len(result['values']) == 1)
-    (time1_date, time1_time) = time1.split(" ")
+    (time1_date, time1_time) = time1.split("T")
     assert (result['values'][0][0] == time1_date + 'T' + time1_time + '+00:00')
     assert (math.isnan(result['values'][0][1]))
     assert set(result['metadata'].items()) == set(float_meta.items())

--- a/services/core/InfluxdbHistorian/tests/test_influxdb_historian.py
+++ b/services/core/InfluxdbHistorian/tests/test_influxdb_historian.py
@@ -170,7 +170,10 @@ def publish_some_fake_data(publish_agent, data_count, value_type='float'):
             }]
 
         timestamp_iso = format_timestamp(timestamp)
-        headers = {headers_mod.DATE: timestamp_iso}
+        headers = {
+            headers_mod.DATE: timestamp_iso,
+            headers_mod.TIMESTAMP: timestamp_iso
+        }
 
         # Publish messages
         publish_agent.vip.pubsub.publish(
@@ -238,7 +241,10 @@ def publish_data_with_updated_meta(publish_agent):
         }]
 
     timestamp_iso = format_timestamp(now)
-    headers = {headers_mod.DATE: timestamp_iso}
+    headers = {
+        headers_mod.DATE: timestamp_iso,
+        headers_mod.TIMESTAMP: timestamp_iso
+    }
 
     # Publish messages
     publish_agent.vip.pubsub.publish(
@@ -284,7 +290,10 @@ def publish_data_with_updated_topic_case(publish_agent, data_count):
             }]
 
         timestamp_iso = format_timestamp(now)
-        headers = {headers_mod.DATE: timestamp_iso}
+        headers = {
+            headers_mod.DATE: timestamp_iso,
+            headers_mod.TIMESTAMP: timestamp_iso
+        }
 
         # Publish messages
         publish_agent.vip.pubsub.publish(

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -256,10 +256,12 @@ class DriverAgent(BasicAgent):
 
         utcnow = utils.get_aware_utc_now()
         utcnow_string = utils.format_timestamp(utcnow)
+        sync_timestamp = utils.format_timestamp(now - datetime.timedelta(seconds=self.time_slot_offset))
 
         headers = {
             headers_mod.DATE: utcnow_string,
             headers_mod.TIMESTAMP: utcnow_string,
+            headers_mod.SYNC_TIMESTAMP: sync_timestamp
         }
 
 

--- a/services/core/MasterDriverAgent/master_driver/interfaces/chargepoint/tests/TestAgent/tester/agent.py
+++ b/services/core/MasterDriverAgent/master_driver/interfaces/chargepoint/tests/TestAgent/tester/agent.py
@@ -104,9 +104,13 @@ class TestAgent(Agent):
             result = self.get_chargepoint_point('Status')
             # result = self.get_chargepoint_point('stationRightsProfile')
 
+            now = utils.format_timestamp(datetime.datetime.now())
             # Also publish a test pub/sub message just for kicks.
             result = self.publish_message('test_topic/test_subtopic',
-                                          {headers_mod.DATE: datetime.datetime.now().isoformat()},
+                                          {
+                                              headers_mod.DATE: now,
+                                              headers_mod.TIMESTAMP: now
+                                          },
                                           [{'property_1': 1, 'property_2': 2}, {'property_3': 3, 'property_4': 4}])
 
             counter = 0

--- a/services/core/MongodbHistorian/tests/test_mongohistorian.py
+++ b/services/core/MongodbHistorian/tests/test_mongohistorian.py
@@ -264,7 +264,10 @@ def publish_minute_data_for_two_hours(agent):
                 "damper_point": damper_reading}
 
             # now = '2015-12-02T00:00:00'
-            headers = {headers_mod.DATE: now_iso_string}
+            headers = {
+                headers_mod.DATE: now_iso_string,
+                headers_mod.TIMESTAMP: now_iso_string
+            }
 
             # Publish messages
             agent.vip.pubsub.publish(
@@ -330,7 +333,10 @@ def publish_fake_data(agent, now=None, value=None):
     print('NOW IS: ', now)
 
     # now = '2015-12-02T00:00:00'
-    headers = {headers_mod.DATE: now.isoformat()}
+    headers = {
+        headers_mod.DATE: format_timestamp(now),
+        headers_mod.TIMESTAMP: format_timestamp(now)
+    }
 
     # Publish messages
     agent.vip.pubsub.publish('pubsub', ALL_TOPIC, headers, all_message).get(
@@ -378,7 +384,10 @@ def test_insert_duplicate(volttron_instance, database_client):
         print('NOW IS: ', now)
 
         # now = '2015-12-02T00:00:00'
-        headers = {headers_mod.DATE: now.isoformat()}
+        headers = {
+            headers_mod.DATE: format_timestamp(now),
+            headers_mod.TIMESTAMP: format_timestamp(now)
+        }
 
         # Publish messages
         publisher.vip.pubsub.publish(
@@ -397,7 +406,12 @@ def test_insert_duplicate(volttron_instance, database_client):
 def publish_data(publisher, topic, message, now=None):
     if now is None:
         now = datetime.now()
-    headers = {headers_mod.DATE: now.isoformat()}
+
+    now = format_timestamp(now)
+    headers = {
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
+    }
 
     # Publish messages
     publisher.vip.pubsub.publish('pubsub', topic, headers, message).get(

--- a/services/core/SQLHistorian/tests/test_sqlitehistorian.py
+++ b/services/core/SQLHistorian/tests/test_sqlitehistorian.py
@@ -313,11 +313,12 @@ def test_sqlite_timeout(request, historian, publish_agent, query_agent,
                         }]
 
         # Create timestamp
-        now = datetime.utcnow().isoformat(' ')
+        now = utils.format_timestamp(datetime.utcnow())
 
         # now = '2015-12-02T00:00:00'
         headers = {
-            headers_mod.DATE: now
+            headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         print("Published time in header: " + now)
         # Publish messages
@@ -333,7 +334,7 @@ def test_sqlite_timeout(request, historian, publish_agent, query_agent,
                                           order="LAST_TO_FIRST").get(timeout=100)
         print('Query Result', result)
         assert (len(result['values']) == 1)
-        (now_date, now_time) = now.split(" ")
+        (now_date, now_time) = now.split("T")
         assert result['values'][0][0] == now_date + 'T' + now_time + '+00:00'
         assert (result['values'][0][1] == oat_reading)
         assert set(result['metadata'].items()) == set(float_meta.items())
@@ -362,10 +363,11 @@ def publish_devices_fake_data(publish_agent, time=None):
                     }]
     # Create timestamp
     if not time:
-        time = datetime.utcnow().isoformat('T') + "+00:00"
+        time = utils.format_timestamp(datetime.utcnow())
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: time
+        headers_mod.DATE: time,
+        headers_mod.TIMESTAMP: time
     }
     print("Published time in header: " + time)
     # Publish messages

--- a/volttron/drivers/deprecated-remove-5.0/base.py
+++ b/volttron/drivers/deprecated-remove-5.0/base.py
@@ -64,6 +64,7 @@ import zmq
 import datetime
 
 from volttron.platform.agent.base import PublishMixin
+from volttron.platform.agent import utils
 
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.messaging.topics import DRIVER_TOPIC_BASE, DRIVER_TOPIC_ALL
@@ -321,11 +322,12 @@ class BaseSmapVolttron(driver.SmapDriver, PublishMixin):
         if results is None:
             return
 
-        now = datetime.datetime.utcnow().isoformat(' ') + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         
         headers = {
             headers_mod.CONTENT_TYPE: headers_mod.CONTENT_TYPE.JSON,
             headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
          
         for point, value in results.iteritems():

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -831,7 +831,7 @@ class BaseHistorianAgent(Agent):
         # Anon the topic if necessary.
         topic = self.get_renamed_topic(topic)
         timestamp_string = headers.get(headers_mod.SYNC_TIMESTAMP if self._sync_timestamp else headers_mod.TIMESTAMP,
-                                       None)
+                                       headers.get(headers_mod.DATE))
         timestamp = get_aware_utc_now()
         if timestamp_string is not None:
             timestamp, my_tz = process_timestamp(timestamp_string, topic)

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -352,6 +352,7 @@ class BaseHistorianAgent(Agent):
                  message_publish_count=10000,
                  history_limit_days=None,
                  storage_limit_gb=None,
+                 sync_timestamp=False,
                  **kwargs):
 
         super(BaseHistorianAgent, self).__init__(**kwargs)
@@ -390,6 +391,7 @@ class BaseHistorianAgent(Agent):
         self.no_insert = False
         self.no_query = False
         self.instance_name = None
+        self._sync_timestamp = sync_timestamp
 
         self._current_status_context = {
             STATUS_KEY_CACHE_COUNT: 0,
@@ -828,7 +830,8 @@ class BaseHistorianAgent(Agent):
                       device):
         # Anon the topic if necessary.
         topic = self.get_renamed_topic(topic)
-        timestamp_string = headers.get(headers_mod.DATE, None)
+        timestamp_string = headers.get(headers_mod.SYNC_TIMESTAMP if self._sync_timestamp else headers_mod.TIMESTAMP,
+                                       None)
         timestamp = get_aware_utc_now()
         if timestamp_string is not None:
             timestamp, my_tz = process_timestamp(timestamp_string, topic)

--- a/volttron/platform/messaging/headers.py
+++ b/volttron/platform/messaging/headers.py
@@ -52,6 +52,8 @@ DATE = 'Date'
 
 TIMESTAMP = 'TimeStamp'
 
+SYNC_TIMESTAMP = 'SynchronizedTimeStamp'
+
 FROM = 'From'
 TO = 'To'
 

--- a/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
+++ b/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
@@ -15,6 +15,7 @@ from dateutil.parser import parse
 from volttron.platform import get_services_core
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.agent.known_identities import CONFIGURATION_STORE
+from volttron.platform.agent import utils
 
 AGG_AGENT_VIP = 'aggregate_agent'
 
@@ -204,8 +205,10 @@ def publish_test_data(publish_agent, start_time, start_reading, count):
                        {'in_temp': float_meta,
                         'out_temp': float_meta
                         }]
+        time_str = utils.format_timestring(time)
         headers = {
-            headers_mod.DATE: time.isoformat()
+            headers_mod.DATE: time_str,
+            headers_mod.TIMESTAMP: time_str
         }
         publish_agent.vip.pubsub.publish('pubsub',
                                          "devices/device1/all",

--- a/volttrontesting/services/historian/test_historian.py
+++ b/volttrontesting/services/historian/test_historian.py
@@ -523,7 +523,8 @@ def test_basic_function(request, historian, publish_agent, query_agent,
 
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     print("Published time in header: " + now)
     # Publish messages
@@ -1049,7 +1050,8 @@ def test_topic_name_case_change(request, historian, publish_agent,
     # Create timestamp
     time1 = '2015-12-17 00:00:00.000000Z'
     headers = {
-        headers_mod.DATE: time1
+        headers_mod.DATE: time1,
+        headers_mod.TIMESTAMP: time1
     }
 
     # Publish messages
@@ -1068,7 +1070,8 @@ def test_topic_name_case_change(request, historian, publish_agent,
     # Create timestamp
     time2 = '2015-12-17 01:10:00.000000Z'
     headers = {
-        headers_mod.DATE: time2
+        headers_mod.DATE: time2,
+        headers_mod.TIMESTAMP: time2
     }
 
     # Publish messages
@@ -1217,7 +1220,8 @@ def test_analysis_topic(request, historian, publish_agent, query_agent,
     print("publish_time ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: publish_time
+        headers_mod.DATE: publish_time,
+        headers_mod.TIMESTAMP: publish_time
     }
 
     # Publish messages
@@ -1375,7 +1379,8 @@ def test_analysis_topic_no_meta(request, historian, publish_agent, query_agent,
     print("publish_time ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: publish_time
+        headers_mod.DATE: publish_time,
+        headers_mod.TIMESTAMP: publish_time
     }
 
     # Publish messages
@@ -1454,7 +1459,8 @@ def test_tz_conversion_local_tz(request, historian, publish_agent, query_agent,
     print("publish_time local tz is ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: publish_time
+        headers_mod.DATE: publish_time,
+        headers_mod.TIMESTAMP: publish_time
     }
 
     # Publish messages
@@ -1528,7 +1534,8 @@ def test_tz_conversion_naive_ts(request, historian, publish_agent, query_agent,
     print("publish_time naive ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: publish_time
+        headers_mod.DATE: publish_time,
+        headers_mod.TIMESTAMP: publish_time
     }
 
     # Publish messages
@@ -2426,7 +2433,8 @@ def publish_devices_fake_data(publish_agent, time=None):
         time = datetime.utcnow().isoformat('T') + "+00:00"
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: time
+        headers_mod.DATE: time,
+        headers_mod.TIMESTAMP: time
     }
     print("Published time in header: " + time)
     # Publish messages
@@ -2450,7 +2458,8 @@ def publish_devices_fake_data_single_topic(publish_agent, time=None):
         time = datetime.utcnow().isoformat('T') + "+00:00"
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: time
+        headers_mod.DATE: time,
+        headers_mod.TIMESTAMP: time
     }
     print("Published time in header: " + time)
     # Publish messages

--- a/volttrontesting/services/historian/test_historian.py
+++ b/volttrontesting/services/historian/test_historian.py
@@ -519,7 +519,7 @@ def test_basic_function(request, historian, publish_agent, query_agent,
                     }]
 
     # Create timestamp
-    now = datetime.utcnow().isoformat(' ')
+    now = utils.format_timestamp(datetime.utcnow())
 
     # now = '2015-12-02T00:00:00'
     headers = {
@@ -1048,7 +1048,7 @@ def test_topic_name_case_change(request, historian, publish_agent,
                     }]
 
     # Create timestamp
-    time1 = '2015-12-17 00:00:00.000000Z'
+    time1 = '2015-12-17T00:00:00.000000Z'
     headers = {
         headers_mod.DATE: time1,
         headers_mod.TIMESTAMP: time1
@@ -1068,7 +1068,7 @@ def test_topic_name_case_change(request, historian, publish_agent,
                     }]
 
     # Create timestamp
-    time2 = '2015-12-17 01:10:00.000000Z'
+    time2 = '2015-12-17T01:10:00.000000Z'
     headers = {
         headers_mod.DATE: time2,
         headers_mod.TIMESTAMP: time2
@@ -1090,7 +1090,7 @@ def test_topic_name_case_change(request, historian, publish_agent,
     print('Query Result', result)
 
     assert (len(result['values']) == 2)
-    (time1_date, time1_time) = time1.split(" ")
+    (time1_date, time1_time) = time1.split("T")
     time1_time = time1_time[:-1]
     assert_timestamp(result['values'][0][0], time1_date, time1_time)
     assert (result['values'][0][1] == oat_reading)
@@ -1216,7 +1216,8 @@ def test_analysis_topic(request, historian, publish_agent, query_agent,
 
     # Create timestamp
 
-    publish_time = (datetime.utcnow() - timedelta(days=1)).isoformat()
+    publish_time = (datetime.utcnow() - timedelta(days=1))
+    publish_time = utils.format_timestamp(publish_time)
     print("publish_time ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
@@ -1306,9 +1307,10 @@ def test_analysis_topic_replacement(request, historian, publish_agent,
                                             'type': 'float'}}]
 
         # Create timestamp
-        now = datetime.utcnow().isoformat() + 'Z'
+        now = utils.format_timestamp(datetime.utcnow())
         print("now is ", now)
-        headers = {headers_mod.DATE: now}
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         # Publish messages
         publish(publish_agent, 'analysis/pnnl/seb/device', headers,
                 all_message)
@@ -1375,7 +1377,8 @@ def test_analysis_topic_no_meta(request, historian, publish_agent, query_agent,
 
     # Create timestamp
 
-    publish_time = (datetime.utcnow() - timedelta(days=1)).isoformat()
+    publish_time = (datetime.utcnow() - timedelta(days=1))
+    publish_time = utils.format_timestamp(publish_time)
     print("publish_time ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
     headers = {
@@ -1453,8 +1456,8 @@ def test_tz_conversion_local_tz(request, historian, publish_agent, query_agent,
     publish_time_naive  = datetime.now() - timedelta(days=1)
     local_tz = get_localzone()
     local_t = local_tz.localize(publish_time_naive)
-    publish_time = local_t.isoformat()
-    utc_publish_time = local_t.astimezone(pytz.utc).isoformat()
+    publish_time = utils.format_timestamp(local_t)
+    utc_publish_time = utils.format_timestamp(local_t.astimezone(pytz.utc))
     print("publish_time UTC is ", utc_publish_time)
     print("publish_time local tz is ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
@@ -1528,8 +1531,8 @@ def test_tz_conversion_naive_ts(request, historian, publish_agent, query_agent,
     publish_time_naive  = datetime.now() - timedelta(days=1)
     local_tz = get_localzone()
     local_t = local_tz.localize(publish_time_naive)
-    utc_publish_time = local_t.astimezone(pytz.utc).isoformat()
-    publish_time = publish_time_naive.isoformat()
+    utc_publish_time = utils.format_timestamp(local_t.astimezone(pytz.utc))
+    publish_time = utils.format_timestamp(publish_time_naive)
     print("publish_time UTC is ", utc_publish_time)
     print("publish_time naive ", publish_time)
     # publish_time = '2015-12-02T00:00:00'
@@ -1649,7 +1652,8 @@ def test_log_topic(request, historian, publish_agent, query_agent,
     print("current_time is ", current_time)
     future_time = '2017-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: future_time
+        headers_mod.DATE: future_time,
+        headers_mod.TIMESTAMP: future_time
     }
     print("time in header is ", future_time)
 
@@ -1752,10 +1756,11 @@ def test_log_topic_timestamped_readings(request, historian, publish_agent,
 
     # pytest.set_trace()
     # Create timestamp
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = utils.format_timestamp(datetime.utcnow())
     print("now is ", now)
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     # Publish messages
     publish(publish_agent, "datalogger/Building/LAB/Device", headers, message)
@@ -1818,10 +1823,11 @@ def test_get_topic_metadata(request, historian, publish_agent,
 
     # pytest.set_trace()
     # Create timestamp
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = utils.format_timestamp(datetime.utcnow())
     print("now is ", now)
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     # Publish messages
     publish(publish_agent, "datalogger/Building/LAB/Device", headers,
@@ -1886,11 +1892,12 @@ def test_insert_duplicate(request, historian, publish_agent, query_agent,
                    {'OutsideAirTemperature': float_meta}]
 
     # Create timestamp
-    now = datetime.utcnow().isoformat(' ')
+    now = utils.format_timestamp(datetime.utcnow())
 
     # now = '2015-12-02T00:00:00'
     headers = {
-        headers_mod.DATE: now
+        headers_mod.DATE: now,
+        headers_mod.TIMESTAMP: now
     }
     print("Published time in header: " + now)
     # Publish messages
@@ -1906,7 +1913,7 @@ def test_insert_duplicate(request, historian, publish_agent, query_agent,
                                       order="LAST_TO_FIRST").get(timeout=100)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    (now_date, now_time) = now.split(" ")
+    (now_date, now_time) = now.split("T")
     assert_timestamp(result['values'][0][0], now_date, now_time)
     assert (result['values'][0][1] == oat_reading)
     assert set(result['metadata'].items()) == set(float_meta.items())
@@ -1923,7 +1930,7 @@ def test_insert_duplicate(request, historian, publish_agent, query_agent,
         timeout=100)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    (now_date, now_time) = now.split(" ")
+    (now_date, now_time) = now.split("T")
     assert_timestamp(result['values'][0][0], now_date, now_time)
     assert (result['values'][0][1] == oat_reading)
     assert set(result['metadata'].items()) == set(float_meta.items())
@@ -2022,10 +2029,10 @@ def test_multi_topic_query_single_result(request, historian, publish_agent,
     # will not return this
     all_message = [{'MixedAirTemperature': 1.1}]
     # Create timestamp
-    old_time = (datetime.utcnow() - timedelta(days=1)).isoformat(
-        'T') + "+00:00"
+    old_time = utils.format_timestamp(datetime.utcnow() - timedelta(days=1))
     # now = '2015-12-02T00:00:00'
-    headers = {headers_mod.DATE: old_time}
+    headers = {headers_mod.DATE: old_time,
+               headers_mod.TIMESTAMP: old_time}
     publish(publish_agent, DEVICES_ALL_TOPIC, headers, all_message)
     gevent.sleep(1)
 
@@ -2289,11 +2296,12 @@ def test_get_topic_list(request, historian, publish_agent, query_agent,
                         'MixedAirTemperature': float_meta}]
 
         # Create timestamp
-        now = datetime.utcnow().isoformat(' ')
+        now = utils.format_timestamp(datetime.utcnow())
 
         # now = '2015-12-02T00:00:00'
         headers = {
-            headers_mod.DATE: now
+            headers_mod.DATE: now,
+            headers_mod.TIMESTAMP: now
         }
         print("Published time in header: " + now)
         # Publish messages
@@ -2430,7 +2438,7 @@ def publish_devices_fake_data(publish_agent, time=None):
                     }]
     # Create timestamp
     if not time:
-        time = datetime.utcnow().isoformat('T') + "+00:00"
+        time = utils.format_timestamp(datetime.utcnow())
     # now = '2015-12-02T00:00:00'
     headers = {
         headers_mod.DATE: time,
@@ -2455,7 +2463,7 @@ def publish_devices_fake_data_single_topic(publish_agent, time=None):
                     }]
     # Create timestamp
     if not time:
-        time = datetime.utcnow().isoformat('T') + "+00:00"
+        time = utils.format_timestamp(datetime.utcnow())
     # now = '2015-12-02T00:00:00'
     headers = {
         headers_mod.DATE: time,

--- a/volttrontesting/services/tagging/test_tagging.py
+++ b/volttrontesting/services/tagging/test_tagging.py
@@ -50,6 +50,7 @@ from volttron.platform import get_services_core
 from volttron.platform.jsonrpc import RemoteError
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.messaging import topics
+from volttron.platform.agent import utils
 
 try:
     import pymongo
@@ -283,7 +284,9 @@ def test_reinstall(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(2)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [{'p1': 2, 'p2': 2}]}]
         query_agent.vip.rpc.call('platform.historian', 'insert', to_send).get(
@@ -477,7 +480,9 @@ def test_insert_topic_tags(volttron_instance, tagging_service, query_agent,
                                        tagging_service,
                                        tag_table_prefix)
 
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d1/all', 'headers': headers,
                     'message': [{'p1': 2, 'p2': 2}]}]
         query_agent.vip.rpc.call(historian_vip_identity, 'insert', to_send).get(
@@ -547,7 +552,9 @@ def test_insert_topic_pattern_tags(volttron_instance, tagging_service,
                                        tag_table_prefix)
 
         to_send = []
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send.append({'topic': 'devices/campus1/d1/all', 'headers': headers,
                         'message': [{'p1': 2, 'p2': 2}]})
         to_send.append({'topic': 'devices/campus2/d1/all', 'headers': headers,
@@ -665,7 +672,9 @@ def test_insert_topic_tags_update(volttron_instance, tagging_service,
                                        tagging_service,
                                        tag_table_prefix)
         to_send = []
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send.append({'topic': 'devices/campus1/d1/all', 'headers': headers,
                         'message': [{'p1': 2, 'p2': 2}]})
 
@@ -736,7 +745,9 @@ def test_update_topic_tags(volttron_instance, tagging_service, query_agent):
             config_file=hist_config,
             start=True)
         gevent.sleep(1)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [{'p1': 2, 'p2': 2}]}]
         query_agent.vip.rpc.call('platform.historian', 'insert', to_send).get(
@@ -856,7 +867,9 @@ def test_tags_by_topic_no_metadata(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(2)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [{'p1': 2, 'p2': 2}]}]
         query_agent.vip.rpc.call('platform.historian', 'insert', to_send).get(
@@ -962,7 +975,9 @@ def test_tags_by_topic_with_metadata(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(1)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [{'p1': 2, 'p2': 2}]}]
         query_agent.vip.rpc.call('platform.historian', 'insert', to_send).get(
@@ -1057,7 +1072,9 @@ def test_topic_by_tags_param_and_or(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(2)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [
                         {'p1': 2, 'p2': 2, 'p3': 1, 'p4': 2, 'p5': 2}]}]
@@ -1192,7 +1209,9 @@ def test_topic_by_tags_custom_condition(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(2)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [
                         {'p1': 2, 'p2': 2, 'p3': 1, 'p4': 2, 'p5': 2}]}]
@@ -1345,7 +1364,9 @@ def test_topic_by_tags_parent_topic_query(volttron_instance, tagging_service,
             config_file=hist_config,
             start=True)
         gevent.sleep(2)
-        headers = {headers_mod.DATE: datetime.utcnow().isoformat()}
+        now = utils.format_timestamp(datetime.utcnow())
+        headers = {headers_mod.DATE: now,
+                   headers_mod.TIMESTAMP: now}
         to_send = [{'topic': 'devices/campus1/d2/all', 'headers': headers,
                     'message': [
                         {'p1': 2, 'p2': 2, 'p3': 1, 'p4': 2, 'p5': 2}]}]

--- a/volttrontesting/utils/utils.py
+++ b/volttrontesting/utils/utils.py
@@ -8,6 +8,7 @@ import gevent
 import pytest
 
 from volttron.platform.messaging import headers as headers_mod
+from volttron.platform.agent import utils
 
 
 def poll_gevent_sleep(max_seconds, condition=lambda: True, sleep_time=0.2):
@@ -90,9 +91,10 @@ def build_devices_header_and_message(points=['abc', 'def']):
         data[point] = random() * 10
         meta_data[point] = meta_templates[randint(0,len(meta_templates)-1)]
 
-    time1 = datetime.utcnow().isoformat(' ')
+    time1 = utils.format_timestamp( datetime.utcnow())
     headers = {
-        headers_mod.DATE: time1
+        headers_mod.DATE: time1,
+        headers_mod.TIMESTAMP: time1
     }
 
     return headers, [data, meta_data]


### PR DESCRIPTION
# Description

Adds an optional synchronized timestamp to allow grouping device scrapes by timestamp. An example is a historian that creates wide tables grouping values by the synchronized timestamp. The default behavior does not change. The synchronized timestamp can be used by setting `synchronized_timestamp = true` in the historian configuration.

  - Calculates synchronized timestamp is using the time slot offset in device scrapes
  - Message bus carries the synchronized timestamp
  - Updates base historian to capture header timestamp instead of header date from the device data
  - Fixes broken unit tests for historian

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

This was tested using a single emulated modbus device with a master driver configured with multiple devices using the same emulator. We tried various configurations to change the device groups and scrape offsets. Then messages were monitored using the listener agent and a historian to verify that the timestamps were synchronized when configured to do so.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1780%23discussion_r212074063%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1780%23discussion_r215696151%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1780%23discussion_r215792776%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%203e0689a2eedc5b21992a4ac3ea936ed49bf5e1c0%20services/core/MasterDriverAgent/master_driver/driver.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1780%23discussion_r212074063%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20need%20to%20use%20utils.format_timestamp%20to%20convert%20to%20a%20string.%20That%20will%20give%20the%20VOLTTRON%20standard%20date/time%20format.%20This%20will%20also%20make%20sure%20that%20the%20tz%20info%20is%20not%20lost.%20The%20corresponding%20parser%20is%20optimized%20for%20this%20format.%22%2C%20%22created_at%22%3A%20%222018-08-22T19%3A10%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%2C%20%7B%22body%22%3A%20%22Change%20committed.%22%2C%20%22created_at%22%3A%20%222018-09-06T16%3A38%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1288789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hashstat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-09-06T22%3A03%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20services/core/MasterDriverAgent/master_driver/driver.py%3AL258-270%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 3e0689a2eedc5b21992a4ac3ea936ed49bf5e1c0 services/core/MasterDriverAgent/master_driver/driver.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1780#discussion_r212074063'>File: services/core/MasterDriverAgent/master_driver/driver.py:L258-270</a></b>
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> We need to use utils.format_timestamp to convert to a string. That will give the VOLTTRON standard date/time format. This will also make sure that the tz info is not lost. The corresponding parser is optimized for this format.
- <a href='https://github.com/hashstat'><img border=0 src='https://avatars1.githubusercontent.com/u/1288789?v=4' height=16 width=16></a> Change committed.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1780?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1780?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1780'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>