### PR TITLE
RabbitMQ message broker: pytest support with SSL authentication

### DIFF
--- a/ci-integration/run-tests.sh
+++ b/ci-integration/run-tests.sh
@@ -34,7 +34,17 @@ testdirs="services/core/VolttronCentral/tests services/core/VolttronCentralPlatf
 #directories that must have their subdirectories split
 splitdirs="services/core/*"
 
-python bootstrap.py --market
+echo "installing ERLANG"
+wget -O - 'https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc' | sudo apt-key add -
+echo 'deb https://dl.bintray.com/rabbitmq/debian trusty erlang-21.x'|sudo tee --append /etc/apt/sources.list.d/bintray.erlang.list
+sudo apt-get update
+sudo apt-get install -y erlang-diameter erlang-eldap
+sudo apt-get install -y erlang-nox
+
+python bootstrap.py --rabbitmq
+
+echo "rabbitmq status"
+$HOME/rabbitmq_server/rabbitmq_server-3.7.7/sbin/rabbitmqctl status
 
 echo "TestDirs"
 for dir in $testdirs; do

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -126,8 +126,9 @@ def get_authentication_args(ssl_auth):
     global local_user, local_password, admin_user, admin_password, \
         instance_name, crts
 
-    if not crts:
-        crts = certs.Certs()
+    # if not crts:
+    #     crts = certs.Certs()
+    crts = certs.Certs()
 
     if ssl_auth:
         if not instance_name:
@@ -230,8 +231,9 @@ def get_vhost():
 
 
 def get_user():
-    if not config_opts:
-        _load_rmq_config()
+    _load_rmq_config()
+    # if not config_opts:
+    #     _load_rmq_config()
     return config_opts.get('user')
 
 
@@ -1014,39 +1016,3 @@ def get_ssl_url_params():
            "&auth_mechanism=external".format(ca=ca_file,
                                              cert=cert_file,
                                              key=key_file)
-
-
-def create_rmq_volttron_test_setup(volttron_home, host='localhost'):
-    global config_opts
-    _load_rmq_config(volttron_home)
-
-    ssl_auth = False
-    # Set vhost, username, password, hostname and port
-    config_opts['virtual-host'] = 'volttron_test'
-    config_opts['user'] = 'test_user'
-    config_opts['pass'] = 'test_user'
-    config_opts['host'] = host
-    config_opts['amqp-port'] = str(5672)
-    config_opts['mgmt-port'] = str(15672)
-    config_opts['ssl'] = str(ssl_auth)
-    config_opts['rmq-address'] = build_rmq_address()
-    config_opts.async_sync()
-    init_rabbitmq_setup()
-    create_user_with_permissions('test_user',
-                                 dict(configure=".*", read=".*", write=".*"),
-                                 ssl_auth=ssl_auth)
-
-
-def cleanup_rmq_volttron_test_setup(volttron_home):
-    global config_opts
-    _load_rmq_config(volttron_home)
-    try:
-        users = get_users(ssl_auth=False)
-        users.remove('guest')
-        users_to_remove = []
-
-        # Delete all the users using virtual host
-        for user in users_to_remove:
-            delete_user(user)
-    except KeyError as e:
-        return

--- a/volttrontesting/fixtures/rmq_test_setup.py
+++ b/volttrontesting/fixtures/rmq_test_setup.py
@@ -1,0 +1,100 @@
+import os
+import yaml
+import requests
+
+from volttron.platform import instance_setup, get_home
+from volttron.platform.agent.utils import store_message_bus_config
+from volttron.utils.rmq_mgmt import get_users, delete_user, delete_vhost, delete_exchange
+from volttron.utils.rmq_setup import stop_rabbit
+
+
+HOME = os.environ.get('HOME')
+VOLTTRON_INSTANCE_NAME = 'volttron_test'
+
+rabbitmq_config = {
+    'host': 'localhost',
+    'certificate-data': {
+        'country': 'US',
+        'state': 'test-state',
+        'location': 'test-location',
+        'organization': 'test-organization',
+        'organization-unit': 'test-team',
+        'common-name': '{}_root_ca'.format(VOLTTRON_INSTANCE_NAME),
+    },
+    'virtual-host': 'volttron_test',
+    'amqp-port': 5672,
+    'amqp-port-ssl': 5671,
+    'mgmt-port': 15672,
+    'mgmt-port-ssl': 15671,
+    'rmq-home': os.path.join(HOME, 'rabbitmq_server/rabbitmq_server-3.7.7')
+}
+
+
+def create_rmq_volttron_setup(vhome=None, ssl_auth=False):
+    """
+        Set-up rabbitmq broker for volttron testing:
+            - Install config and rabbitmq_config.yml in VOLTTRON_HOME
+            - Create virtual host, exchanges, certificates, and users
+            - Start rabbitmq server
+
+    :param vhome: volttron home directory, if None, use default from environment
+    :param ssl_auth: ssl authentication, if true, all users of message queue must authenticate
+    """
+    if vhome:
+        os.environ['VOLTTRON_HOME'] = vhome
+
+    rabbitmq_config['ssl'] = str(ssl_auth)
+    vhome = get_home()
+    instance_setup._install_config_file()
+    vhome_config = os.path.join(vhome, 'rabbitmq_config.yml')
+
+    if not os.path.isfile(vhome_config):
+        with open(vhome_config, 'w') as yml_file:
+            yaml.dump(rabbitmq_config, yml_file, default_flow_style=False)
+
+    store_message_bus_config(message_bus='rmq',
+                             instance_name=VOLTTRON_INSTANCE_NAME)
+
+    instance_setup.setup_rabbitmq_volttron(type='single',
+                                           verbose=False,
+                                           prompt=False)
+
+
+def cleanup_rmq_volttron_setup(vhome=None, ssl_auth=False):
+    """
+        Teardown rabbitmq at test end:
+            - The function is called when DEBUG = False
+            - delete test users, exchanges, and virtual host
+            - user volttron_test-admin is deleted last in order to use its credentials to connect
+            to the management interface
+            - remove rabbitmq.conf
+            - delete_exchange, delete_vhost, and stop_rabbit are controversial step, there maybe reason to keep
+            the server running between tests
+    """
+    if vhome:
+        os.environ['VOLTTRON_HOME'] = vhome
+
+    users_to_remove = get_users()
+    users_to_remove.remove('guest')
+    if ssl_auth:
+        users_to_remove.remove('volttron_test-admin')
+
+    for user in users_to_remove:
+        try:
+            delete_user(user)
+        except (AttributeError, requests.exceptions.HTTPError):
+            pass
+
+    delete_exchange(exchange='undeliverable',
+                    vhost=rabbitmq_config['virtual-host'])
+    delete_exchange(exchange='volttron',
+                    vhost=rabbitmq_config['virtual-host'])
+    delete_vhost(vhost=rabbitmq_config['virtual-host'])
+
+    if ssl_auth:
+        delete_user('volttron_test-admin')
+
+    stop_rabbit(rmq_home=rabbitmq_config['rmq-home'])
+
+    if ssl_auth:
+        os.remove(os.path.join(rabbitmq_config['rmq-home'], 'etc/rabbitmq/rabbitmq.conf'))

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -49,8 +49,8 @@ def get_rand_ipc_vip():
 
 
 def build_wrapper(vip_address, **kwargs):
-    message_bus = kwargs.pop('message_bus', None)
-    wrapper = PlatformWrapper(message_bus)
+    wrapper = PlatformWrapper(message_bus=kwargs.pop('message_bus', None),
+                              ssl_auth=kwargs.pop('ssl_auth', False))
     print('BUILD_WRAPPER: {}'.format(vip_address))
     wrapper.startup_platform(vip_address=vip_address, **kwargs)
     return wrapper
@@ -59,6 +59,7 @@ def build_wrapper(vip_address, **kwargs):
 def cleanup_wrapper(wrapper):
     print('Shutting down instance: {}'.format(wrapper.volttron_home))
     # Shutdown handles case where the platform hasn't started.
+    wrapper.remove_all_agents()
     wrapper.shutdown_platform()
 
 
@@ -66,26 +67,10 @@ def cleanup_wrappers(platforms):
     for p in platforms:
         cleanup_wrapper(p)
 
-@pytest.fixture(scope="module",
-                params=['zmq', 'rmq'])
+@pytest.fixture(scope="module")
 def volttron_instance1(request):
     print("building instance 1")
-
-    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
-
-    def cleanup():
-        cleanup_wrapper(wrapper)
-
-    request.addfinalizer(cleanup)
-    return wrapper
-
-
-@pytest.fixture(scope="module",
-                params=['zmq', 'rmq'])
-def volttron_instance2(request):
-    print("building instance 2")
-
-    wrapper = build_wrapper(get_rand_vip(), message_bus=request.param)
+    wrapper = build_wrapper(get_rand_vip())
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -95,9 +80,25 @@ def volttron_instance2(request):
 
 
 @pytest.fixture(scope="module")
+def volttron_instance2(request):
+    print("building instance 2")
+    wrapper = build_wrapper(get_rand_vip())
+
+    def cleanup():
+        cleanup_wrapper(wrapper)
+
+    request.addfinalizer(cleanup)
+    return wrapper
+
+
+@pytest.fixture(scope="module",
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance_msgdebug(request):
     print("building msgdebug instance")
-    wrapper = build_wrapper(get_rand_vip(), msgdebug=True)
+    wrapper = build_wrapper(get_rand_vip(),
+                            msgdebug=True,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -128,7 +129,8 @@ def volttron_instance1_web(request):
     print("building instance 1 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address)
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -142,7 +144,8 @@ def volttron_instance2_web(request):
     print("building instance 2 (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address)
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -150,12 +153,16 @@ def volttron_instance2_web(request):
     request.addfinalizer(cleanup)
     return wrapper
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module",
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance_module_web(request):
     print("building module instance (using web)")
     address = get_rand_vip()
     web_address = "http://{}".format(get_rand_ip_and_port())
-    wrapper = build_wrapper(address, bind_web_address=web_address)
+    wrapper = build_wrapper(address,
+                            bind_web_address=web_address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         cleanup_wrapper(wrapper)
@@ -169,21 +176,23 @@ def volttron_instance_module_web(request):
 # Use this fixture when you want a single instance of volttron platform for
 # test
 @pytest.fixture(scope="module",
-                params=['zmq', 'rmq'])
+                params=[('zmq', False), ('rmq', True)])
 def volttron_instance(request):
     """Fixture that returns a single instance of volttron platform for testing
 
     @param request: pytest request object
     @return: volttron platform instance
     """
+    print("building instance")
     wrapper = None
     address = get_rand_vip()
-
-    wrapper = build_wrapper(address, message_bus=request.param)
-
+    wrapper = build_wrapper(address,
+                            message_bus=request.param[0],
+                            ssl_auth=request.param[1])
 
     def cleanup():
         print('Shutting down instance: {}'.format(wrapper.volttron_home))
+        wrapper.remove_all_agents()
         wrapper.shutdown_platform()
 
     request.addfinalizer(cleanup)


### PR DESCRIPTION
Certain fixtures now execute pytests with ZMQ broker, RMQ/no-SSL broker, and RMQ/SSL broker.
Install erlang (for use by RabbitMQ) in run-tests.sh so that travis will be able to use it.
When travis runs bootstrap.py, include a --rabbitmq flag so that it will be installed.
No support at this time for multiplatform testing with RMQ broker.
Temporary edit to rmq_mgmt.py: avoid reuse of stale global variables.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shwethanidd%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1786%23issuecomment-418443891%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-09-04T17%3A02%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20test%20the%20errors%20and%20find%20a%20solution%20consulting%20others%20in%20the%20team%22%2C%20%22created_at%22%3A%20%222018-09-04T17%3A03%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/19616893%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shwethanidd%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1786%23issuecomment-418443891%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1786%23issuecomment-418444191%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shwethanidd'><img src='https://avatars2.githubusercontent.com/u/19616893?v=4' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1786#issuecomment-418443891'>General Comment</a></b>
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> :shipit:
- <a href='https://github.com/shwethanidd'><img border=0 src='https://avatars2.githubusercontent.com/u/19616893?v=4' height=16 width=16></a> I'll test the errors and find a solution consulting others in the team


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1786?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1786?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1786?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1786'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>