### PR TITLE
fixed timing issue with RMQ for thresholddetection tests

### DIFF
--- a/services/ops/ThresholdDetectionAgent/tests/test_thresholddetection.py
+++ b/services/ops/ThresholdDetectionAgent/tests/test_thresholddetection.py
@@ -136,7 +136,7 @@ def test_above_max(threshold_tester_agent):
     """Should get alert because values exceed max"""
     publish(threshold_tester_agent, _test_config, lambda x: x+1)
     check = lambda: threshold_tester_agent.seen_alert_keys == set(['test_max'])
-    assert poll_gevent_sleep(2, check)
+    assert poll_gevent_sleep(3, check)
 
 
 def test_above_min(threshold_tester_agent):


### PR DESCRIPTION
Fixed simple timing issue with rmq in thresholddetectionagent

tested locally and against run-test-docker