### PR TITLE
Fixes for Issue#1962.

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -261,7 +261,7 @@ class ControlService(BaseAgent):
         frames = [bytes(identity)]
 
         # self.core.socket.send_vip(b'', 'agentstop', frames, copy=False)
-        self.core.connection.send_vip_object(Message(peer=b'', subsystem='agentstop', args=frames))
+        self.core.connection.send_vip_object(Message(peer=b'', subsystem='agentstop', args=frames), copy=False)
 
     @RPC.export
     def restart_agent(self, uuid):

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -598,17 +598,6 @@ class Core(BasicCore):
 
         return connection_failed_check, hello, hello_response
 
-    def stop(self, timeout=None):
-        # Send message to router when stop method is called explicitly
-        frames = [bytes(self.identity)]
-        try:
-            self.connection.send_vip_object(Message(peer=b'', subsystem='agentstop', args=frames))
-        except ZMQError as exc:
-            if exc.errno == ENOTSOCK:
-                _log.error("Socket send on non socket {}".format(self.identity))
-        super(Core, self).stop()
-
-
 class ZMQCore(Core):
     """
     Concrete Core class for ZeroMQ message bus


### PR DESCRIPTION
# Description

Additional corrections to Issue#1962. Sending 'agentstop' message inside stop method is causing unexpected behavior during platform shutdown. Router is stopping before all the agents are stopped which not ideal. Will create a separate PR to resolve that issue.

Fixes # 1962
