### PR TITLE
added option to rabbitmq config to avoid prompts during setup

### DIFF
--- a/examples/configurations/rabbitmq/rabbitmq_config.yml
+++ b/examples/configurations/rabbitmq/rabbitmq_config.yml
@@ -42,6 +42,12 @@ mgmt-port-ssl: 15671
 # defaults to true
 ssl: true
 
+# By default if certs exists setup script will prompt to confirm if the same certs should be used.
+# If use-existing-certs is set to True then existing certs would be used without prompting,
+# if set to False new certs will be created
+
+#use-existing-certs: True
+
 # defaults to ~/rabbitmq_server/rabbbitmq_server-3.7.7
 rmq-home: ~/rabbitmq_server/rabbitmq_server-3.7.7
 

--- a/volttron/utils/rmq_config_params.py
+++ b/volttron/utils/rmq_config_params.py
@@ -163,6 +163,13 @@ class RMQConfig(object):
         return ssl_auth in ('true', 'True', 'TRUE', True)
 
     @property
+    def use_existing_certs(self):
+        use_existing = self.config_opts.get('use-existing-certs')
+        if use_existing is not None:
+            return use_existing in ('true', 'True', 'TRUE', True)
+        return use_existing
+
+    @property
     def certificate_data(self):
         return self.config_opts.get('certificate-data')
 


### PR DESCRIPTION
added additional use-existing-certs prompt to avoid prompts about existing certs. If this optional parameter is not set, user will be prompted when ssl certificate exists when running "vcfg --rabbitmq single"  command. If set to True, script will use existing certs. If set to False, script will create new certs overwriting any existing certs