### PR TITLE
Use pytest's approx method to compare equality of floats in tests

### DIFF
--- a/services/core/ActuatorAgent/tests/test_actuator_rpc.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_rpc.py
@@ -44,6 +44,7 @@ from datetime import datetime, timedelta
 import gevent
 import gevent.subprocess as subprocess
 import pytest
+from pytest import approx
 from gevent.subprocess import Popen
 from mock import MagicMock
 
@@ -1321,7 +1322,7 @@ def test_revert_point(publish_agent, cancel_schedules):
         'fakedriver0/SampleWritableFloat1',  # Point to set
         test_value  # New value
     ).get(timeout=10)
-    assert result == test_value
+    assert result == approx(test_value)
 
     publish_agent.vip.rpc.call(
         PLATFORM_ACTUATOR,  # Target agent
@@ -1336,7 +1337,7 @@ def test_revert_point(publish_agent, cancel_schedules):
         'fakedriver0/SampleWritableFloat1',  # Point to get
     ).get(timeout=10)
     # Value taken from fake_unit_testing.csv
-    assert result == initial_value
+    assert result == approx(initial_value)
 
 @pytest.mark.actuator
 def test_revert_point_with_point(publish_agent, cancel_schedules):
@@ -1385,7 +1386,7 @@ def test_revert_point_with_point(publish_agent, cancel_schedules):
         'fakedriver0',  # Point to set
         test_value, point='SampleWritableFloat1'  # New value
     ).get(timeout=10)
-    assert result == test_value
+    assert result == approx(test_value)
 
     publish_agent.vip.rpc.call(
         PLATFORM_ACTUATOR,  # Target agent
@@ -1400,7 +1401,7 @@ def test_revert_point_with_point(publish_agent, cancel_schedules):
         'fakedriver0', point='SampleWritableFloat1',  # Point to get
     ).get(timeout=10)
     # Value taken from fake_unit_testing.csv
-    assert result == initial_value
+    assert result == approx(initial_value)
 
 @pytest.mark.actuator
 def test_revert_device(publish_agent, cancel_schedules):
@@ -1449,7 +1450,7 @@ def test_revert_device(publish_agent, cancel_schedules):
         'fakedriver0/SampleWritableFloat1',  # Point to set
         test_value  # New value
     ).get(timeout=10)
-    assert result == test_value
+    assert result == approx(test_value)
 
     publish_agent.vip.rpc.call(
         PLATFORM_ACTUATOR,  # Target agent
@@ -1464,7 +1465,7 @@ def test_revert_device(publish_agent, cancel_schedules):
         'fakedriver0/SampleWritableFloat1',  # Point to get
     ).get(timeout=10)
     # Value taken from fake_unit_testing.csv
-    assert result == initial_value
+    assert result == approx(initial_value)
 
 
 @pytest.mark.actuator
@@ -1858,7 +1859,7 @@ def test_set_value_no_lock(publish_agent, volttron_instance1):
             'fakedriver0/SampleWritableFloat1',  # Point to set
             6.5  # New value
         ).get(timeout=10)
-        assert result == 6.5
+        assert result == approx(6.5)
 
     finally:
         publish_agent.vip.rpc.call(

--- a/services/core/DataMover/tests/test_datamover.py
+++ b/services/core/DataMover/tests/test_datamover.py
@@ -42,6 +42,7 @@ from datetime import datetime, timedelta
 
 import gevent
 import pytest
+from pytest import approx
 
 from volttron.platform import get_services_core
 from volttron.platform.agent import PublishMixin
@@ -219,7 +220,7 @@ def test_devices_topic(publish_agent, query_agent):
     assert (len(result['values']) == 1)
     (time1_date, time1_time) = time1.split(" ")
     assert (result['values'][0][0] == time1_date + 'T' + time1_time + '+00:00')
-    assert (result['values'][0][1] == oat_reading)
+    assert (result['values'][0][1] == approx(oat_reading))
     assert set(result['metadata'].items()) == set(float_meta.items())
 
 
@@ -388,7 +389,7 @@ def test_analysis_topic(publish_agent, query_agent):
     if now_time[-1:] == 'Z':
         now_time = now_time[:-1]
     assert (result['values'][0][0] == now_date + 'T' + now_time + '+00:00')
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -450,7 +451,7 @@ def test_analysis_topic_no_header(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -515,7 +516,7 @@ def test_log_topic(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -566,7 +567,7 @@ def test_log_topic_no_header(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian

--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -5,6 +5,7 @@ import tempfile
 
 import gevent
 import pytest
+from pytest import approx
 
 from volttron.platform import get_services_core
 from volttron.platform.agent import json as jsonapi
@@ -13,7 +14,7 @@ from volttron.platform.messaging import headers as headers_mod
 
 from volttrontesting.utils.platformwrapper import build_vip_address
 
-BASE_FORWARD_CONFIG = {
+BASE_FORWARD_CONqqqFIG = {
     "agentid": "forwarder1",
     "destination-vip": None
 }
@@ -114,4 +115,4 @@ def test_reconnect_forwarder(get_volttron_instances):
         do_publish(publisher)
 
     for i in range(len(publishedmessages)):
-        assert allforwardedmessage[i] == publishedmessages[i]
+        assert allforwardedmessage[i] == approx(publishedmessages[i])

--- a/services/core/ForwardHistorian/tests/test_forward_historian.py
+++ b/services/core/ForwardHistorian/tests/test_forward_historian.py
@@ -14,7 +14,7 @@ from volttron.platform.messaging import headers as headers_mod
 
 from volttrontesting.utils.platformwrapper import build_vip_address
 
-BASE_FORWARD_CONqqqFIG = {
+BASE_FORWARD_CONFIG = {
     "agentid": "forwarder1",
     "destination-vip": None
 }

--- a/services/core/ForwardHistorian/tests/test_forwardhistorian.py
+++ b/services/core/ForwardHistorian/tests/test_forwardhistorian.py
@@ -42,6 +42,7 @@ from datetime import datetime, timedelta
 
 import gevent
 import pytest
+from pytest import approx
 
 from volttron.platform import get_services_core
 from volttron.platform.agent import PublishMixin
@@ -216,7 +217,7 @@ def test_devices_topic(publish_agent, query_agent):
     assert (len(result['values']) == 1)
     (time1_date, time1_time) = time1.split(" ")
     assert (result['values'][0][0] == time1_date + 'T' + time1_time + '+00:00')
-    assert (result['values'][0][1] == oat_reading)
+    assert (result['values'][0][1] == approx(oat_reading))
     assert set(result['metadata'].items()) == set(float_meta.items())
 
 
@@ -284,7 +285,7 @@ def test_analysis_topic(publish_agent, query_agent):
     if now_time[-1:] == 'Z':
         now_time = now_time[:-1]
     assert (result['values'][0][0] == now_date + 'T' + now_time + '+00:00')
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -345,7 +346,7 @@ def test_analysis_topic_no_header(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -409,7 +410,7 @@ def test_log_topic(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian
@@ -459,7 +460,7 @@ def test_log_topic_no_header(publish_agent, query_agent):
         order="LAST_TO_FIRST").get(timeout=10)
     print('Query Result', result)
     assert (len(result['values']) == 1)
-    assert (result['values'][0][1] == mixed_reading)
+    assert (result['values'][0][1] == approx(mixed_reading))
 
 
 @pytest.mark.historian

--- a/services/core/InfluxdbHistorian/tests/test_influxdb_historian.py
+++ b/services/core/InfluxdbHistorian/tests/test_influxdb_historian.py
@@ -57,6 +57,7 @@ import pytest
 import gevent
 import json
 import pytz
+from pytest import approx
 from datetime import datetime, timedelta
 from dateutil import parser
 
@@ -369,7 +370,7 @@ def test_publish_to_historian(volttron_instance, influxdb_client):
         for point in rs:
             ts = parser.parse(point['time'])
             ts = format_timestamp(ts)
-            assert point["value"] == expected['data'][ts][topic]
+            assert point["value"] == approx(expected['data'][ts][topic])
 
         # Check for measurement MixedAirTemperature
         query = 'SELECT value FROM mixedairtemperature ' \
@@ -383,7 +384,7 @@ def test_publish_to_historian(volttron_instance, influxdb_client):
         for point in rs:
             ts = parser.parse(point['time'])
             ts = format_timestamp(ts)
-            assert point["value"] == expected['data'][ts][topic]
+            assert point["value"] == approx(expected['data'][ts][topic])
 
         # Check for measurement DamperSignal
         query = 'SELECT value FROM dampersignal ' \
@@ -397,7 +398,7 @@ def test_publish_to_historian(volttron_instance, influxdb_client):
         for point in rs:
             ts = parser.parse(point['time'])
             ts = format_timestamp(ts)
-            assert point["value"] == expected['data'][ts][topic]
+            assert point["value"] == approx(expected['data'][ts][topic])
 
         # Check correctness of 'meta' measurement
         topic_id_map, meta_dicts = influxdbutils.get_all_topic_id_and_meta(influxdb_client)
@@ -527,7 +528,7 @@ def test_publish_with_changed_value_type(volttron_instance, influxdb_client):
         for point in rs:
             ts = parser.parse(point['time'])
             ts = format_timestamp(ts)
-            assert point["value"] == float(expected[ts][topic])
+            assert approx(point["value"]) == float(expected[ts][topic])
             assert point["value_string"] == str(expected[ts][topic])
 
         # Check for measurement MixedAirTemperature
@@ -542,7 +543,7 @@ def test_publish_with_changed_value_type(volttron_instance, influxdb_client):
         for point in rs:
             ts = parser.parse(point['time'])
             ts = format_timestamp(ts)
-            assert point["value"] == float(expected[ts][topic])
+            assert approx(point["value"]) == float(expected[ts][topic])
             assert point["value_string"] == str(expected[ts][topic])
 
         # Check for measurement DamperSignal
@@ -559,7 +560,7 @@ def test_publish_with_changed_value_type(volttron_instance, influxdb_client):
             ts = format_timestamp(ts)
             assert point["value_string"] == str(expected[ts][topic])
             try:
-                assert point["value"] == float(expected[ts][topic])
+                assert approx(point["value"]) == float(expected[ts][topic])
             except ValueError:
                 assert point["value"] is None
 
@@ -663,7 +664,7 @@ def test_query_historian_all_topics(volttron_instance, influxdb_client):
                 timestamp = pair[0]
                 value = float(pair[1])
                 assert timestamp in expected['data']
-                assert value == expected['data'][timestamp][topic]
+                assert approx(value) == expected['data'][timestamp][topic]
 
             # meta should be empty if topic argument is a list
             assert actual['metadata'] == {}
@@ -729,7 +730,7 @@ def test_query_historian_single_topic(volttron_instance, influxdb_client):
             timestamp = pair[0]
             value = float(pair[1])
             assert timestamp in expected['data']
-            assert value == expected['data'][timestamp][topic]
+            assert approx(value) == expected['data'][timestamp][topic]
 
         # Check for correctness of metadata
         assert actual['metadata'] == expected['meta'][topic]
@@ -833,7 +834,7 @@ def test_query_historian_all_topics_with_time(volttron_instance, influxdb_client
                 value = float(pair[1])
 
                 assert timestamp in expected['data']
-                assert value == expected['data'][timestamp][topic]
+                assert approx(value) == expected['data'][timestamp][topic]
 
                 dt = parse_timestamp_string(timestamp)
                 actual_time_list.append(dt)
@@ -1204,9 +1205,9 @@ def test_query_aggregate_without_calendar_period(volttron_instance, influxdb_cli
             elif first_ts + timedelta(hours=12) <= ts < first_ts + timedelta(hours=18) and value < min_3:
                 min_3 = value
 
-        assert min_1 == actual["values"][0][1]
-        assert min_2 == actual["values"][1][1]
-        assert min_3 == actual["values"][2][1]
+        assert min_1 == approx(actual["values"][0][1])
+        assert min_2 == approx(actual["values"][1][1])
+        assert min_3 == approx(actual["values"][2][1])
 
     finally:
         volttron_instance.stop_agent(agent_uuid)

--- a/services/core/SQLHistorian/tests/test_sqlitehistorian.py
+++ b/services/core/SQLHistorian/tests/test_sqlitehistorian.py
@@ -48,6 +48,7 @@ import sys
 from tzlocal import get_localzone
 import gevent
 import pytest
+from pytest import approx
 import re
 import pytz
 
@@ -335,7 +336,7 @@ def test_sqlite_timeout(request, historian, publish_agent, query_agent,
         assert (len(result['values']) == 1)
         (now_date, now_time) = now.split(" ")
         assert result['values'][0][0] == now_date + 'T' + now_time + '+00:00'
-        assert (result['values'][0][1] == oat_reading)
+        assert (result['values'][0][1] == approx(oat_reading))
         assert set(result['metadata'].items()) == set(float_meta.items())
     finally:
         if agent_uuid:


### PR DESCRIPTION
#Description

Travis tests on the ForwardHistorian were sometimes failing because a comparison of floats which were nearly equivalent (off by 1e-16) returned false. The approx method in pytest does an epsilon comparison of floats with eps=1e-6 by default, which is good enough for our purposes, so I used approx within the ForwardHistorian test to compare floats. I also dug through the rest of the services/core dirs to find other places where questionable floats were being compared and used approx on those as well.

##Type of change

Bug fix (non-breaking change which fixes an issue)

#How Has This Been Tested?

I first tested the approx method in a sandbox environment to ensure that it would work appropriately on cases like those one would expect in the ForwardHistorian. I then integrated approx into different test files and ran the them with the changes to make sure that nothing broke.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1828%23discussion_r228606074%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1828%23issuecomment-433483766%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1828%23issuecomment-433483766%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Other%20than%20the%20comment%20I%20left%20this%20looks%20good.%22%2C%20%22created_at%22%3A%20%222018-10-26T17%3A27%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2049c3ad6f8c5a23e8a3848f4fb005d0297a5a298e%20services/core/ForwardHistorian/tests/test_forward_historian.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1828%23discussion_r228606074%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LOLWAT%3F%22%2C%20%22created_at%22%3A%20%222018-10-26T17%3A27%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20services/core/ForwardHistorian/tests/test_forward_historian.py%3AL14-21%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 49c3ad6f8c5a23e8a3848f4fb005d0297a5a298e services/core/ForwardHistorian/tests/test_forward_historian.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1828#discussion_r228606074'>File: services/core/ForwardHistorian/tests/test_forward_historian.py:L14-21</a></b>
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> LOLWAT?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1828#issuecomment-433483766'>General Comment</a></b>
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> Other than the comment I left this looks good.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1828?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1828?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1828'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>