### PR TITLE
Bacnet COV fixes

### DIFF
--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -387,7 +387,7 @@ class DriverAgent(BasicAgent):
                                       message=message)
             #
             if self.publish_breadth_first:
-                self._publish_wrapper(self.breadth_first_topic,
+                self._publish_wrapper(breadth_first_topic,
                                       headers=headers,
                                       message=message)
 

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -374,12 +374,10 @@ class DriverAgent(BasicAgent):
             headers_mod.TIMESTAMP: utcnow_string,
         }
         for point, value in point_values.iteritems():
-            if self.publish_breadth_first_all or self.publish_depth_first_all:
-                results = {point_name: value}
-                meta = {point_name: self.meta_data[point_name]}
-                message = [results, meta]
-            else:
-                message = [value, self.meta_data[point_name]]
+            results = {point_name: value}
+            meta = {point_name: self.meta_data[point_name]}
+            all_message = [results, meta]
+            individual_point_message = [value, self.meta_data[point_name]]
 
             depth_first_topic, breadth_first_topic = self.get_paths_for_point(
                 point_name)
@@ -387,19 +385,19 @@ class DriverAgent(BasicAgent):
             if self.publish_depth_first:
                 self._publish_wrapper(depth_first_topic,
                                       headers=headers,
-                                      message=message)
+                                      message=individual_point_message)
             #
             if self.publish_breadth_first:
                 self._publish_wrapper(breadth_first_topic,
                                       headers=headers,
-                                      message=message)
+                                      message=individual_point_message)
 
             if self.publish_depth_first_all:
                 self._publish_wrapper(self.all_path_depth,
                                       headers=headers,
-                                      message=message)
+                                      message=all_message)
 
             if self.publish_breadth_first_all:
                 self._publish_wrapper(self.all_path_breadth,
                                       headers=headers,
-                                      message=message)
+                                      message=all_message)

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -378,12 +378,25 @@ class DriverAgent(BasicAgent):
             meta = {point_name: self.meta_data[point_name]}
             message = [results, meta]
 
+            depth_first_topic, breadth_first_topic = self.get_paths_for_point(
+                point_name)
+
             if self.publish_depth_first:
-                self._publish_wrapper(self.all_path_depth,
+                self._publish_wrapper(depth_first_topic,
                                       headers=headers,
                                       message=message)
             #
             if self.publish_breadth_first:
+                self._publish_wrapper(self.breadth_first_topic,
+                                      headers=headers,
+                                      message=message)
+
+            if self.publish_depth_first_all:
+                self._publish_wrapper(self.all_path_depth,
+                                      headers=headers,
+                                      message=message)
+
+            if self.publish_breadth_first_all:
                 self._publish_wrapper(self.all_path_breadth,
                                       headers=headers,
                                       message=message)

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -373,9 +373,9 @@ class DriverAgent(BasicAgent):
             headers_mod.DATE: utcnow_string,
             headers_mod.TIMESTAMP: utcnow_string,
         }
-        for value in point_values:
+        for point, value in point_values.iteritems():
             if self.publish_breadth_first_all or self.publish_depth_first_all:
-                results = {point_name: point_values[value]}
+                results = {point_name: value}
                 meta = {point_name: self.meta_data[point_name]}
                 message = [results, meta]
             else:

--- a/services/core/MasterDriverAgent/master_driver/driver.py
+++ b/services/core/MasterDriverAgent/master_driver/driver.py
@@ -374,9 +374,12 @@ class DriverAgent(BasicAgent):
             headers_mod.TIMESTAMP: utcnow_string,
         }
         for value in point_values:
-            results = {point_name: point_values[value]}
-            meta = {point_name: self.meta_data[point_name]}
-            message = [results, meta]
+            if self.publish_breadth_first_all or self.publish_depth_first_all:
+                results = {point_name: point_values[value]}
+                meta = {point_name: self.meta_data[point_name]}
+                message = [results, meta]
+            else:
+                message = [value, self.meta_data[point_name]]
 
             depth_first_topic, breadth_first_topic = self.get_paths_for_point(
                 point_name)

--- a/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
+++ b/services/core/MasterDriverAgent/master_driver/interfaces/bacnet.py
@@ -106,7 +106,7 @@ class Interface(BaseInterface):
 
         # list of points to establish change of value subscriptions with, generated from the registry config
         for point_name in self.cov_points:
-            self.establish_cov_subscription(point_name, DEFAULT_COV_LIFETIME, True)
+            self.establish_cov_subscription(point_name, self.cov_lifetime, True)
 
     def schedule_ping(self):
         if self.scheduled_ping is None:


### PR DESCRIPTION
Updates driver to use the correct configuration/topic combinations when publishing COV messages.
Updates bacnet interface to use the configured COV lifetime rather than always using the default lifetime.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/VOLTTRON/volttron/pull/1855%23discussion_r239547920%22%2C%20%22https%3A//github.com/VOLTTRON/volttron/pull/1855%23discussion_r239555650%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2044732ba303602bdb04658a7e2fe7b3f92877dc61%20services/core/MasterDriverAgent/master_driver/driver.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/VOLTTRON/volttron/pull/1855%23discussion_r239547920%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20message%20is%20wrong%20for%20the%20publish_depth_first%20and%20publish_breadth_first%20publishes.%20The%20results%20are%20not%20supposed%20to%20be%20wrapped%20in%20a%20dictionary%20in%20those%20cases.%20See%20https%3A//github.com/VOLTTRON/volttron/blob/44732ba303602bdb04658a7e2fe7b3f92877dc61/services/core/MasterDriverAgent/master_driver/driver.py%23L272%20for%20what%20is%20expected%20in%20a%20single%20value%20publish.%22%2C%20%22created_at%22%3A%20%222018-12-06T17%3A43%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2049915%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kmonson%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222018-12-06T18%3A05%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/40306657%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jklarson%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20services/core/MasterDriverAgent/master_driver/driver.py%3AL378-403%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 44732ba303602bdb04658a7e2fe7b3f92877dc61 services/core/MasterDriverAgent/master_driver/driver.py 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/VOLTTRON/volttron/pull/1855#discussion_r239547920'>File: services/core/MasterDriverAgent/master_driver/driver.py:L378-403</a></b>
- <a href='https://github.com/kmonson'><img border=0 src='https://avatars3.githubusercontent.com/u/2049915?v=4' height=16 width=16></a> The message is wrong for the publish_depth_first and publish_breadth_first publishes. The results are not supposed to be wrapped in a dictionary in those cases. See https://github.com/VOLTTRON/volttron/blob/44732ba303602bdb04658a7e2fe7b3f92877dc61/services/core/MasterDriverAgent/master_driver/driver.py#L272 for what is expected in a single value publish.


<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1855?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1855?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1855'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>