### PR TITLE
RMQ pytest with ssl=True

### DIFF
--- a/ci-integration/run-tests.sh
+++ b/ci-integration/run-tests.sh
@@ -34,7 +34,7 @@ testdirs="services/core/VolttronCentral/tests services/core/VolttronCentralPlatf
 #directories that must have their subdirectories split
 splitdirs="services/core/*"
 
-python bootstrap.py --market
+python bootstrap.py --rabbitmq
 
 echo "TestDirs"
 for dir in $testdirs; do

--- a/ci-integration/run-tests.sh
+++ b/ci-integration/run-tests.sh
@@ -34,7 +34,17 @@ testdirs="services/core/VolttronCentral/tests services/core/VolttronCentralPlatf
 #directories that must have their subdirectories split
 splitdirs="services/core/*"
 
+echo "installing ERLANG"
+wget -O - 'https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc' | sudo apt-key add -
+echo 'deb https://dl.bintray.com/rabbitmq/debian trusty erlang-21.x'|sudo tee --append /etc/apt/sources.list.d/bintray.erlang.list
+sudo apt-get update
+sudo apt-get install -y erlang-diameter erlang-eldap
+sudo apt-get install -y erlang-nox
+
 python bootstrap.py --rabbitmq
+
+echo "rabbitmq status"
+$HOME/rabbitmq_server/rabbitmq_server-3.7.7/sbin/rabbitmqctl status
 
 echo "TestDirs"
 for dir in $testdirs; do

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -126,8 +126,9 @@ def get_authentication_args(ssl_auth):
     global local_user, local_password, admin_user, admin_password, \
         instance_name, crts
 
-    if not crts:
-        crts = certs.Certs()
+    # if not crts:
+    #     crts = certs.Certs()
+    crts = certs.Certs()
 
     if ssl_auth:
         if not instance_name:
@@ -230,8 +231,9 @@ def get_vhost():
 
 
 def get_user():
-    if not config_opts:
-        _load_rmq_config()
+    _load_rmq_config()
+    # if not config_opts:
+    #     _load_rmq_config()
     return config_opts.get('user')
 
 

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -1016,39 +1016,3 @@ def get_ssl_url_params():
            "&auth_mechanism=external".format(ca=ca_file,
                                              cert=cert_file,
                                              key=key_file)
-
-
-def create_rmq_volttron_test_setup(volttron_home, host='localhost'):
-    global config_opts
-    _load_rmq_config(volttron_home)
-
-    ssl_auth = False
-    # Set vhost, username, password, hostname and port
-    config_opts['virtual-host'] = 'volttron_test'
-    config_opts['user'] = 'test_user'
-    config_opts['pass'] = 'test_user'
-    config_opts['host'] = host
-    config_opts['amqp-port'] = str(5672)
-    config_opts['mgmt-port'] = str(15672)
-    config_opts['ssl'] = str(ssl_auth)
-    config_opts['rmq-address'] = build_rmq_address()
-    config_opts.async_sync()
-    init_rabbitmq_setup()
-    create_user_with_permissions('test_user',
-                                 dict(configure=".*", read=".*", write=".*"),
-                                 ssl_auth=ssl_auth)
-
-
-def cleanup_rmq_volttron_test_setup(volttron_home):
-    global config_opts
-    _load_rmq_config(volttron_home)
-    try:
-        users = get_users(ssl_auth=False)
-        users.remove('guest')
-        users_to_remove = []
-
-        # Delete all the users using virtual host
-        for user in users_to_remove:
-            delete_user(user)
-    except KeyError as e:
-        return

--- a/volttrontesting/fixtures/rmq_fixture.py
+++ b/volttrontesting/fixtures/rmq_fixture.py
@@ -67,6 +67,6 @@ def cleanup_rmq_volttron_setup():
         delete_exchange(exchange='volttron',
                         vhost=rabbitmq_config['virtual-host'])
         delete_vhost(vhost=rabbitmq_config['virtual-host'])
-        stop_rabbit(rmq_home=rabbitmq_config['rmq-home'])
+        # stop_rabbit(rmq_home=rabbitmq_config['rmq-home'])
     except requests.exceptions.HTTPError:
         pass

--- a/volttrontesting/fixtures/rmq_fixture.py
+++ b/volttrontesting/fixtures/rmq_fixture.py
@@ -31,6 +31,13 @@ rabbitmq_config = {
 
 
 def create_rmq_volttron_setup(ssl_auth=False):
+    """
+        Create RMQ volttron test setup:
+            - Install config and rabbitmq_config.yml in VOLTTRON_HOME
+            - Create virtual host, exchanges, certificates, and users
+
+    :param ssl_auth: ssl authentication
+    """
     rabbitmq_config['ssl'] = str(ssl_auth)
     vhome = get_home()
     instance_setup._install_config_file()
@@ -49,6 +56,11 @@ def create_rmq_volttron_setup(ssl_auth=False):
 
 
 def cleanup_rmq_volttron_setup():
+    """
+        Clean-up RMQ volttron test setup:
+            - The function is called when DEBUG = False
+            - delete test users, exchanges, and virtual host
+    """
     global config_opts
     _load_rmq_config()
     users_to_remove = get_users()

--- a/volttrontesting/fixtures/rmq_fixture.py
+++ b/volttrontesting/fixtures/rmq_fixture.py
@@ -1,0 +1,72 @@
+import os
+import yaml
+import requests
+
+from volttron.platform import instance_setup, get_home
+from volttron.platform.agent.utils import store_message_bus_config
+from volttron.utils.rmq_mgmt import _load_rmq_config, get_users, delete_user, delete_vhost, delete_exchange
+from volttron.utils.rmq_setup import stop_rabbit
+
+
+HOME = os.environ.get('HOME')
+VOLTTRON_INSTANCE_NAME = 'volttron_test'
+
+rabbitmq_config = {
+    'host': 'localhost',
+    'certificate-data': {
+        'country': 'US',
+        'state': 'Washington',
+        'location': 'Richland',
+        'organization': 'PNNL',
+        'organization-unit': 'VOLTTRON Team',
+        'common-name': '{}_root_ca'.format(VOLTTRON_INSTANCE_NAME),
+    },
+    'virtual-host': 'volttron_test',
+    'amqp-port': 5672,
+    'amqp-port-ssl': 5671,
+    'mgmt-port': 15672,
+    'mgmt-port-ssl': 15671,
+    'rmq-home': os.path.join(HOME, 'rabbitmq_server/rabbitmq_server-3.7.7')
+}
+
+
+def create_rmq_volttron_setup(ssl_auth=False):
+    rabbitmq_config['ssl'] = str(ssl_auth)
+    vhome = get_home()
+    instance_setup._install_config_file()
+    vhome_config = os.path.join(vhome, 'rabbitmq_config.yml')
+
+    if not os.path.isfile(vhome_config):
+        with open(vhome_config, 'w') as yml_file:
+            yaml.dump(rabbitmq_config, yml_file, default_flow_style=False)
+
+    store_message_bus_config(message_bus='rmq',
+                             instance_name=VOLTTRON_INSTANCE_NAME)
+
+    instance_setup.setup_rabbitmq_volttron(type='single',
+                                           verbose=False,
+                                           prompt=False)
+
+
+def cleanup_rmq_volttron_setup():
+    global config_opts
+    _load_rmq_config()
+    users_to_remove = get_users()
+    users_to_remove.remove('guest')
+
+    # Delete all the users using virtual host
+    for user in users_to_remove:
+        try:
+            delete_user(user)
+        except (AttributeError, requests.exceptions.HTTPError):
+            pass
+
+    try:
+        delete_exchange(exchange='undeliverable',
+                        vhost=rabbitmq_config['virtual-host'])
+        delete_exchange(exchange='volttron',
+                        vhost=rabbitmq_config['virtual-host'])
+        delete_vhost(vhost=rabbitmq_config['virtual-host'])
+        stop_rabbit(rmq_home=rabbitmq_config['rmq-home'])
+    except requests.exceptions.HTTPError:
+        pass

--- a/volttrontesting/fixtures/rmq_test_setup.py
+++ b/volttrontesting/fixtures/rmq_test_setup.py
@@ -60,7 +60,7 @@ def create_rmq_volttron_setup(vhome=None, ssl_auth=False):
                                            prompt=False)
 
 
-def cleanup_rmq_volttron_setup(vhome=None):
+def cleanup_rmq_volttron_setup(vhome=None, ssl_auth=False):
     """
         Teardown rabbitmq at test end:
             - The function is called when DEBUG = False
@@ -76,7 +76,8 @@ def cleanup_rmq_volttron_setup(vhome=None):
 
     users_to_remove = get_users()
     users_to_remove.remove('guest')
-    users_to_remove.remove('volttron_test-admin')
+    if ssl_auth:
+        users_to_remove.remove('volttron_test-admin')
 
     for user in users_to_remove:
         try:
@@ -89,6 +90,11 @@ def cleanup_rmq_volttron_setup(vhome=None):
     delete_exchange(exchange='volttron',
                     vhost=rabbitmq_config['virtual-host'])
     delete_vhost(vhost=rabbitmq_config['virtual-host'])
-    delete_user('volttron_test-admin')
+
+    if ssl_auth:
+        delete_user('volttron_test-admin')
+
     stop_rabbit(rmq_home=rabbitmq_config['rmq-home'])
-    os.remove(os.path.join(rabbitmq_config['rmq-home'], 'etc/rabbitmq/rabbitmq.conf'))
+
+    if ssl_auth:
+        os.remove(os.path.join(rabbitmq_config['rmq-home'], 'etc/rabbitmq/rabbitmq.conf'))

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -49,9 +49,8 @@ def get_rand_ipc_vip():
 
 
 def build_wrapper(vip_address, **kwargs):
-    message_bus = kwargs.pop('message_bus', None)
-    ssl_auth = kwargs.pop('ssl_auth', False)
-    wrapper = PlatformWrapper(message_bus, ssl_auth)
+    wrapper = PlatformWrapper(message_bus=kwargs.pop('message_bus', None),
+                              ssl_auth=kwargs.pop('ssl_auth', False))
     print('BUILD_WRAPPER: {}'.format(vip_address))
     wrapper.startup_platform(vip_address=vip_address, **kwargs)
     return wrapper
@@ -68,11 +67,12 @@ def cleanup_wrappers(platforms):
         cleanup_wrapper(p)
 
 @pytest.fixture(scope="module",
-                params=['zmq', 'rmq'])
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance1(request):
     print("building instance 1")
-
-    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
+    wrapper = build_wrapper(get_rand_vip(),
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -82,11 +82,12 @@ def volttron_instance1(request):
 
 
 @pytest.fixture(scope="module",
-                params=['zmq', 'rmq'])
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance2(request):
     print("building instance 2")
-
-    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
+    wrapper = build_wrapper(get_rand_vip(),
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -95,10 +96,14 @@ def volttron_instance2(request):
     return wrapper
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance_msgdebug(request):
     print("building msgdebug instance")
-    wrapper = build_wrapper(get_rand_vip(), msgdebug=True)
+    wrapper = build_wrapper(get_rand_vip(),
+                            msgdebug=True,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -124,12 +129,15 @@ def volttron_instance_encrypt(request):
     return wrapper
 
 
-@pytest.fixture
+@pytest.fixture(params=[('zmq', False), ('rmq', True)])
 def volttron_instance1_web(request):
     print("building instance 1 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -138,12 +146,15 @@ def volttron_instance1_web(request):
     return wrapper
 
 
-@pytest.fixture
+@pytest.fixture(params=[('zmq', False), ('rmq', True)])
 def volttron_instance2_web(request):
     print("building instance 2 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -151,12 +162,16 @@ def volttron_instance2_web(request):
     request.addfinalizer(cleanup)
     return wrapper
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance_module_web(request):
     print("building module instance (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -170,23 +185,22 @@ def volttron_instance_module_web(request):
 # Use this fixture when you want a single instance of volttron platform for
 # test
 @pytest.fixture(scope="module",
-                params=[('rmq', True)])
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance(request):
     """Fixture that returns a single instance of volttron platform for testing
 
     @param request: pytest request object
     @return: volttron platform instance
     """
+    print("building instance")
     wrapper = None
     address = get_rand_vip()
-    message_bus = request.param[0]
-    ssl_auth = request.param[1]
-
-    wrapper = build_wrapper(address, message_bus=message_bus, ssl_auth=ssl_auth)
+    wrapper = build_wrapper(address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         print('Shutting down instance: {}'.format(wrapper.volttron_home))
-        wrapper.remove_all_agents()
         wrapper.shutdown_platform()
 
     request.addfinalizer(cleanup)

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -59,6 +59,7 @@ def build_wrapper(vip_address, **kwargs):
 def cleanup_wrapper(wrapper):
     print('Shutting down instance: {}'.format(wrapper.volttron_home))
     # Shutdown handles case where the platform hasn't started.
+    wrapper.remove_all_agents()
     wrapper.shutdown_platform()
 
 
@@ -191,6 +192,7 @@ def volttron_instance(request):
 
     def cleanup():
         print('Shutting down instance: {}'.format(wrapper.volttron_home))
+        wrapper.remove_all_agents()
         wrapper.shutdown_platform()
 
     request.addfinalizer(cleanup)

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -66,13 +66,10 @@ def cleanup_wrappers(platforms):
     for p in platforms:
         cleanup_wrapper(p)
 
-@pytest.fixture(scope="module",
-                params=[('zmq', False), ('rmq', True)])
+@pytest.fixture(scope="module")
 def volttron_instance1(request):
     print("building instance 1")
-    wrapper = build_wrapper(get_rand_vip(),
-                            message_bus=request.param[0],
-                            ssl_auth=request.param[1])
+    wrapper = build_wrapper(get_rand_vip())
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -81,13 +78,10 @@ def volttron_instance1(request):
     return wrapper
 
 
-@pytest.fixture(scope="module",
-                params=[('zmq', False), ('rmq', True)])
+@pytest.fixture(scope="module")
 def volttron_instance2(request):
     print("building instance 2")
-    wrapper = build_wrapper(get_rand_vip(),
-                            message_bus=request.param[0],
-                            ssl_auth=request.param[1])
+    wrapper = build_wrapper(get_rand_vip())
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -129,15 +123,13 @@ def volttron_instance_encrypt(request):
     return wrapper
 
 
-@pytest.fixture(params=[('zmq', False), ('rmq', True)])
+@pytest.fixture
 def volttron_instance1_web(request):
     print("building instance 1 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
     wrapper = build_wrapper(address,
-                            bind_web_address=web_address,
-                            message_bus=request.param[0],
-                            ssl_auth=request.param[1])
+                            bind_web_address=web_address)
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -146,15 +138,13 @@ def volttron_instance1_web(request):
     return wrapper
 
 
-@pytest.fixture(params=[('zmq', False), ('rmq', True)])
+@pytest.fixture
 def volttron_instance2_web(request):
     print("building instance 2 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
     wrapper = build_wrapper(address,
-                            bind_web_address=web_address,
-                            message_bus=request.param[0],
-                            ssl_auth=request.param[1])
+                            bind_web_address=web_address)
 
     def cleanup():
         cleanup_wrapper(wrapper)

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -186,8 +186,6 @@ def volttron_instance(request):
 
     def cleanup():
         print('Shutting down instance: {}'.format(wrapper.volttron_home))
-        if message_bus == 'rmq' and ssl_auth:
-            os.remove('/home/anh/rabbitmq_server/rabbitmq_server-3.7.7/etc/rabbitmq/rabbitmq.conf')
         wrapper.remove_all_agents()
         wrapper.shutdown_platform()
 

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -20,7 +20,7 @@ from gevent.fileobject import FileObject
 from gevent.subprocess import Popen
 from volttron.platform import packaging
 from volttron.platform.agent import utils
-from volttron.platform.agent.utils import strip_comments
+from volttron.platform.agent.utils import strip_comments, load_platform_config
 from volttron.platform.aip import AIPplatform
 from volttron.platform.auth import (AuthFile, AuthEntry,
                                     AuthFileEntryAlreadyExists)
@@ -30,8 +30,7 @@ from volttron.platform.vip.agent.connection import Connection
 from volttrontesting.utils.utils import get_rand_http_address
 from volttrontesting.utils.utils import get_rand_tcp_address
 from volttron.platform.agent import json as jsonapi
-from volttron.utils.rmq_mgmt import create_rmq_volttron_test_setup, \
-    cleanup_rmq_volttron_test_setup
+from volttrontesting.fixtures.rmq_fixture import create_rmq_volttron_setup, cleanup_rmq_volttron_setup
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -157,7 +156,7 @@ def start_wrapper_platform(wrapper, with_http=False, with_tcp=True,
 
 
 class PlatformWrapper:
-    def __init__(self, message_bus=None):
+    def __init__(self, message_bus=None, ssl_auth=False):
         """ Initializes a new VOLTTRON instance
 
         Creates a temporary VOLTTRON_HOME directory with a packaged directory
@@ -170,6 +169,7 @@ class PlatformWrapper:
         self._instance_shutdown = False
 
         self.volttron_home = tempfile.mkdtemp()
+        os.environ['VOLTTRON_HOME'] = self.volttron_home
         self.packaged_dir = os.path.join(self.volttron_home, "packaged")
         os.makedirs(self.packaged_dir)
 
@@ -226,6 +226,7 @@ class PlatformWrapper:
         self.keystore = KeyStore(keystorefile)
         self.keystore.generate()
         self.message_bus = message_bus if message_bus else 'zmq'
+        self.ssl_auth = ssl_auth
 
 
     def logit(self, message):
@@ -424,7 +425,9 @@ class PlatformWrapper:
         self.skip_cleanup = self.env.get('SKIP_CLEANUP', False)
         if self.message_bus == 'rmq':
             self.logit("Setting up volttron test environemnt {}".format(self.volttron_home))
-            create_rmq_volttron_test_setup(self.volttron_home)
+            create_rmq_volttron_setup(ssl_auth=self.ssl_auth)
+            platform_config = load_platform_config()
+            instance_name = platform_config.get('instance-name', '').strip('"')
             if not instance_name:
                 self.instance_name = instance_name = 'volttron_test'
 
@@ -1019,7 +1022,7 @@ class PlatformWrapper:
                     logpath
                 ))
         if not self.skip_cleanup and self.message_bus == 'rmq':
-            cleanup_rmq_volttron_test_setup(self.volttron_home)
+            cleanup_rmq_volttron_setup()
         if not self.skip_cleanup:
             self.logit('Removing {}'.format(self.volttron_home))
             shutil.rmtree(self.volttron_home, ignore_errors=True)

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -30,7 +30,7 @@ from volttron.platform.vip.agent.connection import Connection
 from volttrontesting.utils.utils import get_rand_http_address
 from volttrontesting.utils.utils import get_rand_tcp_address
 from volttron.platform.agent import json as jsonapi
-from volttrontesting.fixtures.rmq_fixture import create_rmq_volttron_setup, cleanup_rmq_volttron_setup
+from volttrontesting.fixtures.rmq_test_setup import create_rmq_volttron_setup, cleanup_rmq_volttron_setup
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -161,6 +161,9 @@ class PlatformWrapper:
 
         Creates a temporary VOLTTRON_HOME directory with a packaged directory
         for agents that are built.
+
+        :param message_bus: rmq or zmq
+        :param ssl_auth: if message_bus=rmq, authenticate users if True
         """
 
         # This is hopefully going to keep us from attempting to shutdown

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -169,7 +169,6 @@ class PlatformWrapper:
         self._instance_shutdown = False
 
         self.volttron_home = tempfile.mkdtemp()
-        os.environ['VOLTTRON_HOME'] = self.volttron_home
         self.packaged_dir = os.path.join(self.volttron_home, "packaged")
         os.makedirs(self.packaged_dir)
 
@@ -425,7 +424,7 @@ class PlatformWrapper:
         self.skip_cleanup = self.env.get('SKIP_CLEANUP', False)
         if self.message_bus == 'rmq':
             self.logit("Setting up volttron test environemnt {}".format(self.volttron_home))
-            create_rmq_volttron_setup(ssl_auth=self.ssl_auth)
+            create_rmq_volttron_setup(vhome=self.volttron_home, ssl_auth=self.ssl_auth)
             platform_config = load_platform_config()
             instance_name = platform_config.get('instance-name', '').strip('"')
             if not instance_name:
@@ -1022,7 +1021,7 @@ class PlatformWrapper:
                     logpath
                 ))
         if not self.skip_cleanup and self.message_bus == 'rmq':
-            cleanup_rmq_volttron_setup()
+            cleanup_rmq_volttron_setup(self.volttron_home)
         if not self.skip_cleanup:
             self.logit('Removing {}'.format(self.volttron_home))
             shutil.rmtree(self.volttron_home, ignore_errors=True)

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -427,7 +427,8 @@ class PlatformWrapper:
         self.skip_cleanup = self.env.get('SKIP_CLEANUP', False)
         if self.message_bus == 'rmq':
             self.logit("Setting up volttron test environemnt {}".format(self.volttron_home))
-            create_rmq_volttron_setup(vhome=self.volttron_home, ssl_auth=self.ssl_auth)
+            create_rmq_volttron_setup(vhome=self.volttron_home,
+                                      ssl_auth=self.ssl_auth)
             platform_config = load_platform_config()
             instance_name = platform_config.get('instance-name', '').strip('"')
             if not instance_name:
@@ -1024,7 +1025,8 @@ class PlatformWrapper:
                     logpath
                 ))
         if not self.skip_cleanup and self.message_bus == 'rmq':
-            cleanup_rmq_volttron_setup(self.volttron_home)
+            cleanup_rmq_volttron_setup(vhome=self.volttron_home,
+                                       ssl_auth=self.ssl_auth)
         if not self.skip_cleanup:
             self.logit('Removing {}'.format(self.volttron_home))
             shutil.rmtree(self.volttron_home, ignore_errors=True)


### PR DESCRIPTION
- rmq_fixture.py: create_rmq_volttron_setup() and cleanup_rmq_volttron_setup() to create and cleanup rmq test
- pytest pass: volttron/volttrontesting/subsystems
- pytest teardown: delete_user, delete_exchange, delete_vhost raise requests.exceptions.HTTPError
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1783?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1783'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>