### PR TITLE
ForwardHistorian should publish all by default

### DIFF
--- a/services/core/ForwardHistorian/forwarder/agent.py
+++ b/services/core/ForwardHistorian/forwarder/agent.py
@@ -77,7 +77,7 @@ def historian(config_path, **kwargs):
         _log.warning(w)
 
         # Populate the new values for the kwargs based upon the old data.
-        kwargs['capture_device_data'] = True if ("device" in service_topic_list  or "all" in service_topic_list) else False
+        kwargs['capture_device_data'] = True if ("device" in service_topic_list or "all" in service_topic_list) else False
         kwargs['capture_log_data'] = True if ("datalogger" in service_topic_list or "all" in service_topic_list) else False
         kwargs['capture_record_data'] = True if ("record" in service_topic_list or "all" in service_topic_list) else False
         kwargs['capture_analysis_data'] = True if ("analysis" in service_topic_list or "all" in service_topic_list) else False
@@ -129,12 +129,18 @@ class ForwardHistorian(BaseHistorian):
         self.required_target_agents = required_target_agents
         self.cache_only = cache_only
 
-        config = {"custom_topic_list": custom_topic_list,
-                  "topic_replace_list": self.topic_replace_list,
-                  "required_target_agents": self.required_target_agents,
-                  "destination_vip": self.destination_vip,
-                  "destination_serverkey": self.destination_serverkey,
-                  "cache_only": self.cache_only}
+        config = {
+            "custom_topic_list": custom_topic_list,
+            "topic_replace_list": self.topic_replace_list,
+            "required_target_agents": self.required_target_agents,
+            "destination_vip": self.destination_vip,
+            "destination_serverkey": self.destination_serverkey,
+            "cache_only": self.cache_only,
+            "capture_device_data": True,
+            "capture_analysis_data": True,
+            "capture_log_data": True,
+            "capture_record_data": True,
+        }
 
         self.update_default_config(config)
 

--- a/services/core/ForwardHistorian/tests/test_forwarder_reconnections.py
+++ b/services/core/ForwardHistorian/tests/test_forwarder_reconnections.py
@@ -112,8 +112,6 @@ def test_topic_forwarding(setup_instances, topic_root, topic, replace, headers):
     pub_listener.core.stop()
 
 
-
-
 def test_target_shutdown(setup_instances):
 
     inst_forward, inst_target = setup_instances
@@ -174,7 +172,3 @@ def test_target_shutdown(setup_instances):
     validate_published_device_data(headers, message,
                                    pubsub_retrieved[0][1],
                                    pubsub_retrieved[0][2])
-
-
-def test_can_pause_publishing(setup_instances):
-    pass

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -1043,7 +1043,7 @@ class BaseHistorianAgent(Agent):
 
                 # Check to see if we are caught up.
                 if not to_publish_list:
-                    if self._message_publish_count > 0:
+                    if self._message_publish_count > 0 and next_report_count < current_published_count:
                         _log.info("Historian processed {} total records.".format(current_published_count))
                         next_report_count = current_published_count + self._message_publish_count
                     self._update_status({STATUS_KEY_BACKLOGGED: False,

--- a/volttrontesting/utils/utils.py
+++ b/volttrontesting/utils/utils.py
@@ -132,5 +132,4 @@ def validate_published_device_data(expected_headers, expected_message,
 
     for k, v in expected_message[0].items():
         assert k in message[0]
-        # pytest.approx gives 10^-6 (one millionth accuracy)
-        assert message[0][k] == pytest.approx(v)
+        assert message[0][k] == pytest.approx(v, rel=0.0000001)

--- a/volttrontesting/utils/utils.py
+++ b/volttrontesting/utils/utils.py
@@ -132,4 +132,4 @@ def validate_published_device_data(expected_headers, expected_message,
 
     for k, v in expected_message[0].items():
         assert k in message[0]
-        assert message[0][k] == pytest.approx(v, rel=0.0000001)
+        assert message[0][k] == pytest.approx(v, abs=1e-6)


### PR DESCRIPTION
# Description

Changes the base historian so that it only reports the total published on specified period.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1785?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1785'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>