### PR TITLE
Fixed rmq test issues. Updated logic to check rabbitmq status

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -41,4 +41,5 @@ markers =
         alert: Alerter agent tests
         multiplatform: Tests for multiplatforn functionality
         weather: Weather agent tests
+        rmq_pubsub: rmq pubsub test
         ecorithm: Tests associated with ecorithm's agents

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -46,6 +46,7 @@ RabbitMQ setup script to
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import time
 from socket import getfqdn
@@ -335,7 +336,7 @@ trust_store.refresh_interval=0""".format(
     # Stop server, move new config file with ssl params, start server
     stop_rabbit(rmq_config.rmq_home)
 
-    os.rename(os.path.join(vhome, "rabbitmq.conf"),
+    shutil.move(os.path.join(vhome, "rabbitmq.conf"),
               os.path.join(rmq_config.rmq_home,
                            "etc/rabbitmq/rabbitmq.conf"))
     start_rabbit(rmq_config.rmq_home)


### PR DESCRIPTION
Changes - 
updated script that installs dependencies for Rabbit to handle centos 
Updated logic to check rabbitmq status
Added HOME, and LANG to env when starting volttron in platformwrapper so that Rabbitmq will work right

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1851?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1851'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>