### PR TITLE
Fixes for DNP3 and Mesa's use of the config store.

### DIFF
--- a/services/core/DNP3Agent/dnp3/agent.py
+++ b/services/core/DNP3Agent/dnp3/agent.py
@@ -60,12 +60,6 @@ class DNP3Agent(BaseDNP3Agent):
             $ source services/core/DNP3Agent/install_dnp3_agent.sh
     """
 
-    def __init__(self, **kwargs):
-        """Initialize the DNP3 agent."""
-        super(DNP3Agent, self).__init__(**kwargs)
-        self.vip.config.set_default('config', self.default_config)
-        self.vip.config.subscribe(self._configure, actions=['NEW', 'UPDATE'], pattern='config')
-
     def _process_point_value(self, point_value):
         """DNP3Agent publishes each point value to the message bus as the value is received from the master."""
         point_val = super(DNP3Agent, self)._process_point_value(point_value)

--- a/services/core/DNP3Agent/dnp3/base_dnp3_agent.py
+++ b/services/core/DNP3Agent/dnp3/base_dnp3_agent.py
@@ -78,7 +78,7 @@ class BaseDNP3Agent(Agent):
     def __init__(self, points=None, point_topic='', local_ip=None, port=None,
                  outstation_config=None, local_point_definitions_path=None, **kwargs):
         """Initialize the DNP3 agent."""
-        super(BaseDNP3Agent, self).__init__(enable_web=True, **kwargs)
+        super(BaseDNP3Agent, self).__init__(**kwargs)
         self.points = points
         self.point_topic = point_topic
         self.local_ip = local_ip
@@ -100,6 +100,9 @@ class BaseDNP3Agent(Agent):
         self._local_point_definitions_path = local_point_definitions_path
         self._selector_block_points = {}
 
+        self.vip.config.set_default('config', self.default_config)
+        self.vip.config.subscribe(self._configure, actions=['NEW', 'UPDATE'], pattern='config')
+
     def _configure(self, config_name, action, contents):
         """Initialize/Update the agent configuration."""
         self._configure_parameters(contents)
@@ -112,19 +115,8 @@ class BaseDNP3Agent(Agent):
         """
         _log.debug('Loading DNP3 point definitions.')
         try:
-            if type(self.points) == str:
-                # There's something odd here. The point and function definitions are defined in the
-                # config file using a 'config://' entry (previously used only by MasterDriveAgent).
-                # It seems like this should have been resolved to the registry entry at which the
-                # 'config://' entry points, and in that case 'self.points' should already be
-                # a json structure. But instead, it's still the string 'config://mesa_points.config'.
-                # The call to get_from_config_store() below works around the issue by fetching the linked
-                # registry entry.
-                point_defs = self.get_from_config_store(self.points)
-            else:
-                point_defs = self.points
             self.point_definitions = PointDefinitions()
-            self.point_definitions.load_points(point_defs)
+            self.point_definitions.load_points(self.points)
         except (AttributeError, TypeError) as err:
             if self._local_point_definitions_path:
                 _log.warning("Attempting to load point definitions from local path.")
@@ -132,23 +124,27 @@ class BaseDNP3Agent(Agent):
             else:
                 raise DNP3Exception("Failed to load point definitions from config store: {}".format(err))
 
-    def get_from_config_store(self, config_path):
-        """Query the agent's config store for the data at the key 'config_path'."""
-        resolved_path = check_for_config_link(config_path)
-        entry = self.vip.rpc.call(CONFIGURATION_STORE, 'manage_get', self.core.identity, resolved_path, raw=True).get()
-        if type(entry) == str:
-            entry = json.loads(utils.strip_comments(entry))
-        return entry
+    @Core.receiver('onstop')
+    def onstop(self, sender, **kwargs):
+        """Stop the DNP3Outstation instance for agent shutdown."""
+        self.stop_outstation()
 
-    @Core.receiver('onstart')
-    def onstart(self, sender, **kwargs):
+    def start_outstation(self):
         """Start the DNP3Outstation instance, kicking off communication with the DNP3 Master."""
-        self._configure_parameters(self.default_config)
+        self.stop_outstation()
         _log.info('Starting DNP3Outstation')
         self.publish_outstation_status('starting')
         self.application = DNP3Outstation(self.local_ip, self.port, self.outstation_config)
         self.application.start()
         self.publish_outstation_status('running')
+
+    def stop_outstation(self):
+        if self.application is not None:
+            _log.info('Stopping DNP3Outstation')
+            self.publish_outstation_status('stopping')
+            self.application.shutdown()
+            self.publish_outstation_status('stopped')
+            self.application = None
 
     def _configure_parameters(self, contents):
         """
@@ -200,6 +196,7 @@ class BaseDNP3Agent(Agent):
         _log.debug('\toutstation_config={}'.format(self.outstation_config))
         self.load_point_definitions()
         DNP3Outstation.set_agent(self)
+        self.start_outstation()
         return config
 
     @RPC.export

--- a/services/core/DNP3Agent/dnp3/mesa/agent.py
+++ b/services/core/DNP3Agent/dnp3/mesa/agent.py
@@ -65,9 +65,7 @@ class MesaAgent(BaseDNP3Agent):
         That file specifies a default agent configuration, which can be overridden as needed.
     """
 
-    def __init__(self, points=None, functions=None,
-                 point_topic='', local_ip=None, port=None, outstation_config=None,
-                 function_topic='', outstation_status_topic='',
+    def __init__(self, functions=None, function_topic='', outstation_status_topic='',
                  all_functions_supported_by_default=False,
                  local_function_definitions_path=None, function_validation=False, **kwargs):
         """Initialize the MESA agent."""
@@ -77,20 +75,18 @@ class MesaAgent(BaseDNP3Agent):
         self.outstation_status_topic = outstation_status_topic
         self.all_functions_supported_by_default = all_functions_supported_by_default
         self.function_validation = function_validation
-        self.default_config = {
-            'points': points,
+
+        # Update default config
+        self.default_config.update({
             'functions': functions,
-            'point_topic': point_topic,
-            'local_ip': local_ip,
-            'port': port,
-            'outstation_config': outstation_config,
             'function_topic': function_topic,
             'outstation_status_topic': outstation_status_topic,
             'all_functions_supported_by_default': all_functions_supported_by_default,
             'function_validation': function_validation
-        }
+        })
+
+        # Update default config in config store.
         self.vip.config.set_default('config', self.default_config)
-        self.vip.config.subscribe(self._configure, actions=['NEW', 'UPDATE'], pattern='config')
 
         self.function_definitions = None
         self._current_func = None


### PR DESCRIPTION
# Description

Updates the DNP3 and Mesa Agents to properly use config store. Fixes default configuration overriding config store configuration.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests still pass (as often as this did before, anyway)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1885?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1885'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>