### PR TITLE
Add documentation to standalone agent.

### DIFF
--- a/examples/StandAloneListener/settings.py
+++ b/examples/StandAloneListener/settings.py
@@ -23,8 +23,7 @@ _params = {
 	# configuration to enable standalone agent access to volttron instance. Use
 	# command 'vctl auth add' Provide this agent's public key when prompted
 	# for credential.
-	# For more details see
-	# https://volttron.readthedocs.io/en/develop/devguides/walkthroughs/Agent-Authentication-Walkthrough.html
+
 	'agent_public': 'dpu13XKPvGB3XJNVUusCNn2U0kIWcuyDIP5J8mAgBQ0',
 	'agent_secret': 'Hlya-6BvfUot5USdeDHZ8eksDkWgEEHABs1SELmQhMs',
 	

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -28,7 +28,7 @@
 
     4. With a volttron activated shell this script can be run like:
 
-       python test_weather2.py
+       python standalonelistener.py
 
 
     This python script will listen to the defined vip address for specific

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -1,44 +1,45 @@
 '''
 
-    1. Make sure volttron instance is running using tcp address. use vcfg
-    command to configure volttron instance address,.
+    This python script will listen to the defined vip address for specific
+    topics. This script prints all output to standard  out rather than using the
+    logging facilities. This script will also publish a heart beat
+    (which will be returned if listening to the heartbeat topic).
 
-    2. Update settings.py
+    Setup:
+    ~~~~~
 
-    3. Add this standalone agent to volttron auth entry using vctl auth add
-    command. Provide ip of the volttron instance when prompted for address[]:
-    and  provide public key of standalone agent when prompted for
-    credentials[]:
-    For more details see
-    https://volttron.readthedocs.io/en/develop/devguides/walkthroughs/Agent-Authentication-Walkthrough.html
+      1. Make sure volttron instance is running using tcp address. use vcfg
+         command to configure volttron instance address,.
 
-    Example command:
+      2. Update settings.py
 
-    (volttron)[vdev@cs_cbox myvolttron]$ vctl auth add
-    domain []:
-    address []: 127.0.0.1
-    user_id []:
-    capabilities (delimit multiple entries with comma) []:
-    roles (delimit multiple entries with comma) []:
-    groups (delimit multiple entries with comma) []:
-    mechanism [CURVE]:
-    credentials []: GsEq7mIsU6mJ31TN44lQJeGwkJlb6_zbWgRxVo2gUUU
-    comments []:
-    enabled [True]:
+      3. Add this standalone agent to volttron auth entry using vctl auth add
+         command. Provide ip of the volttron instance when prompted for
+         address[]: and  provide public key of standalone agent when prompted
+         for credentials[]:
+         For more details see
+         https://volttron.readthedocs.io/en/develop/devguides/walkthroughs/Agent-Authentication-Walkthrough.html
+
+         Example command:
+
+         .. code-block:: console
+
+         (volttron)[vdev@cs_cbox myvolttron]$ vctl auth add
+         domain []:
+         address []: 127.0.0.1
+         user_id []:
+         capabilities (delimit multiple entries with comma) []:
+         roles (delimit multiple entries with comma) []:
+         groups (delimit multiple entries with comma) []:
+         mechanism [CURVE]:
+         credentials []: GsEq7mIsU6mJ31TN44lQJeGwkJlb6_zbWgRxVo2gUUU
+         comments []:
+         enabled [True]:
 
     4. With a volttron activated shell this script can be run like:
 
        python standalonelistener.py
 
-
-    This python script will listen to the defined vip address for specific
-    topics.
-
-    This script prints all output to standard  out rather than using the
-    logging facilities.
-
-    This script will also publish a heart beat (which will be returned if
-    listening to the heartbeat topic).
 
     Example output to standard out:
 

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -1,11 +1,38 @@
 '''
-        This python script will listen to the defined vip address for specific
-    topics.  The user can modify the settings.py file to set the specific
-    topics to listen to.
 
-    With a volttron activated shell this script can be run like:
+    1. Make sure volttron instance is running using tcp address. use vcfg
+    command to configure volttron instance address,.
 
-       python standalonelistener.py
+    2. Update settings.py
+
+    3. Add this standalone agent to volttron auth entry using vctl auth add
+    command. Provide ip of the volttron instance when prompted for address[]:
+    and  provide public key of standalone agent when prompted for
+    credentials[]:
+    For more details see
+    https://volttron.readthedocs.io/en/develop/devguides/walkthroughs/Agent-Authentication-Walkthrough.html
+
+    Example command:
+
+    (volttron)[vdev@cs_cbox myvolttron]$ vctl auth add
+    domain []:
+    address []: 127.0.0.1
+    user_id []:
+    capabilities (delimit multiple entries with comma) []:
+    roles (delimit multiple entries with comma) []:
+    groups (delimit multiple entries with comma) []:
+    mechanism [CURVE]:
+    credentials []: GsEq7mIsU6mJ31TN44lQJeGwkJlb6_zbWgRxVo2gUUU
+    comments []:
+    enabled [True]:
+
+    4. With a volttron activated shell this script can be run like:
+
+       python test_weather2.py
+
+
+    This python script will listen to the defined vip address for specific
+    topics.
 
     This script prints all output to standard  out rather than using the
     logging facilities.

--- a/examples/StandAloneListener/standalonelistener.py
+++ b/examples/StandAloneListener/standalonelistener.py
@@ -36,9 +36,9 @@
          comments []:
          enabled [True]:
 
-    4. With a volttron activated shell this script can be run like:
+      4. With a volttron activated shell this script can be run like:
 
-       python standalonelistener.py
+         python standalonelistener.py
 
 
     Example output to standard out:


### PR DESCRIPTION
Updated documentation of examples/StandAloneListener agent
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1841%23discussion_r234325487%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1841%23discussion_r234326521%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1841%23discussion_r234327585%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20adced64fd53e1492d621a9e44cdb1721e5be0daa%20examples/StandAloneListener/standalonelistener.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1841%23discussion_r234325487%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20should%20be%20a%20preamble%20before%20starting%20at%201.%22%2C%20%22created_at%22%3A%20%222018-11-16T19%3A40%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222018-11-16T19%3A47%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20examples/StandAloneListener/standalonelistener.py%3AL1-39%22%7D%2C%20%22Pull%20adced64fd53e1492d621a9e44cdb1721e5be0daa%20examples/StandAloneListener/standalonelistener.py%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1841%23discussion_r234326521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22sorry%20fixed%20it.%22%2C%20%22created_at%22%3A%20%222018-11-16T19%3A43%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/16124920%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/schandrika%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20examples/StandAloneListener/standalonelistener.py%3AL1-39%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull adced64fd53e1492d621a9e44cdb1721e5be0daa examples/StandAloneListener/standalonelistener.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1841#discussion_r234325487'>File: examples/StandAloneListener/standalonelistener.py:L1-39</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> There should be a preamble before starting at 1.
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> fixed
- [x] <a href='#crh-comment-Pull adced64fd53e1492d621a9e44cdb1721e5be0daa examples/StandAloneListener/standalonelistener.py 36'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1841#discussion_r234326521'>File: examples/StandAloneListener/standalonelistener.py:L1-39</a></b>
- <a href='https://github.com/schandrika'><img border=0 src='https://avatars2.githubusercontent.com/u/16124920?v=4' height=16 width=16></a> sorry fixed it.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1841?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1841?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1841'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>