### PR TITLE
Fixes for issue #1702. Router and agent attempts to reconnect 60/30 …

### DIFF
--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -881,6 +881,7 @@ class RMQCore(Core):
         else:
             param = self.rmq_mgmt.build_agent_connection(self.identity,
                                                          self.instance_name)
+
         return param
 
     def loop(self, running_event):
@@ -908,9 +909,30 @@ class RMQCore(Core):
             self.stop()
             self.ondisconnected.send(self)
 
+        def connect_callback():
+            router_connected = False
+            bindings = self.rmq_mgmt.get_bindings('volttron')
+            router_user = router_key = "{inst}.{ident}".format(inst=self.instance_name,
+                                                               ident='router')
+            if bindings:
+                for binding in bindings:
+                    if binding['destination'] == router_user and \
+                                    binding['routing_key'] == router_key:
+                        router_connected = True
+                        break
+            # Connection retry attempt issue #1702.
+            # If the agent detects that RabbitMQ broker is reconnected before the router, wait for the router to
+            # connect before sending hello()
+            if router_connected:
+                hello()
+            else:
+                _log.debug("Router not bound to RabbitMQ yet, waiting for 5 seconds before sending hello".
+                           format(self.identity))
+                self.spawn_later(5, hello)
+
         # Connect to RMQ broker. Register a callback to get notified when
         # connection is confirmed
-        self.connection.connect(hello, connection_error)
+        self.connection.connect(connect_callback, connection_error)
 
         self.onconnected.connect(hello_response)
         self.ondisconnected.connect(self.connection.close_connection)

--- a/volttron/platform/vip/agent/subsystems/heartbeat.py
+++ b/volttron/platform/vip/agent/subsystems/heartbeat.py
@@ -45,6 +45,7 @@ from volttron.platform.messaging.headers import TIMESTAMP
 from volttron.platform.agent.utils import (get_aware_utc_now,
                                            format_timestamp)
 from volttron.platform.scheduling import periodic
+from ..errors import Unreachable, VIPError
 
 """The heartbeat subsystem adds an optional periodic publish to all agents.
 Heartbeats can be started with agents and toggled on and off at runtime.
@@ -64,6 +65,7 @@ class Heartbeat(SubsystemBase):
         self.autostart = heartbeat_autostart
         self.period = heartbeat_period
         self.enabled = False
+        self.connect_error = False
 
         def onsetup(sender, **kwargs):
             rpc.export(self.start, 'heartbeat.start')
@@ -78,6 +80,7 @@ class Heartbeat(SubsystemBase):
 
         core.onsetup.connect(onsetup, self)
         core.onstart.connect(onstart, self)
+        core.onconnected.connect(self.reconnect)
 
     def start(self):
         """RPC method
@@ -97,6 +100,11 @@ class Heartbeat(SubsystemBase):
         """
         self.set_period(period)
         self.start()
+
+    def reconnect(self, sender, **kwargs):
+        if self.connect_error:
+            self.restart()
+            self.connect_error = False
 
     def stop(self):
         """RPC method
@@ -134,5 +142,9 @@ class Heartbeat(SubsystemBase):
         topic = 'heartbeat/' + self.core().identity
         headers = {TIMESTAMP: format_timestamp(get_aware_utc_now())}
         message = self.owner.vip.health.get_status_value()
+        try:
+            self.pubsub().publish('pubsub', topic, headers, message)
+        except Unreachable as exc:
+            self.connect_error = True
+            self.stop()
 
-        self.pubsub().publish('pubsub', topic, headers, message)

--- a/volttron/platform/vip/agent/subsystems/hello.py
+++ b/volttron/platform/vip/agent/subsystems/hello.py
@@ -91,10 +91,10 @@ class Hello(SubsystemBase):
                                                     subsystem=b'hello',
                                                     args=[b'hello'],
                                                     id=result.ident))
-            #socket.send_vip(peer, b'hello', [b'hello'], msg_id=result.ident)
+            #self.core().socket.send_vip(peer, b'hello', [b'hello'], msg_id=result.ident)
         except ZMQError as exc:
             if exc.errno == ENOTSOCK:
-                _log.debug("Socket send on non socket {}".format(self.core().identity))
+                _log.error("Socket send on non socket {}".format(self.core().identity))
 
         return result
 

--- a/volttron/platform/vip/rmq_connection.py
+++ b/volttron/platform/vip/rmq_connection.py
@@ -107,7 +107,7 @@ class RMQConnection(BaseConnection):
         self._connection = pika.GeventConnection(self._connection_param,
                                                  on_open_callback=self.on_connection_open,
                                                  on_open_error_callback=self.on_open_error,
-                                                 on_close_callback=self.on_connection_closed,
+                                                 on_close_callback=self.on_connection_closed
                                                  )
 
     def on_connection_open(self, unused_connection):
@@ -150,14 +150,16 @@ class RMQConnection(BaseConnection):
         self._connection.add_timeout(timeout, self._reconnect)
 
     def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
+        """
+        This method tells pika to call the on_channel_closed method if
         RabbitMQ unexpectedly closes the channel.
 
         """
         self.channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, reply_code, reply_text):
-        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
+        """
+        Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
         violates the protocol, such as re-declare an exchange or queue with
         different parameters. In this case, we'll close the connection

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -763,6 +763,7 @@ class RabbitMQMgmt(object):
         """
         ssl_auth = ssl_auth if ssl_auth is not None else self.is_ssl
         crt = self.rmq_config.crts
+        heartbeat_interval = 20 #sec
         try:
             if ssl_auth:
                 ssl_options = dict(
@@ -777,6 +778,7 @@ class RabbitMQMgmt(object):
                     virtual_host=self.rmq_config.virtual_host,
                     connection_attempts=retry_attempt,
                     retry_delay=retry_delay,
+                    heartbeat=heartbeat_interval,
                     ssl=True,
                     ssl_options=ssl_options,
                     credentials=pika.credentials.ExternalCredentials())
@@ -785,6 +787,7 @@ class RabbitMQMgmt(object):
                     host=self.rmq_config.hostname,
                     port=int(self.rmq_config.amqp_port),
                     virtual_host=self.rmq_config.virtual_host,
+                    heartbeat=heartbeat_interval,
                     credentials=pika.credentials.PlainCredentials(
                         rmq_user, rmq_user))
         except KeyError:

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -754,7 +754,7 @@ class RabbitMQMgmt(object):
         self.delete_parameter(component, parameter_name, vhost,
                               ssl_auth=self.rmq_config.is_ssl)
 
-    def build_connection_param(self, rmq_user, ssl_auth=None):
+    def build_connection_param(self, rmq_user, ssl_auth=None, retry_attempt=30, retry_delay=2):
         """
         Build Pika Connection parameters
         :param rmq_user: RabbitMQ user
@@ -775,6 +775,8 @@ class RabbitMQMgmt(object):
                     host=self.rmq_config.hostname,
                     port=int(self.rmq_config.amqp_port_ssl),
                     virtual_host=self.rmq_config.virtual_host,
+                    connection_attempts=retry_attempt,
+                    retry_delay=retry_delay,
                     ssl=True,
                     ssl_options=ssl_options,
                     credentials=pika.credentials.ExternalCredentials())
@@ -927,7 +929,10 @@ class RabbitMQMgmt(object):
 
         self.create_user_with_permissions(rmq_user, permissions, ssl_auth=self.is_ssl)
 
-        param = self.build_connection_param(rmq_user, ssl_auth=self.is_ssl)
+        param = self.build_connection_param(rmq_user,
+                                            ssl_auth=self.is_ssl,
+                                            retry_attempt=60,
+                                            retry_delay=2)
         return param
 
     def get_ssl_url_params(self):


### PR DESCRIPTION
Router and agent tries to reconnect to RabbitMQ broker few times (30 to 60 retries) before giving up. Covered corner cases where agent detects RabbitMQ broker re-connection before the router.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1879?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1879'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>