### PR TITLE
VolttronCentral: fix missing Performance metric list issue

### DIFF
--- a/services/core/VolttronCentral/volttroncentral/platforms.py
+++ b/services/core/VolttronCentral/volttroncentral/platforms.py
@@ -342,7 +342,7 @@ class PlatformHandler(object):
             # devices and status.
             # ('devices/', self._on_device_message),
             # statistics for showing performance in the ui.
-            ('datalogger/platform/status', self._on_platform_stats),
+            ('status', self._on_platform_stats),
             # iam and configure callbacks
             ('iam/', self._on_platform_message),
             # iam and configure callbacks
@@ -683,11 +683,11 @@ class PlatformHandler(object):
                                                                     expected_prefix)))
 
         # Pull off the "real" topic from the prefix
-        topic = topic[len(expected_prefix):]
+        which_stats = topic[len(expected_prefix):]
+        self._log.debug("WHICH STATS: {}".format(which_stats))
 
         prefix = "datalogger/platform"
-        which_stats = topic[len(prefix)+1:]
-        self._log.debug("WHICH STATS: {}".format(which_stats))
+
         point_list = []
 
         for point, item in message.iteritems():

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -1415,7 +1415,8 @@ volttron-central-serverkey."""
         if self._stat_publish_event is not None:
             self._stat_publish_event.cancel()
 
-        topic = LOGGER(subtopic=self._publish_topic + "/status/cpu")
+        # topic = LOGGER(subtopic=self._publish_topic + "/status/cpu")
+        topic = self._publish_topic + "/status/cpu"
 
         points = {}
 


### PR DESCRIPTION
# Description

Changes to both the VolttronCentralPlatform and VolttronCentral agent were necessary to resolve 
the issue observed on the VolttronCentral web UI (list.performance RPC returns an empty 'performance' list).

VolttronCentralPlatform changes:
- _publish_stats: publish platform 'status/cpu' metrics under the topic:

platforms/vcp-tcp___127_0_0_1_22916/status/cpu

instead of:

datalogger/platforms/vcp-Test_Platform_1/status

(it is my understanding that topics starting with datalogger/* are being used for communication from VolttronCentralAgent to the VolttronCentral web UI and topics starting with platform/* are being used for communication from VolttronCentralPlatform to VoltronCentral)

VolttronCentral changes:
- init: the topic to subscribe to (from VolttronCentralPlatform) was changed to match the topic name now generated by the VolttronCentralPlatform agent)
- _on_platform_stats: ensure that 'which_stats' is assigned to 'status/cpu'

Fixes https://github.com/VOLTTRON/volttron/issues/1812

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: bring up test environment - verify that Performance section is missing
$ . env/bin/activate
$ export VOLTTRON_HOME=~/.volttron4

$ volttron-cfg 

$ vctl status
  AGENT                    IDENTITY            TAG                STATUS          HEALTH
3 listeneragent-3.2        listeneragent-3.2_1 listener           running [12498] GOOD
8 master_driveragent-3.2   platform.driver     master_driver      running [12499] GOOD
b sqlhistorianagent-3.6.1  platform.historian  platform_historian running [12500] GOOD
6 vcplatformagent-4.7      platform.agent      vcp                running [12501] GOOD
4 volttroncentralagent-4.2 volttron.central    vc                 running [12502] GOOD

- [x] Test B: introduce changes to VolttronCentral and VolttronCentralPlatform - verify that Performance section is present

vctl stop --tag vc                                                                                                                                                                              
vctl stop --tag vcp                                                                                                                                                                             
vctl remove --tag vc                                                                                                                                                                            
vctl remove --tag vcp                                                                                                                                                                           
python scripts/install-agent.py -s services/core/VolttronCentralPlatform -c services/core/VolttronCentralPlatform/config -t vcp                                                                 
python scripts/install-agent.py -s services/core/VolttronCentral -c services/core/VolttronCentral/config -t vc                                                                                  
vctl start --tag vcp                                                                                                                                                                            
vctl start --tag vc     

![volttron_central_performance_section](https://user-images.githubusercontent.com/9003123/46262491-fb0faa80-c4b6-11e8-946d-75ecbe50139f.png)

**Test Configuration**:

* Firmware version: Ubuntu 16.04 LTS
* Hardware: 
* Toolchain: Python 2.7.12
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1813?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1813'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>