### PR TITLE
Iterable schedule

### DIFF
--- a/docs/source/devguides/agent_development/Agent-Development-Cheatsheet.rst
+++ b/docs/source/devguides/agent_development/Agent-Development-Cheatsheet.rst
@@ -62,23 +62,34 @@ The easiest way to register a callback is with a function decorator:
 Periodic and Scheduled Function Calls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Functions and agent methods can be registered to be called periodically or scheduled
-to be run at a particular time. Decorators or explicit access to an agent's core.periodic()
-method can be used for this purpose. The latter is especially useful if, for example, a
-decision needs to be made in an agent's onstart method as to whether a periodic call should
-be initialized.
+to run at a particular time using the Core.schedule decorator or by calling an agent's
+core.schedule() method. The latter is especially useful if, for example, a decision
+needs to be made in an agent's onstart method as to whether a call should be scheduled.
 
 .. code-block:: python
 
-    @Core.periodic(t)
-    def function(self, ...):
-        function_body
+    from volttron.platform.scheduling import cron, periodic
+
+    @Core.schedule(t)
+    def function(self):
+        ...
+
+    @Core.schedule(periodic(t))
+    def periodic_function(self):
+        ...
+
+    @Core.schedule(cron('0 1 * * *'))
+    def cron_function(self):
+       ...
 
 or
 
 .. code-block:: python
 
     # inside some agent method
-    self.core.periodic(t, function)
+    self.core.schedule(t, function)
+    self.core.schedule(periodic(t), periodic_function)
+    self.core.schedule(cron('0 1 * * *'), cron_function)
 
 
 Subsystem

--- a/examples/CAgent/c_agent/agent.py
+++ b/examples/CAgent/c_agent/agent.py
@@ -47,6 +47,7 @@ import os
 from volttron.platform.vip.agent import Agent, Core, PubSub, compat
 from volttron.platform.agent import utils
 from volttron.platform.messaging import headers as headers_mod
+from volttron.platform.scheduling import periodic
 
 __docformat__ = 'reStructuredText'
 __version__ = '1.0'
@@ -73,7 +74,7 @@ class CAgent(Agent):
         self.get_water_temperature = self.shared_object.get_water_temperature
         self.get_water_temperature.restype = c_float
 
-    @Core.periodic(PUBLISH_PERIOD)
+    @Core.schedule(periodic(PUBLISH_PERIOD))
     def publish_water_temperature(self):
         """Call the function from the shared object.
         """

--- a/examples/DDSAgent/ddsagent/agent.py
+++ b/examples/DDSAgent/ddsagent/agent.py
@@ -40,6 +40,7 @@ import datetime
 from math import sin, cos, pi
 from volttron.platform.vip.agent import Agent, RPC, Core
 from volttron.platform.agent import utils
+from volttron.platform.scheduling import periodic
 
 # The 'connector' api doesn't come with a nice
 # way to install itself so we have it added
@@ -68,7 +69,7 @@ class DDSAgent(Agent):
             self.writer[typename] = connector.getOutput(publisher_name)
             self.reader[typename] = connector.getInput(subscriber_name)
 
-    @Core.periodic(1)
+    @Core.schedule(periodic(1))
     def publish_demo(self):
         """
         Publish a square that follows a circular path.

--- a/examples/DataCleaner/data_cleaner/agent.py
+++ b/examples/DataCleaner/data_cleaner/agent.py
@@ -43,6 +43,7 @@ import sys
 from volttron.platform.agent import utils
 from volttron.platform.messaging import headers
 from volttron.platform.vip.agent import Agent
+from volttron.platform.scheduling import periodic
 from datetime import datetime, timedelta
 
 _log = logging.getLogger(__name__)
@@ -124,9 +125,9 @@ class DataCleaner(Agent):
         self.points = points
 
         if self.periodic is not None:
-            self.periodic.kill()
+            self.periodic.cancel()
 
-        self.periodic = self.core.periodic(self.period, self.process_points)
+        self.periodic = self.core.schedule(periodic(self.period), self.process_points)
 
     def process_points(self):
         now = utils.get_aware_utc_now()

--- a/examples/ExampleSubscriber/subscriber/subscriber_agent.py
+++ b/examples/ExampleSubscriber/subscriber/subscriber_agent.py
@@ -46,6 +46,7 @@ import sys
 from volttron.platform.vip.agent import Agent, Core, PubSub, compat
 from volttron.platform.agent import utils
 from volttron.platform.messaging import headers as headers_mod
+from volttron.platform.scheduling import periodic
 
 
 
@@ -139,7 +140,7 @@ def subscriber_agent(config_path, **kwargs):
             print(topic)
 #     
         # Demonstrate periodic decorator and settings access
-        @Core.periodic(10)
+        @Core.schedule(periodic(10))
         def lookup_data(self):
             '''
             This method demonstrates how to query the platform historian for data
@@ -168,7 +169,7 @@ def subscriber_agent(config_path, **kwargs):
                 print ("Could not contact historian. Is it running?")
                 print(e)
 
-        @Core.periodic(10)
+        @Core.schedule(periodic(10))
         def pub_fake_data(self):
             ''' This method publishes fake data for use by the rest of the agent.
             The format mimics the format used by VOLTTRON drivers.

--- a/examples/NodeRed/node_red_subscriber.py
+++ b/examples/NodeRed/node_red_subscriber.py
@@ -8,6 +8,7 @@ import gevent
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.vip.agent import Agent, PubSub, Core
 from volttron.platform.agent import utils
+from volttron.platform.scheduling import periodic
 
 from settings import topic_prefixes_to_watch, heartbeat_period, agent_kwargs
 
@@ -27,7 +28,7 @@ class NodeRedSubscriber(Agent):
             self.vip.pubsub.subscribe(peer='pubsub', prefix=prefix, callback=self.onmessage).get(timeout=10)
 
     # Demonstrate periodic decorator and settings access
-    @Core.periodic(heartbeat_period)
+    @Core.schedule(periodic(heartbeat_period))
     def publish_heartbeat(self):
         now = utils.format_timestamp(datetime.utcnow())
         headers = {

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -39,6 +39,7 @@ import logging
 from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.vip.agent import Agent, PubSub, Core
 from volttron.platform.agent import utils
+from volttron.platform.scheduling import periodic
 
 # These are the options that can be set from the settings module.
 from settings import remote_url, topics_prefixes_to_watch, heartbeat_period
@@ -75,7 +76,7 @@ class StandAloneListener(Agent):
                        callback=self.onmessage).get(timeout=5)
 
     # Demonstrate periodic decorator and settings access
-    @Core.periodic(heartbeat_period)
+    @Core.schedule(periodic(heartbeat_period))
     def publish_heartbeat(self):
         '''Send heartbeat message every heartbeat_period seconds.
 

--- a/examples/StandAloneWithAuth/standalonewithauth.py
+++ b/examples/StandAloneWithAuth/standalonewithauth.py
@@ -31,6 +31,7 @@ from gevent.core import callback
 
 from volttron.platform.vip.agent import Agent, Core, RPC
 from volttron.platform.agent import utils
+from volttron.platform.scheduling import periodic
 
 # These are the options that can be set from the settings module.
 from settings import remote_url, topics_prefixes_to_watch, heartbeat_period
@@ -49,7 +50,7 @@ class StandAloneWithAuth(Agent):
     ''' A standalone agent that demonstrates how to use agent authorization'''
 
     # Demonstrate calling methods via RPC
-    @Core.periodic(heartbeat_period)
+    @Core.schedule(periodic(heartbeat_period))
     def call_foo_and_bar(self):
         foo_result = self.vip.rpc.call(IDENTITY, 'foo').get(timeout=5)
         sys.stdout.write('foo returned: {}\n'.format(foo_result))

--- a/examples/WeatherForecastCSV_UW/weatherdata/agent.py
+++ b/examples/WeatherForecastCSV_UW/weatherdata/agent.py
@@ -51,6 +51,7 @@ from volttron.platform.vip.agent import Agent, Core
 from volttron.platform.async import AsyncCall
 from volttron.platform.agent import utils
 from volttron.platform.vip.agent import *
+from volttron.platform.scheduling import periodic
 
 import settings
 
@@ -134,7 +135,7 @@ class WeatherData(Agent):
                 while (now.minute % (poll_time/60) != 0):
                     now=datetime.datetime.now()
                 _log.debug("... Start periodic URL Request")   
-                self.weather = self.core.periodic(poll_time,self.weather_conditions,wait=0)       
+                self.weather = self.core.schedule(periodic(poll_time),self.weather_conditions)
                                     
         
         '''

--- a/services/core/DNP3Agent/tests/MesaTestAgent/testagent/agent.py
+++ b/services/core/DNP3Agent/tests/MesaTestAgent/testagent/agent.py
@@ -34,6 +34,7 @@ import sys
 
 from volttron.platform.agent import utils
 from volttron.platform.vip.agent import Agent, Core, RPC
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class MesaTestAgent(Agent):
         self.vip.pubsub.subscribe(peer='pubsub', prefix=self.point_topic, callback=self.receive_point_value)
         self.vip.pubsub.subscribe(peer='pubsub', prefix=self.function_topic, callback=self.receive_function)
         self.vip.pubsub.subscribe(peer='pubsub', prefix=self.outstation_status_topic, callback=self.receive_status)
-        self.core.periodic(RPC_INTERVAL_SECS, self.issue_rpcs)
+        self.core.schedule(periodic(RPC_INTERVAL_SECS), self.issue_rpcs)
 
     @staticmethod
     def receive_point_value(peer, sender, bus, topic, headers, point_value):

--- a/services/core/ExternalData/external_data/agent.py
+++ b/services/core/ExternalData/external_data/agent.py
@@ -55,6 +55,7 @@ from volttron.platform.messaging.utils import Topic
 from volttron.platform.vip.agent import Agent, Core
 from volttron.platform.agent import utils
 from volttron.platform.messaging import headers as headers_mod
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 __author__ = 'Kyle Monson'
@@ -89,7 +90,7 @@ class ExternalData(Agent):
         self.default_user = default_user
         self.default_password = default_password
 
-        self.periodic_greenlet = None
+        self.periodic = None
 
         self.default_config = {"interval": interval,
                                "global_topic_prefix": global_topic_prefix,
@@ -149,10 +150,10 @@ class ExternalData(Agent):
             _log.error("Error setting scrape interval, reverting to default of 300 seconds")
             interval = 300.0
 
-        if self.periodic_greenlet is not None:
-            self.periodic_greenlet.kill()
+        if self.periodic is not None:
+            self.periodic.cancel()
 
-        self.periodic_greenlet = self.core.periodic(interval, self._publish_data)
+        self.periodic = self.core.schedule(periodic(interval), self._publish_data)
 
 
     def _publish_data(self):

--- a/services/core/MarketServiceAgent/market_service/director.py
+++ b/services/core/MarketServiceAgent/market_service/director.py
@@ -39,6 +39,7 @@
 import logging
 import gevent
 from volttron.platform.agent import utils
+from volttron.platform.scheduling import periodic
 
 _log = logging.getLogger(__name__)
 utils.setup_logging()
@@ -53,7 +54,7 @@ class Director(object):
     def start(self, sender):
         _log.debug("Starting Director for MarketServiceAgent")
         self.sender = sender
-        self.sender.core.periodic(self.market_period, self._trigger)
+        self.sender.core.schedule(periodic(self.market_period), self._trigger)
 
     def _trigger(self):
         _log.debug("Trigger market period in Director for MarketServiceAgent")

--- a/services/core/MongodbHistorian/mongodb/historian.py
+++ b/services/core/MongodbHistorian/mongodb/historian.py
@@ -61,6 +61,7 @@ from volttron.platform.agent.base_historian import BaseHistorian
 from volttron.platform.agent.utils import get_aware_utc_now
 from volttron.platform.dbutils import mongoutils
 from volttron.platform.vip.agent import Core
+from volttron.platform.scheduling import periodic
 from volttron.utils.docs import doc_inherit
 
 try:
@@ -240,9 +241,10 @@ class MongodbHistorian(BaseHistorian):
         _log.debug("In on start method. scheduling periodic call to rollup "
                    "data")
         if not self._readonly:
-            self.core.periodic(self.periodic_rollup_frequency,
-                               self.periodic_rollup,
-                               wait=self.periodic_rollup_initial_wait)
+            delay = timedelta(seconds=self.periodic_rollup_initial_wait)
+            self.core.schedule(periodic(self.periodic_rollup_frequency,
+                                        start=delay),
+                               self.periodic_rollup)
 
     def periodic_rollup(self):
         _log.info("periodic attempt to do hourly and daily rollup.")

--- a/services/core/OpenADRVenAgent/openadrven/agent.py
+++ b/services/core/OpenADRVenAgent/openadrven/agent.py
@@ -63,6 +63,7 @@ from volttron.platform.agent import utils
 from volttron.platform.agent.utils import format_timestamp
 from volttron.platform.messaging import topics, headers
 from volttron.platform.vip.agent import Agent, Core, RPC
+from volttron.platform.scheduling import periodic
 
 from oadr_builder import *
 from oadr_extractor import *
@@ -352,7 +353,7 @@ class OpenADRVenAgent(Agent):
             self.send_oadr_create_party_registration()
         else:
             # Schedule an hourly database-cleanup task.
-            self.core.periodic(60 * 60, self.telemetry_cleanup)
+            self.core.schedule(periodic(60 * 60), self.telemetry_cleanup)
 
             # Populate the caches with all of the database's events and reports that are active.
             for event in self._get_events():
@@ -373,7 +374,7 @@ class OpenADRVenAgent(Agent):
                     self.send_oadr_register_report()
             except Exception, err:
                 _log.error('Error in agent startup: {}'.format(err), exc_info=True)
-            self.core.periodic(PROCESS_LOOP_FREQUENCY_SECS, self.main_process_loop)
+            self.core.schedule(periodic(PROCESS_LOOP_FREQUENCY_SECS), self.main_process_loop)
 
     def main_process_loop(self):
         """

--- a/services/core/OpenADRVenAgent/test/ControlAgentSim/controlagentsim/agent.py
+++ b/services/core/OpenADRVenAgent/test/ControlAgentSim/controlagentsim/agent.py
@@ -49,6 +49,7 @@ import sys
 from volttron.platform.agent import utils
 from volttron.platform.vip.agent import Agent, Core, RPC
 from volttron.platform.messaging import topics
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -141,7 +142,7 @@ class ControlAgentSim(Agent):
         self.vip.pubsub.subscribe(peer='pubsub', prefix=topics.OPENADR_EVENT, callback=self.receive_event)
         self.vip.pubsub.subscribe(peer='pubsub', prefix=topics.OPENADR_STATUS, callback=self.receive_status)
 
-        self.core.periodic(self.report_interval_secs, self.issue_rpcs)
+        self.core.schedule(periodic(self.report_interval_secs), self.issue_rpcs)
 
     def issue_rpcs(self):
         """Periodically issue RPCs, including report_sample_telemetry, to the VEN agent."""

--- a/services/ops/AgentWatcher/watcher/agent.py
+++ b/services/ops/AgentWatcher/watcher/agent.py
@@ -41,6 +41,7 @@ import logging
 from volttron.platform.vip.agent import Agent, Core
 from volttron.platform.agent import utils
 from volttron.platform.messaging.health import Status, STATUS_BAD
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class AgentWatcher(Agent):
 
     @Core.receiver('onstart')
     def onstart(self, sender, **kwargs):
-        self.core.periodic(self.check_period, self.watch_agents)
+        self.core.schedule(periodic(self.check_period), self.watch_agents)
 
     def watch_agents(self):
         peerlist = self.vip.peerlist().get()

--- a/services/ops/FailoverAgent/failover/agent.py
+++ b/services/ops/FailoverAgent/failover/agent.py
@@ -49,6 +49,7 @@ from volttron.platform.keystore import KnownHostsStore
 from volttron.platform.messaging.health import Status, STATUS_BAD, STATUS_GOOD
 from volttron.platform.vip.agent import Agent, Core, PubSub, Unreachable
 from volttron.platform.vip.agent.connection import Connection
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ class FailoverAgent(Agent):
         connected = self.heartbeat.is_connected()
         _log.debug("is connected to remote instance: {}".format(connected))
 
-        def periodic():
+        def heartbeat():
             try:
                 self.heartbeat.publish('heartbeat/{}'.format(self.agent_id))
                 self.last_connected = self.timestamp()
@@ -118,8 +119,8 @@ class FailoverAgent(Agent):
                     self.heartbeat = self.build_connection()
                     self.last_connected = self.timestamp()
 
-        self.core.periodic(self.heartbeat_period, periodic)
-        self.core.periodic(1, self.check_pulse)
+        self.core.schedule(periodic(self.heartbeat_period), heartbeat)
+        self.core.schedule(periodic(1), self.check_pulse)
 
     def timestamp(self):
         return time.mktime(datetime.datetime.now().timetuple())

--- a/services/ops/TopicWatcher/topic_watcher/agent.py
+++ b/services/ops/TopicWatcher/topic_watcher/agent.py
@@ -47,6 +47,7 @@ from volttron.platform.agent import utils
 from volttron.platform.messaging.health import Status, STATUS_BAD
 from volttron.platform.vip.agent import Agent, Core, RPC
 from volttron.platform.agent.utils import get_aware_utc_now
+from volttron.platform.scheduling import periodic
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -387,7 +388,7 @@ class AlertGroup(Agent):
                              "alert agent configuration".format(parts))
 
 
-    @Core.periodic(1)
+    @Core.schedule(periodic(1))
     def decrement_ttl(self):
         """Periodic call
 

--- a/volttron/platform/agent/cron.py
+++ b/volttron/platform/agent/cron.py
@@ -1,0 +1,5 @@
+__import__('warnings').warn(
+    'Module {} is deprecated in favor of volttron.platform.scheduling '
+    'and will be removed in a future version.'.format( __name__),
+    DeprecationWarning)
+from volttron.platform.scheduling import cron as schedule, parse_cron_string

--- a/volttron/platform/scheduling.py
+++ b/volttron/platform/scheduling.py
@@ -46,7 +46,7 @@ from itertools import chain, count, cycle
 import re
 
 
-__all__ = ['schedule']
+__all__ = ['cron']
 
 __author__ = 'Brandon Carpenter <brandon.carpenter@pnnl.gov>'
 __copyright__ = 'Copyright (c) 2016, Battelle Memorial Institute'
@@ -177,7 +177,7 @@ def parse_cron_string(cron_string):
             _coallesce_ranges('weekday', weekday, 0, 7, _translate_weekday))
 
 
-def schedule(cron_string, start=None, stop=None, second=0):
+def cron(cron_string, start=None, stop=None, second=0):
     '''Return a schedule generator from a cron-style string.
 
     cron_string is a cron-style time expression consisting of five

--- a/volttron/platform/vip/agent/__init__.py
+++ b/volttron/platform/vip/agent/__init__.py
@@ -100,7 +100,6 @@ class Agent(object):
         self.vip = Agent.Subsystems(self, self.core, heartbeat_autostart,
                                     heartbeat_period, enable_store, enable_web,
                                     enable_channel, enable_fncs)
-        self.core.setup()
         self.vip.rpc.export(self.core.version, 'agent.version')
 
 

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -49,6 +49,7 @@ import threading
 import time
 import urlparse
 import uuid
+import warnings
 import weakref
 import signal
 
@@ -372,6 +373,11 @@ class BasicCore(object):
 
     @dualmethod
     def periodic(self, period, func, args=None, kwargs=None, wait=0):
+        warnings.warn(
+            'Use of the periodic() method is deprecated in favor of the '
+            'schedule() method with the periodic() generator. This '
+            'method will be removed in a future version.',
+            DeprecationWarning)
         greenlet = Periodic(period, args, kwargs, wait).get(func)
         self.spawned_greenlets.add(greenlet)
         greenlet.start()
@@ -379,6 +385,11 @@ class BasicCore(object):
 
     @periodic.classmethod
     def periodic(cls, period, args=None, kwargs=None, wait=0):  # pylint: disable=no-self-argument
+        warnings.warn(
+            'Use of the periodic() decorator is deprecated in favor of '
+            'the schedule() decorator with the periodic() generator. '
+            'This decorator will be removed in a future version.',
+            DeprecationWarning)
         return Periodic(period, args, kwargs, wait)
 
     @classmethod

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -39,7 +39,6 @@
 from __future__ import absolute_import, print_function
 
 from contextlib import contextmanager
-from datetime import datetime
 from errno import ENOENT
 import heapq
 import inspect
@@ -191,15 +190,12 @@ class BasicCore(object):
             periodics.extend(
                 periodic.get(member) for periodic in annotations(
                     member, list, 'core.periodics'))
-            self._schedule.extend(
-                (deadline, ScheduledEvent(member, args, kwargs))
-                for deadline, args, kwargs in
-                annotations(member, list, 'core.schedule'))
+            for deadline, args, kwargs in annotations(member, list, 'core.schedule'):
+                self.schedule(deadline, member, *args, **kwargs)
             for name in annotations(member, set, 'core.signals'):
                 findsignal(self, owner, name).connect(member, owner)
 
         inspect.getmembers(owner, setup)
-        heapq.heapify(self._schedule)
 
         def start_periodics(sender, **kwargs):  # pylint: disable=unused-argument
             for periodic in periodics:
@@ -227,6 +223,7 @@ class BasicCore(object):
     def run(self, running_event=None):  # pylint: disable=method-hidden
         '''Entry point for running agent.'''
 
+        self._schedule_event = gevent.event.Event()
         self.setup()
         self.greenlet = current = gevent.getcurrent()
 
@@ -264,7 +261,6 @@ class BasicCore(object):
                     cur.link(lambda glt: greenlet.kill())
 
         self._stop_event = stop = gevent.event.Event()
-        self._schedule_event = gevent.event.Event()
         self._async = gevent.get_hub().loop.async()
         self._async.start(handle_async)
         current.link(lambda glt: self._async.stop())
@@ -276,9 +272,10 @@ class BasicCore(object):
         loop = looper.next()
         if loop:
             self.spawned_greenlets.add(loop)
-        scheduler = gevent.spawn(schedule_loop)
+        scheduler = gevent.Greenlet(schedule_loop)
         if loop:
             loop.link(lambda glt: scheduler.kill())
+        self.onstart.connect(lambda *_, **__: scheduler.start())
         if not self.delay_onstart_signal:
             self.onstart.sendby(self.link_receiver, self)
         if not self.delay_running_event_set:
@@ -394,11 +391,40 @@ class BasicCore(object):
 
     @dualmethod
     def schedule(self, deadline, func, *args, **kwargs):
-        deadline = utils.get_utc_seconds_from_epoch(deadline)
         event = ScheduledEvent(func, args, kwargs)
-        heapq.heappush(self._schedule, (deadline, event))
-        self._schedule_event.set()
+        try:
+            it = iter(deadline)
+        except TypeError:
+            self._schedule_callback(deadline, event)
+        else:
+            self._schedule_iter(it, event)
         return event
+
+    def _schedule_callback(self, deadline, callback):
+        deadline = utils.get_utc_seconds_from_epoch(deadline)
+        heapq.heappush(self._schedule, (deadline, callback))
+        self._schedule_event.set()
+
+    def _schedule_iter(self, it, event):
+        def wrapper():
+            if event.canceled:
+                event.finished = True
+                return
+            try:
+                deadline = next(it)
+            except StopIteration:
+                event.function(*event.args, **event.kwargs)
+                event.finished = True
+            else:
+                self._schedule_callback(deadline, wrapper)
+                event.function(*event.args, **event.kwargs)
+
+        try:
+            deadline = next(it)
+        except StopIteration:
+            event.finished = True
+        else:
+            self._schedule_callback(deadline, wrapper)
 
     @schedule.classmethod
     def schedule(cls, deadline, *args, **kwargs):  # pylint: disable=no-self-argument

--- a/volttron/platform/vip/agent/example.py
+++ b/volttron/platform/vip/agent/example.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 import gevent
 
 from volttron.platform.vip.agent import *
+from volttron.platform.scheduling import periodic
 
 
 def meh():
@@ -18,7 +19,7 @@ class ExampleAgent(Agent):
         self.vip.rpc.export(meh)
         self.vip.pubsub.add_bus('')
         self.core.onfinish.connect(self.finish)
-        self.core.periodic(5, self.saybye, wait=None)
+        self.core.schedule(periodic(5), self.saybye)
 
     @Core.receiver('onstart')
     def starting(self, sender, **kwargs):
@@ -38,7 +39,7 @@ class ExampleAgent(Agent):
     def finish(self, sender, **kwargs):
         print('agent finished')
 
-    @Core.periodic(3)
+    @Core.schedule(periodic(3))
     def sayhi(self):
         print('hello')
 

--- a/volttron/platform/vip/agent/subsystems/heartbeat.py
+++ b/volttron/platform/vip/agent/subsystems/heartbeat.py
@@ -44,6 +44,7 @@ from .base import SubsystemBase
 from volttron.platform.messaging.headers import TIMESTAMP
 from volttron.platform.agent.utils import (get_aware_utc_now,
                                            format_timestamp)
+from volttron.platform.scheduling import periodic
 
 """The heartbeat subsystem adds an optional periodic publish to all agents.
 Heartbeats can be started with agents and toggled on and off at runtime.
@@ -84,7 +85,7 @@ class Heartbeat(SubsystemBase):
         Starts an agent's heartbeat.
         """
         if not self.enabled:
-            self.greenlet = self.core().periodic(self.period, self.publish)
+            self.scheduled = self.core().schedule(periodic(self.period), self.publish)
             self.enabled = True
 
     def start_with_period(self, period):
@@ -103,7 +104,7 @@ class Heartbeat(SubsystemBase):
         Stop an agent's heartbeat.
         """
         if self.enabled:
-            self.greenlet.kill()
+            self.scheduled.cancel()
             self.enabled = False
 
     def restart(self):


### PR DESCRIPTION
# Description

Adds the ability to pass iterable objects to the core schedule decorator and associated method (dualmethod) as the deadline parameter. The iterable should yield datetime objects in increasing order and the scheduled function will be executed at the first time and automatically rescheduled at each execution, using the next time in the iterator. A new periodic() generator is added to use with the updated schedule functions, obsoleting the periodic decorator and associated method, which are now marked as deprecated.

Fixes #1823 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Functionality was tested using a simple agent that schedules simple tasks using cron.schedule() and periodic() generators. The full suite of CI tests was also successfully run.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-431985364%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-432335949%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-432354563%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-432444710%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-432457805%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1827%23issuecomment-431985364%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40hashstat%20This%20is%20good%20stuff.%20I%27m%20already%20thinking%20of%20ways%20to%20use%20this%20to%20clean%20up%20the%20master%20driver%20and%20actuator.%5Cr%5Cn%5Cr%5CnIf%20no%20one%20is%20using%20cron%20we%20should%20take%20advantage%20of%20this%20opportunity%20to%20move%20it%20to%20vip.agent.%20We%20are%20dropping%20support%20%20for%20pre%20VOLTTRON%203%20agents.%20Most%20of%20those%20imports%20remain%20in%20volttron.platform.agent%20due%20to%20momentum.%20Eventually%20we%27ll%20move%20them%20all%20out%20and%20put%20links%20to%20new%20vip.agent%20imports%20with%20a%20warning.%5Cr%5Cn%5Cr%5CnI%27ll%20let%20you%20decide%20if%20you%20want%20to%20bother%20with%20that%20and%20then%20I%27ll%20pull%20this%20in.%20%5Cr%5Cn%5Cr%5CnAlso%2C%20the%20tests%20aren%27t%20running...%20I%27ll%20have%20to%20figure%20that%20one%20out.%22%2C%20%22created_at%22%3A%20%222018-10-22T21%3A03%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kmonson%20said%3A%5Cr%5Cn%3E%20If%20no%20one%20is%20using%20cron%20we%20should%20take%20advantage%20of%20this%20opportunity%20to%20move%20it%20to%20vip.agent.%5Cr%5Cn%5Cr%5Cn%40dmossie%20is%20the%20only%20person%20I%20know%20using%20cron%2C%20and%20just%20recently.%20I%20don%27t%20think%20he%20would%20object%20to%20moving%20the%20module.%5Cr%5Cn%5Cr%5CnPerhaps%20we%20should%20move%20cron%20to%20volttron.platform.scheduling%2C%20renaming%20schedule%28%29%20to%20cron%28%29%2C%20and%20then%20move%20periodic%28%29%20from%20vip.core%20into%20scheduling.%20These%20are%2C%20after%20all%2C%20just%20datetime%20generators%20and%20not%20vip-specific.%22%2C%20%22created_at%22%3A%20%222018-10-23T17%3A10%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1288789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hashstat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20true.%20Go%20for%20it.%20Just%20make%20sure%20you%20don%27t%20break%20backwards%20compatibility%20for%20everyone%20else.%22%2C%20%22created_at%22%3A%20%222018-10-23T17%3A59%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kmonson%20Changes%20are%20in.%20This%20should%20be%20completely%20backward%20compatible.%20I%20even%20left%20a%20cron%20module%20in%20the%20original%20location%2C%20but%20marked%20it%20deprecated.%22%2C%20%22created_at%22%3A%20%222018-10-23T22%3A28%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1288789%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hashstat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20doing%20this%20is%20a%20great%20idea.%20My%20agent%20is%20using%20cron%20but%20I%20am%20happy%20to%20move%20it%20to%20this%20new%20functionality%20once%20it%20is%20finalized%20and%20available.%20Thanks%20guys%21%22%2C%20%22created_at%22%3A%20%222018-10-23T23%3A29%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/30665550%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dmossie%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1827#issuecomment-431985364'>General Comment</a></b>
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> @hashstat This is good stuff. I'm already thinking of ways to use this to clean up the master driver and actuator.
If no one is using cron we should take advantage of this opportunity to move it to vip.agent. We are dropping support  for pre VOLTTRON 3 agents. Most of those imports remain in volttron.platform.agent due to momentum. Eventually we'll move them all out and put links to new vip.agent imports with a warning.
I'll let you decide if you want to bother with that and then I'll pull this in.
Also, the tests aren't running... I'll have to figure that one out.
- <a href='https://github.com/hashstat'><img border=0 src='https://avatars1.githubusercontent.com/u/1288789?v=4' height=16 width=16></a> @kmonson said:
> If no one is using cron we should take advantage of this opportunity to move it to vip.agent.
@dmossie is the only person I know using cron, and just recently. I don't think he would object to moving the module.
Perhaps we should move cron to volttron.platform.scheduling, renaming schedule() to cron(), and then move periodic() from vip.core into scheduling. These are, after all, just datetime generators and not vip-specific.
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> This is true. Go for it. Just make sure you don't break backwards compatibility for everyone else.
- <a href='https://github.com/hashstat'><img border=0 src='https://avatars1.githubusercontent.com/u/1288789?v=4' height=16 width=16></a> @kmonson Changes are in. This should be completely backward compatible. I even left a cron module in the original location, but marked it deprecated.
- <a href='https://github.com/dmossie'><img border=0 src='https://avatars1.githubusercontent.com/u/30665550?v=4' height=16 width=16></a> I think doing this is a great idea. My agent is using cron but I am happy to move it to this new functionality once it is finalized and available. Thanks guys!


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1827?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1827?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1827'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>