### PR TITLE
Replaced large TM with small TM

### DIFF
--- a/docs/source/community_resources/documentation.rst
+++ b/docs/source/community_resources/documentation.rst
@@ -7,7 +7,7 @@ The Community is encouraged to contribute documentation back to the project as t
 developers may not have considered or documented. By contributing documentation back, the community can
 learn from each other and build up a much more extensive knowledge base.
 
-VOLTTRON\ :sup:`TM` documentation utilizes ReadTheDocs: http://volttron.readthedocs.io/en/develop/ and is built
+|VOLTTRON| documentation utilizes ReadTheDocs: http://volttron.readthedocs.io/en/develop/ and is built
 using the `Sphinx <http://www.sphinx-doc.org/en/stable/>`_ Python library with static content in
 `Restructured Text <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_.
 
@@ -18,8 +18,8 @@ Static documentation can be found in the `docs/source` directory. Edit or create
 using the `Restructured Text <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_ format. To see the results
 of your changes. the documenation can be built locally through the command line using the following instructions.
 
-If you've already :ref:`bootstrapped <setup>` VOLTTRON\ :sup:`TM`, do the following while activated. If not,
-this will also pull down the necessary VOLTTRON\ :sup:`TM` libraries.
+If you've already :ref:`bootstrapped <setup>` |VOLTTRON|, do the following while activated. If not,
+this will also pull down the necessary |VOLTTRON| libraries.
 
 .. code-block:: bash
 
@@ -37,5 +37,4 @@ Then, open your browser to the created local files:
 When complete, changes can be contributed back using the same process as code :ref:`contributions <contributing>` by
 creating a pull request. When the changes are accepted and merged, they will be reflected in the ReadTheDocs site.
 
-
-
+.. |VOLTTRON| unicode:: VOLTTRON U+2122

--- a/docs/source/community_resources/index.rst
+++ b/docs/source/community_resources/index.rst
@@ -14,8 +14,8 @@ learn more, check out :ref:`Contributing <contributing>` and :ref:`Documentation
 Slack Channel
 ^^^^^^^^^^^^^
 
-volttron-community.slack.com is where the VOLTTRON\ :sup:`TM` community at large can ask questions and meet with others
-using VOLTTRON\ :sup:`TM`.  Signup via https://volttron-community.signup.team/
+volttron-community.slack.com is where the |VOLTTRON| community at large can ask questions and meet with others
+using |VOLTTRON| Signup via https://volttron-community.signup.team/
 
 Mailing List
 ^^^^^^^^^^^^
@@ -54,3 +54,5 @@ Contributing Back
    contributing
    documentation
    *
+
+.. |VOLTTRON| unicode:: VOLTTRON U+2122

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,13 +4,16 @@
    contain the root `toctree` directive.
 
 ====================================
-VOLTTRON\ :sup:`TM`\  documentation!
+|VOLTTRON|  documentation!
 ====================================
+
+
 
 |VOLTTRON Tagline|
 
-VOLTTRON\ :sup:`TM` is an open-source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications
+|VOLTTRON| is an open-source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications
 that interact with that data.
+
 
 Features
 --------
@@ -29,7 +32,7 @@ Out of the box VOLTTRON provides:
 Background
 ----------
 
-VOLTTRON\ :sup:`TM` is written in Python 2.7 and runs on Linux Operating Systems. For users unfamiliar with those technologies, the following resources are recommended:
+|VOLTTRON| is written in Python 2.7 and runs on Linux Operating Systems. For users unfamiliar with those technologies, the following resources are recommended:
 
 - https://docs.python.org/2.7/tutorial/
 - http://ryanstutorials.net/linuxtutorial/
@@ -64,4 +67,5 @@ Indices and tables
 
 
 .. |VOLTTRON Logo| image:: images/volttron-webimage.jpg
+.. |VOLTTRON| unicode:: VOLTTRON U+2122
 .. |VOLTTRON Tagline| image:: images/VOLLTRON_Logo_Black_Horizontal_with_Tagline.png


### PR DESCRIPTION
Replaced  VOLTTRON\ :sup:`TM` with .. unicode:: VOLTTRON U+2122
This replaces the TM superscript with the unicode TM.
This was done everywhere in the documentation.
