### PR TITLE
RMQ Config yml  syntax error message

### DIFF
--- a/volttron/platform/config.py
+++ b/volttron/platform/config.py
@@ -49,11 +49,14 @@ the order encountered.
 '''
 
 import argparse as _argparse
+import logging
 import os as _os
 import re as _re
 import shlex as _shlex
 import sys as _sys
-from . instance_setup import main
+from volttron.platform.instance_setup import main
+from volttron.platform.agent import utils
+
 
 
 def expandall(string):
@@ -585,6 +588,8 @@ _patch_argparse()
 
 def _main():
     try:
+        # Protect against configuration of base logger when not the "main entry point"
+        utils.setup_logging()
         main()
     except KeyboardInterrupt:
         print('\n')

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -781,7 +781,15 @@ def start_volttron_process(opts):
         else:
             # Start RabbitMQ server if not running
             rmq_config = RMQConfig()
-            start_rabbit(rmq_config.rmq_home)
+            if rmq_config is None:
+                _log.error("DEBUG: Exiting due to error in rabbitmq config file. Please check.")
+                sys.exit()
+
+            try:
+                start_rabbit(rmq_config.rmq_home)
+            except AttributeError as exc:
+                _log.error("Exception while starting RabbitMQ. Check the path in the config file.")
+                sys.exit()
 
             # Start the config store before auth so we may one day have auth use it.
             config_store = ConfigStoreService(address=address,

--- a/volttron/utils/rmq_config_params.py
+++ b/volttron/utils/rmq_config_params.py
@@ -86,8 +86,13 @@ class RMQConfig(object):
                         self.config_opts['rmq-home'])
         except IOError as exc:
             raise
+        except (yaml.parser.ParserError, yaml.scanner.ScannerError) as exc:
+            _log.error("The rabbitmq config file contain invalid syntax. Fix and restart platform. {}.".format(exc))
+            raise
         except yaml.YAMLError as exc:
-            print("The rabbitmq config file contain invalid syntax. Fix and restart platform.")
+           # _log.error("The rabbitmq config file contain invalid syntax. Fix and restart platform {}.".format(exc))
+            raise
+
 
     def write_rmq_config(self, volttron_home=None):
         """

--- a/volttron/utils/rmq_config_params.py
+++ b/volttron/utils/rmq_config_params.py
@@ -39,6 +39,7 @@
 import os
 import logging
 
+
 try:
     import yaml
 except ImportError:
@@ -86,7 +87,7 @@ class RMQConfig(object):
         except IOError as exc:
             raise
         except yaml.YAMLError as exc:
-            raise
+            print("The rabbitmq config file contain invalid syntax. Fix and restart platform.")
 
     def write_rmq_config(self, volttron_home=None):
         """

--- a/volttron/utils/rmq_config_params.py
+++ b/volttron/utils/rmq_config_params.py
@@ -78,21 +78,12 @@ class RMQConfig(object):
         :return:
         """
         """Loads the config file if the path exists."""
-        try:
-            with open(self.volttron_rmq_config, 'r') as yaml_file:
-                self.config_opts = yaml.load(yaml_file)
-                if self.config_opts.get('rmq-home'):
-                    self.config_opts['rmq-home'] = os.path.expanduser(
-                        self.config_opts['rmq-home'])
-        except IOError as exc:
-            raise
-        except (yaml.parser.ParserError, yaml.scanner.ScannerError) as exc:
-            _log.error("The rabbitmq config file contain invalid syntax. Fix and restart platform. {}.".format(exc))
-            raise
-        except yaml.YAMLError as exc:
-           # _log.error("The rabbitmq config file contain invalid syntax. Fix and restart platform {}.".format(exc))
-            raise
-
+        
+        with open(self.volttron_rmq_config, 'r') as yaml_file:
+            self.config_opts = yaml.load(yaml_file)
+            if self.config_opts.get('rmq-home'):
+                self.config_opts['rmq-home'] = os.path.expanduser(
+                    self.config_opts['rmq-home'])
 
     def write_rmq_config(self, volttron_home=None):
         """

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -518,11 +518,11 @@ def setup_rabbitmq_volttron(setup_type, verbose=False, prompt=False):
     try:
         rmq_config.load_rmq_config()
 
-    except (yaml.parser.ParserError, yaml.scanner.ScannerError) as exc:
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError, yaml.YAMLError) as exc:
         _log.error("Error: YAML file cannot parsed properly. Check the contents of the file")
         return exc
 
-    except (IOError, yaml.YAMLError) as exc:
+    except IOError as exc:
         _log.error("Error opening {}. Please create a rabbitmq_config.yml "
                    "file in your volttron home. If you want to point to a "
                    "volttron home other than {} please set it as the "

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -517,6 +517,11 @@ def setup_rabbitmq_volttron(setup_type, verbose=False, prompt=False):
     # Load either the newly created config or config passed
     try:
         rmq_config.load_rmq_config()
+
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError) as exc:
+        _log.error("Error: YAML file cannot parsed properly. Check the contents of the file")
+        return exc
+
     except (IOError, yaml.YAMLError) as exc:
         _log.error("Error opening {}. Please create a rabbitmq_config.yml "
                    "file in your volttron home. If you want to point to a "
@@ -529,6 +534,7 @@ def setup_rabbitmq_volttron(setup_type, verbose=False, prompt=False):
                    "volttron instance with which communication needs "
                    "to be established. Please refer to example config file "
                    "at examples/configurations/rabbitmq/rabbitmq_config.yml")
+        raise
         return exc
 
     invalid = True
@@ -937,6 +943,7 @@ def start_rabbit(rmq_home):
     #  purpose. shovel_status comes close...
     status_cmd = [os.path.join(rmq_home, "sbin/rabbitmqctl"), "shovel_status"]
     start_cmd = [os.path.join(rmq_home, "sbin/rabbitmq-server"), "-detached"]
+
 
     i = 0
     started = False


### PR DESCRIPTION
# Description

Created more descriptive error message in the event that yml file has incorrect syntax errors. Note: current fix results in error message being printed twice (which is why change is currently listed as breaking change below).


Fixes #1864

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
      Removed colons after ``volttron-host`` and ``amqp-port`` in ``examples/configurations/rabbitmq/rabbitmq_config.yml`` 
      Run ``vcfg --rabbitmq single /home/username/volttron/examples/configurations/rabbitmq/rabbitmq_config.yml``
Current output:
![rabbitmq_yml_output](https://user-images.githubusercontent.com/14077072/50805930-61bc1580-12a9-11e9-90d7-d53e013750fc.png)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
