### PR TITLE
Forwarder datamover remote identity

### DIFF
--- a/services/core/DataMover/README.rst
+++ b/services/core/DataMover/README.rst
@@ -42,12 +42,17 @@ by the DataMover agent.
         #   Address of the target platform.
         #   Examples:
         #       "destination-vip": "ipc://@/home/volttron/.volttron/run/vip.socket"
-        #       "destination-vip": "tcp://127.0.0.1:22916"
-        "destination-vip": "tcp://<ip address>:<port>"
+        #       "destination-vip": "tcp://127.0.0.1:23916"
+        "destination-vip": "tcp://<ip address>:<port>",
 
         # destination_historian_identity
         #   Identity of the historian to send data to. Only needed if data
         #   should be sent an agent other than "platform.historian"
-        "destination_historian_identity": "platform.historian"
+        "destination-historian-identity": "platform.historian",
 
+        # remote_identity - OPTIONAL
+        #    identity that will show up in peers list on the remote platform
+        #    By default this identity is randomly generated
+        "remote-identity": "22916.datamover"
     }
+

--- a/services/core/DataMover/config
+++ b/services/core/DataMover/config
@@ -2,10 +2,5 @@
     "destination-vip": "tcp://127.0.0.1:22916",
     "destination-serverkey": "<valid server key>",
     "destination-historian-identity": "platform.historian"
-
-    "custom_topic_list": [],
-    "services_topic_list": [
-       "devices", "analysis", "record", "datalogger", "actuators"
-    ],
 }
 

--- a/services/core/DataMover/datamover/agent.py
+++ b/services/core/DataMover/datamover/agent.py
@@ -83,6 +83,7 @@ class DataMover(BaseHistorian):
 
     def __init__(self, destination_vip, destination_serverkey,
                  destination_historian_identity=PLATFORM_HISTORIAN,
+                 remote_identity=None,
                  **kwargs):
         """
         
@@ -103,10 +104,12 @@ class DataMover(BaseHistorian):
         self.destination_vip = destination_vip
         self.destination_serverkey = destination_serverkey
         self.destination_historian_identity = destination_historian_identity
+        self.remote_identity = remote_identity
 
         config = {"destination_vip":self.destination_vip,
                   "destination_serverkey": self.destination_serverkey,
-                  "destination_historian_identity": self.destination_historian_identity}
+                  "destination_historian_identity": self.destination_historian_identity,
+                  "remote_identity": self.remote_identity}
 
         self.update_default_config(config)
 
@@ -117,7 +120,7 @@ class DataMover(BaseHistorian):
         self.destination_vip = str(configuration.get('destination_vip', ""))
         self.destination_serverkey = str(configuration.get('destination_serverkey', ""))
         self.destination_historian_identity = str(configuration.get('destination_historian_identity', PLATFORM_HISTORIAN))
-
+        self.remote_identity = configuration.get("remote_identity")
 
     #Redirect the normal capture functions to capture_data.
     def _capture_device_data(self, peer, sender, bus, topic, headers, message):
@@ -230,6 +233,7 @@ class DataMover(BaseHistorian):
         _log.debug("Setting up to forward to {}".format(self.destination_vip))
         try:
             agent = build_agent(address=self.destination_vip,
+                                identity=self.remote_identity,
                                 serverkey=self.destination_serverkey,
                                 publickey=self.core.publickey,
                                 secretkey=self.core.secretkey,

--- a/services/core/DataMover/datamover/agent.py
+++ b/services/core/DataMover/datamover/agent.py
@@ -105,7 +105,8 @@ class DataMover(BaseHistorian):
         self.destination_serverkey = destination_serverkey
         self.destination_historian_identity = destination_historian_identity
         self.remote_identity = remote_identity
-
+        self._target_platform = None
+        
         config = {"destination_vip":self.destination_vip,
                   "destination_serverkey": self.destination_serverkey,
                   "destination_historian_identity": self.destination_historian_identity,
@@ -147,12 +148,6 @@ class DataMover(BaseHistorian):
 
         data = message
         try:
-            # 2.0 agents compatability layer makes sender = pubsub.compat
-            # so we can do the proper thing when it is here
-            _log.debug("message in capture_data {}".format(message))
-            if sender == 'pubsub.compat':
-                data = compat.unpack_legacy_message(headers, message)
-                _log.debug("data in capture_data {}".format(data))
             if isinstance(data, dict):
                 data = data
             elif isinstance(data, int) or \


### PR DESCRIPTION
# Description

Allows a specific identity to appear in a peer list on the destination (remote) machine.  Useful to detect outage from a central instance using the AgentWatcher.

Fixes #1900 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on PNNL internal campus deployrment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
