### PR TITLE
Fixed bacnet cov subscription lifetime always being set to default

### DIFF
--- a/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
+++ b/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
@@ -106,7 +106,7 @@ class Interface(BaseInterface):
 
         # list of points to establish change of value subscriptions with, generated from the registry config
         for point_name in self.cov_points:
-            self.establish_cov_subscription(point_name, DEFAULT_COV_LIFETIME, True)
+            self.establish_cov_subscription(point_name, self.cov_lifetime, True)
 
     def schedule_ping(self):
         if self.scheduled_ping is None:


### PR DESCRIPTION
Changed value used when establishing a cov subscription to the value in the configuration, rather than always using the default value.
2nd part fix for #1852
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1854?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1854'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>