### PR TITLE
fix datetime tzinfo mismatch with crate client

### DIFF
--- a/services/core/CrateHistorian/cratedb/historian.py
+++ b/services/core/CrateHistorian/cratedb/historian.py
@@ -413,14 +413,14 @@ class CrateHistorian(BaseHistorian):
         args = [topic]
         if start and end and start == end:
             where_clauses.append("ts = ?")
-            args.append(start)
+            args.append(start.replace(tzinfo=None))
         else:
             if start:
                 where_clauses.append("ts >= ?")
-                args.append(start)
+                args.append(start.replace(tzinfo=None))
             if end:
                 where_clauses.append("ts < ?")
-                args.append(end)
+                args.append(end.replace(tzinfo=None))
 
         where_statement = ' AND '.join(where_clauses)
 

--- a/services/core/CrateHistorian/cratedb/historian.py
+++ b/services/core/CrateHistorian/cratedb/historian.py
@@ -411,6 +411,9 @@ class CrateHistorian(BaseHistorian):
 
         where_clauses = ["WHERE topic =?"]
         args = [topic]
+        # Because the crate client requires naive dates we replace
+        # tzinfo with None.  This won't have any impact on the query
+        # as data in the database is in UTC already.
         if start and end and start == end:
             where_clauses.append("ts = ?")
             args.append(start.replace(tzinfo=None))


### PR DESCRIPTION
# Description
Remove datetime tzinfo before Crate Historian sends query to Crate client. Functionality unaffected, since base historian has already enforced UTC.

Fixes #1888 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/VOLTTRON/volttron/pull/1889?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/VOLTTRON/volttron/pull/1889'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>