### PR TITLE
Fixes #1834

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -147,20 +147,21 @@ def bootstrap(dest, prompt='(volttron)', version=None, verbose=None):
         def get_version(self):
             """Return the latest version from virtualenv DOAP record."""
             _log.info('Downloading virtualenv package information')
-            default_version = "15.1.0"
+            default_version = "16.0.0"
             url = 'https://pypi.python.org/pypi/virtualenv/json'
-            with contextlib.closing(self._fetch(url)) as response:
-                result = json.load(response)
-                releases_dict = result.get("releases", {})
-                releases = sorted(
-                    [LooseVersion(x) for x in releases_dict.keys()])
-            if releases:
-                _log.info('latest release of virtualenv={}'.format(releases[-1]))
-                return str(releases[-1])
-            else:
-                _log.info("Returning default version of virtualenv "
-                          "({})".format(default_version))
-                return default_version
+            # with contextlib.closing(self._fetch(url)) as response:
+            #     result = json.load(response)
+            #     releases_dict = result.get("releases", {})
+            #     releases = sorted(
+            #         [LooseVersion(x) for x in releases_dict.keys()])
+            # if releases:
+            #     _log.info('latest release of virtualenv={}'.format(releases[-1]))
+            #     return str(releases[-1])
+            # else:
+            #     _log.info("Returning default version of virtualenv "
+            #               "({})".format(default_version))
+            #     return default_version
+            return default_version
 
         def download(self, directory):
             '''Download the virtualenv tarball into directory.'''


### PR DESCRIPTION
# Description

virtualenv 16.1.0 changes the package structure pin virtualenv to 16.0.0

Fixes #1834 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on linux mint
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1835?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1835'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>