### PR TITLE
Develop

### DIFF
--- a/docs/source/core_services/control/PlatformCommands.rst
+++ b/docs/source/core_services/control/PlatformCommands.rst
@@ -160,7 +160,7 @@ volttron-pkg Commands
 .. code-block:: console
 
     usage: volttron-pkg [-h] [-l FILE] [-L FILE] [-q] [-v] [--verboseness LEVEL]
-                        {package,repackage,configure} ...
+                        {install-agent,package,repackage,configure} ...
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -168,8 +168,10 @@ volttron-pkg Commands
     subcommands:
       valid subcommands
 
-      {package,repackage,configure}
+      {install-agent,package,repackage,configure}
                         additional help
+        install-agent       Install an agent from a source file and other
+                        (optional) options.
         package             Create agent package (whl) from a directory or
                         installed agent name.
         repackage           Creates agent package from a currently installed
@@ -182,7 +184,7 @@ enabled):
 .. code-block:: console
 
     usage: volttron-pkg [-h] [-l FILE] [-L FILE] [-q] [-v] [--verboseness LEVEL]
-                        {package,repackage,configure,create_ca,create_cert,sign,verify}
+                        {install-agent,package,repackage,configure,create_ca,create_cert,sign,verify}
                         ...
 
     VOLTTRON packaging and signing utility
@@ -201,8 +203,10 @@ enabled):
     subcommands:
       valid subcommands
 
-      {package,repackage,configure,create_ca,create_cert,sign,verify}
+      {install-agent,package,repackage,configure,create_ca,create_cert,sign,verify}
                             additional help
+        install-agent       Install an agent from a source file and other
+                            (optional) options.
         package             Create agent package (whl) from a directory or
                             installed agent name.
         repackage           Creates agent package from a currently installed

--- a/scripts/install-agent.py
+++ b/scripts/install-agent.py
@@ -264,6 +264,7 @@ if __name__ == '__main__':
                         help="skip a requirements.txt file if it exists.")
 
     opts = parser.parse_args()
+
     agent_source = opts.agent_source
     if not os.path.isdir(agent_source):
         if os.path.isdir(os.path.join(opts.volttron_root, agent_source)):

--- a/scripts/install-agent.py
+++ b/scripts/install-agent.py
@@ -259,12 +259,11 @@ if __name__ == '__main__':
     parser.add_argument("--csv", action='store_true',
                         help="format the standard out output to csv")
     parser.add_argument("--json", action="store_true",
-                        help="format the standard out output to jso")
+                        help="format the standard out output to json")
     parser.add_argument("--skip-requirements", action="store_true",
                         help="skip a requirements.txt file if it exists.")
 
     opts = parser.parse_args()
-    
     agent_source = opts.agent_source
     if not os.path.isdir(agent_source):
         if os.path.isdir(os.path.join(opts.volttron_root, agent_source)):

--- a/volttron/platform/packaging.py
+++ b/volttron/platform/packaging.py
@@ -53,7 +53,7 @@ from wheel.install import WheelFile
 from .packages import *
 from . import config
 from .agent import utils
-from volttron.platform import get_volttron_data, get_address, get_home, get_volttron_root
+from volttron.platform import get_volttron_data
 from volttron.utils.prompt import prompt_response
 
 
@@ -719,62 +719,62 @@ def main(argv=sys.argv):
     whl_path = None
     user_type = None
 
-    #try:
+    try:
 
-    if opts.subparser_name == 'package':
-        whl_path = create_package(opts.agent_directory, wheelhouse=opts.dest, identity=opts.vip_identity)
-    elif opts.subparser_name == 'install-agent':
-        install_args = ['python', 'scripts/install-agent.py']
-        install_args.extend(sys.argv[2:])
-        subprocess.Popen(install_args)
-    elif opts.subparser_name == 'repackage':
-        whl_path = repackage(opts.directory, dest=opts.dest)
-    elif opts.subparser_name == 'configure' :
-        add_files_to_package(opts.package, {'config_file': opts.config_file})
-    elif opts.subparser_name == 'init' :
-        init_agent(opts.directory, opts.module_name, opts.template, opts.silent, opts.identity)
-    else:
-        if auth is not None:
-            try:
-                if opts.subparser_name == 'create_ca':
-                    _create_ca()
-                elif opts.subparser_name == 'verify':
-                    if not os.path.exists(opts.package):
-                        print('Invalid package name {}'.format(opts.package))
-                    verifier = auth.SignedZipPackageVerifier(opts.package)
-                    verifier.verify()
-                    print "Package is verified"
-                else:
-                    user_type = {'admin': opts.admin,
-                              'creator': opts.creator,
-                              'initiator': opts.initiator,
-                              'platform': opts.platform}
-                    if opts.subparser_name == 'sign':
-                        in_args = {
-                                'config_file': opts.config_file,
-                                'user_type': user_type,
-                                'contract': opts.contract,
-                                'certs_dir': opts.certs_dir
-                            }
-                        _sign_agent_package(opts.package, **in_args)
+        if opts.subparser_name == 'package':
+            whl_path = create_package(opts.agent_directory, wheelhouse=opts.dest, identity=opts.vip_identity)
+        elif opts.subparser_name == 'install-agent':
+            install_args = ['python', 'scripts/install-agent.py']
+            install_args.extend(sys.argv[2:])
+            subprocess.Popen(install_args)
+        elif opts.subparser_name == 'repackage':
+            whl_path = repackage(opts.directory, dest=opts.dest)
+        elif opts.subparser_name == 'configure' :
+            add_files_to_package(opts.package, {'config_file': opts.config_file})
+        elif opts.subparser_name == 'init' :
+            init_agent(opts.directory, opts.module_name, opts.template, opts.silent, opts.identity)
+        else:
+            if auth is not None:
+                try:
+                    if opts.subparser_name == 'create_ca':
+                        _create_ca()
+                    elif opts.subparser_name == 'verify':
+                        if not os.path.exists(opts.package):
+                            print('Invalid package name {}'.format(opts.package))
+                        verifier = auth.SignedZipPackageVerifier(opts.package)
+                        verifier.verify()
+                        print "Package is verified"
+                    else:
+                        user_type = {'admin': opts.admin,
+                                  'creator': opts.creator,
+                                  'initiator': opts.initiator,
+                                  'platform': opts.platform}
+                        if opts.subparser_name == 'sign':
+                            in_args = {
+                                    'config_file': opts.config_file,
+                                    'user_type': user_type,
+                                    'contract': opts.contract,
+                                    'certs_dir': opts.certs_dir
+                                }
+                            _sign_agent_package(opts.package, **in_args)
 
-                    elif opts.subparser_name == 'create_cert':
-                        _create_cert(name=opts.name, **user_type)
-            except auth.AuthError as e:
-                _log.error(e.message)
-                #print(e.message)
+                        elif opts.subparser_name == 'create_cert':
+                            _create_cert(name=opts.name, **user_type)
+                except auth.AuthError as e:
+                    _log.error(e.message)
+                    #print(e.message)
 
 
 #         elif opts.subparser_name == 'create_cert':
 #             _create_cert(name=opts.name, **)
-    '''
+
     except AgentPackageError as e:
         _log.error(e.message)
         #print(e.message)
     except Exception as e:
         _log.error(str(e))
         #print e
-    '''
+
 
     if whl_path:
         print("Package created at: {}".format(whl_path))


### PR DESCRIPTION
# Description

Integrated the functionality of scripts/install-agent.py into the vpkg module by adding an 'install-agent' option and an argument parser for that command. When the command is 'install-agent,' vpkg opens a subprocess calling scripts/install-agent.py with all the arguments received by vpkg. Corresponding documentation updates were also made.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

During the coding process and once finished I tested this manually by creating a testbed VOLTTRON instance and running `vpkg install-agent` to install agents, then check `vctl status` to ensure the agent was created and `vctl start` to start it.
Currently working on pytests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1849?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1849'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>