### PR TITLE
DNP3: send single point 

### DIFF
--- a/services/core/DNP3Agent/dnp3/agent.py
+++ b/services/core/DNP3Agent/dnp3/agent.py
@@ -36,10 +36,7 @@ import logging
 import sys
 
 from volttron.platform.agent import utils
-from volttron.platform.vip.agent import Core
-
 from base_dnp3_agent import BaseDNP3Agent
-from points import DNP3Exception
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -74,11 +71,6 @@ class DNP3Agent(BaseDNP3Agent):
         point_val = super(DNP3Agent, self)._process_point_value(point_value)
         if point_val:
             self.publish_point_value(point_value)
-
-    @Core.receiver('onstart')
-    def onstart(self, sender, **kwargs):
-        """Start the DNP3Outstation instance, kicking off communication with the DNP3 Master."""
-        super(DNP3Agent, self).onstart(sender, **kwargs)
 
 
 def dnp3_agent(config_path, **kwargs):

--- a/services/core/DNP3Agent/dnp3/base_dnp3_agent.py
+++ b/services/core/DNP3Agent/dnp3/base_dnp3_agent.py
@@ -50,6 +50,7 @@ from outstation import DNP3Outstation
 from points import DEFAULT_POINT_TOPIC, DEFAULT_OUTSTATION_STATUS_TOPIC
 from points import DEFAULT_LOCAL_IP, DEFAULT_PORT
 from points import POINT_TYPE_ANALOG_INPUT, POINT_TYPE_BINARY_INPUT
+from dnp3.points import PUBLISH_AND_RESPOND
 from points import PointDefinitions, PointDefinition, PointArray
 from points import DNP3Exception
 
@@ -465,10 +466,15 @@ class BaseDNP3Agent(Agent):
     def publish_point_value(self, point_value):
         """Publish a PointValue as it is received from the DNP3 Master."""
         _log.info('Publishing DNP3 {}'.format(point_value))
-        self.publish_points({point_value.name: (point_value.unwrapped_value() if point_value else None)})
+        msg = {
+            point_value.name: (point_value.unwrapped_value() if point_value else None)
+        }
 
-    def publish_points(self, msg):
-        """Publish point values to the message bus."""
+        if point_value.point_def.action == PUBLISH_AND_RESPOND:
+            msg.update({
+                'response': point_value.point_def.response
+            })
+
         self.publish_data(self.point_topic, msg)
 
     def publish_outstation_status(self, outstation_status):

--- a/services/core/DNP3Agent/dnp3/mesa_points.config
+++ b/services/core/DNP3Agent/dnp3/mesa_points.config
@@ -4202,7 +4202,9 @@
         "group": 40, 
         "index": 638, 
         "name": "DVRT.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4272,7 +4274,9 @@
         "group": 40, 
         "index": 648, 
         "name": "DFRT.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4307,7 +4311,9 @@
         "group": 40, 
         "index": 653, 
         "name": "RDGS.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4377,7 +4383,9 @@
         "group": 40, 
         "index": 663, 
         "name": "DVWD.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4503,7 +4511,9 @@
         "group": 40, 
         "index": 681, 
         "name": "DCHD.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4524,7 +4534,9 @@
         "group": 40, 
         "index": 684, 
         "name": "DTCD.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4552,7 +4564,9 @@
         "group": 40, 
         "index": 688, 
         "name": "DAMG.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4580,7 +4594,9 @@
         "group": 40, 
         "index": 692, 
         "name": "DPKP.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4601,7 +4617,9 @@
         "group": 40, 
         "index": 695, 
         "name": "DLFL.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4622,7 +4640,9 @@
         "group": 40, 
         "index": 698, 
         "name": "DGFL.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4650,7 +4670,9 @@
         "group": 40, 
         "index": 702, 
         "name": "DAGC.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4699,7 +4721,9 @@
         "group": 40, 
         "index": 709, 
         "name": "DWSM.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4734,7 +4758,9 @@
         "group": 40, 
         "index": 714, 
         "name": "DVWG.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4797,7 +4823,9 @@
         "group": 40, 
         "index": 723, 
         "name": "DFPF.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4825,7 +4853,9 @@
         "group": 40, 
         "index": 727, 
         "name": "DVVC.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4874,7 +4904,9 @@
         "group": 40, 
         "index": 734, 
         "name": "DWVR.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -4923,7 +4955,9 @@
         "group": 40, 
         "index": 741, 
         "name": "DPFC.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "AO", 
@@ -5853,7 +5887,8 @@
         "group": 1, 
         "index": 0, 
         "name": "CALH.GrAlm.1", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -5861,7 +5896,8 @@
         "group": 1, 
         "index": 1, 
         "name": "DBAT.BatHi", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -5869,7 +5905,8 @@
         "group": 1, 
         "index": 2, 
         "name": "DBAT.BatLoRsv", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -5877,7 +5914,8 @@
         "group": 1, 
         "index": 3, 
         "name": "DBAT.BatLo", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -5885,7 +5923,8 @@
         "group": 1, 
         "index": 4, 
         "name": "DBAT.IntnBatTmp.range", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -5893,7 +5932,8 @@
         "group": 1, 
         "index": 5, 
         "name": "MMET.EnvTmp.range", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -6493,7 +6533,9 @@
         "group": 1, 
         "index": 80, 
         "name": "DGSM.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "BI", 
@@ -6509,7 +6551,8 @@
         "group": 1, 
         "index": 82, 
         "name": "CALH.GrAlm.2", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -6517,7 +6560,8 @@
         "group": 1, 
         "index": 83, 
         "name": "CALH.GrAlm", 
-        "variation": 2
+        "variation": 2,
+        "category": "alarm"
     }, 
     {
         "data_type": "BI", 
@@ -6853,7 +6897,9 @@
         "group": 10, 
         "index": 31, 
         "name": "DGSMn > 10.ModEna", 
-        "variation": 2
+        "variation": 2,
+        "action": "publish",
+        "category": "mode_enable"
     }, 
     {
         "data_type": "BO", 

--- a/services/core/DNP3Agent/dnp3/outstation.py
+++ b/services/core/DNP3Agent/dnp3/outstation.py
@@ -388,12 +388,17 @@ class MyLogger(openpal.ILogHandler):
 
     def __init__(self):
         super(MyLogger, self).__init__()
+        self.tcp_client = None
 
     def Log(self, entry):
         """Write a DNP3 log entry to the logger (debug level)."""
         location = entry.location.rsplit('/')[-1] if entry.location else ''
         filters = entry.filters.GetBitfield()
         message = entry.message
+
+        if "Accepted connection from" in message:
+            self.tcp_client = message.split(": ")[1]
+
         _log.debug('DNP3Log {0}\t(filters={1}) {2}'.format(location, filters, message))
         # This is here as an example of how to send a specific log entry to the message bus as outstation status.
         # if 'Accepted connection' in message or 'Listening on' in message:

--- a/services/core/DNP3Agent/dnp3/points.py
+++ b/services/core/DNP3Agent/dnp3/points.py
@@ -51,6 +51,10 @@ DIRECT_OPERATE = 'direct_operate'       # This is actually DIRECT OPERATE / RESP
 SELECT = 'select'                       # This is actually SELECT / RESPONSE
 OPERATE = 'operate'                     # This is actually OPERATE / RESPONSE
 
+# PointDefinition.action values:
+PUBLISH = 'publish'
+PUBLISH_AND_RESPOND = 'publish_and_respond'
+
 # Some PointDefinition.point_type values:
 POINT_TYPE_ANALOG_INPUT = 'Analog Input'
 POINT_TYPE_ANALOG_OUTPUT = 'Analog Output'
@@ -424,6 +428,9 @@ class BasePointDefinition(object):
         self.selector_block_start = element_def.get('selector_block_start', None)
         self.selector_block_end = element_def.get('selector_block_end', None)
         self.save_on_write = element_def.get('save_on_write', None)
+        self.action = element_def.get('action', None)
+        self.response = element_def.get('response', None)
+        self.category = element_def.get('category', None)
 
     @property
     def is_array_point(self):
@@ -539,6 +546,10 @@ class BasePointDefinition(object):
         return self.point_type in [POINT_TYPE_ANALOG_OUTPUT, POINT_TYPE_BINARY_OUTPUT]
 
     @property
+    def is_refid(self):
+        return True if 'RefId' in self.name else False
+
+    @property
     def is_selector_block(self):
         return self.type == 'selector_block'
 
@@ -594,7 +605,7 @@ class ArrayHeadPointDefinition(BasePointDefinition):
         super(ArrayHeadPointDefinition, self).__init__(json_element)
         self.array_points = json_element.get('array_points', None)
         self.array_times_repeated = json_element.get('array_times_repeated', None)
-        self.array_point_definitions = []         # Holds all ArrayPointDefinitions belonging to this array.
+        self.array_point_definitions = []  # Holds all ArrayPointDefinitions belonging to this array.
         self.validate_point()
 
     def validate_point(self):

--- a/services/core/DNP3Agent/mesaagent.config
+++ b/services/core/DNP3Agent/mesaagent.config
@@ -6,10 +6,10 @@
     "outstation_status_topic": "mesa/outstation_status",
     "outstation_config": {
         "database_sizes": 10000,
-        # "log_levels": ["NORMAL", "ALL_APP_COMMS"]
         "log_levels": ["NORMAL"]
     },
     "local_ip": "0.0.0.0",
     "port": 20000,
-    "all_functions_supported_by_default": "True"
+    "all_functions_supported_by_default": true,
+    "function_validation": false
 }

--- a/services/core/DNP3Agent/tests/data/mesa_points.config
+++ b/services/core/DNP3Agent/tests/data/mesa_points.config
@@ -172,7 +172,8 @@
         "group": 12,                        # Binary Output Command
         "variation": 1,                     # Control Relay Output Block (CROB)
         "index": 5,
-        "description": "Enable (output)"
+        "description": "Enable (output)",
+        "action": "publish"
     },
     {
         "name": "DCHD.ModEna (in)",
@@ -359,5 +360,26 @@
         "group": 30,
         "variation": 1,
         "index": 800
+    },
+    {
+        "name": "Publish Test Point (AO)",
+        "group": 41,
+        "variation": 1,
+        "index": 1,
+        "action": "publish"
+    },
+    {
+        "name": "Publish and Respond Test Point (AO)",
+        "group": 41,
+        "variation": 1,
+        "index": 3,
+        "action": "publish_and_respond",
+        "response": "Respond Test Point (AI)"
+    },
+    {
+        "name": "Respond Test Point (AI)",
+        "group": 30,
+        "variation": 1,
+        "index": 3
     }
 ]

--- a/services/core/DNP3Agent/tests/data/mesaagent.config
+++ b/services/core/DNP3Agent/tests/data/mesaagent.config
@@ -6,10 +6,10 @@
     "outstation_status_topic": "mesa/outstation_status",
     "outstation_config": {
         "database_sizes": 2000,
-        # "log_levels": {"NORMAL", "ALL_APP_COMMS"]
         "log_levels": ["NORMAL"]
     },
     "local_ip": "0.0.0.0",
     "port": 20000,
-    "all_functions_supported_by_default": "True"
+    "all_functions_supported_by_default": true,
+    "function_validation": false
 }


### PR DESCRIPTION
- Now able to send a single DNP3 point.
- mesaagent.config: add function_validation field with default value to false. If function_validation is false, it is allowed to send a single point without throwing function validation exception. If function_validation is true, the function will be checked to make sure there are no duplicate steps, that the steps are received in order, and that no mandatory steps are missing.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1868?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1868'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>