### PR TITLE
Fixed topics for BACnet COV publish in driver.py

### DIFF
--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -387,7 +387,7 @@ class DriverAgent(BasicAgent):
                                       message=message)
             #
             if self.publish_breadth_first:
-                self._publish_wrapper(self.breadth_first_topic,
+                self._publish_wrapper(breadth_first_topic,
                                       headers=headers,
                                       message=message)
 

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -378,12 +378,25 @@ class DriverAgent(BasicAgent):
             meta = {point_name: self.meta_data[point_name]}
             message = [results, meta]
 
+            depth_first_topic, breadth_first_topic = self.get_paths_for_point(
+                point_name)
+
             if self.publish_depth_first:
-                self._publish_wrapper(self.all_path_depth,
+                self._publish_wrapper(depth_first_topic,
                                       headers=headers,
                                       message=message)
             #
             if self.publish_breadth_first:
+                self._publish_wrapper(self.breadth_first_topic,
+                                      headers=headers,
+                                      message=message)
+
+            if self.publish_depth_first_all:
+                self._publish_wrapper(self.all_path_depth,
+                                      headers=headers,
+                                      message=message)
+
+            if self.publish_breadth_first_all:
                 self._publish_wrapper(self.all_path_breadth,
                                       headers=headers,
                                       message=message)


### PR DESCRIPTION
Depth/breadth first publishes now publish to the individual point topic.
Depth/breadth first all publishes now publish to the relevant all topic.

fix for one portion of #1852 

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1853?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1853'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>