### PR TITLE
influx historian cannot process topic data of record/*

### DIFF
--- a/services/core/InfluxdbHistorian/influx/historian.py
+++ b/services/core/InfluxdbHistorian/influx/historian.py
@@ -239,6 +239,11 @@ class InfluxdbHistorian(BaseHistorian):
                 ts = utils.format_timestamp(row['timestamp'])
                 source = row['source']
                 topic = row['topic']
+
+                # record/* has got wrong format for InfluxDB, only timeseries data
+                if topic.startswith('record/'):
+                    continue
+
                 meta = row['meta']
                 value = row['value']
                 value_string = str(value)


### PR DESCRIPTION
# Description

influx historian cannot handle 'record/*' topic format and raises error when messages are written to 'record/*'. To avoid the error 'record/*' messages are being excluded from handling. No further dependencies.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

String message has been published on 'record/*' in our test installation, no more errors raised.
No unit-tests because fixture 'volttron_instance' is hanging (no response) on OSX installation (known problem?)

# Checklist:

- [ ] My code follows the style guidelines of this project
Where can I find the styleguide?

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1833?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1833'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>