### PR TITLE
pubsub unsubscribe issues

### DIFF
--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -463,10 +463,13 @@ class PubSub(BasePubSub):
         bus_subscriptions = dict()
         if prefix is None:
             if callback is None:
-                if platform in self._my_subscriptions:
+                if len(self._my_subscriptions) and platform in \
+                        self._my_subscriptions:
                     bus_subscriptions = self._my_subscriptions[platform]
-                if bus in bus_subscriptions:
-                    topics.extend(bus_subscriptions[bus].keys())
+                    if bus in bus_subscriptions:
+                        topics.extend(bus_subscriptions[bus].keys())
+                if not len(topics):
+                    return []
             else:
                 if platform in self._my_subscriptions:
                     bus_subscriptions = self._my_subscriptions[platform]

--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -461,14 +461,12 @@ class PubSub(BasePubSub):
         """
         topics = []
         bus_subscriptions = dict()
-        subscriptions = dict()
         if prefix is None:
             if callback is None:
                 if platform in self._my_subscriptions:
                     bus_subscriptions = self._my_subscriptions[platform]
                 if bus in bus_subscriptions:
-                    subscriptions = bus_subscriptions.pop(bus)
-                    topics = subscriptions.keys()
+                    topics.extend(bus_subscriptions[bus].keys())
             else:
                 if platform in self._my_subscriptions:
                     bus_subscriptions = self._my_subscriptions[platform]
@@ -493,7 +491,8 @@ class PubSub(BasePubSub):
             if not topics:
                 raise KeyError('no such subscription')
         else:
-            _log.debug("PUSUB unsubscribe my subscriptions: {0} {1}".format(prefix, self._my_subscriptions))
+            _log.debug("PUSUB unsubscribe my subscriptions: {0} {1}".format(
+                prefix, self._my_subscriptions))
             if platform in self._my_subscriptions:
                 bus_subscriptions = self._my_subscriptions[platform]
                 if bus in bus_subscriptions:

--- a/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
@@ -356,7 +356,8 @@ class RMQPubSub(BasePubSub):
                 topic = item[1]
                 if test(topic):
                     member = self.core().identity in peer
-                    results.append(('', topic, member))
+                    if not subscribed or member:
+                        results.append(('', topic, member))
         self.core().spawn_later(0.01, self.set_result, async_result.ident, results)
         return async_result
 

--- a/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
@@ -511,11 +511,16 @@ class RMQPubSub(BasePubSub):
         self._logger.debug("DROP subscriptions: {}".format(routing_key))
         topics = []
         remove = []
-        subscriptions = dict()
         remove_topics = []
         if routing_key is None:
             if callback is None:
-                return []
+                for prefix in self._my_subscriptions:
+                    subscriptions = self._my_subscriptions[prefix]
+                    for queue_name in subscriptions.keys():
+                        self.core().connection.channel.queue_delete(
+                            callback=None, queue=queue_name)
+                        subscriptions.pop(queue_name)
+                    topics.append(prefix)
             else:
                 # Traverse through all subscriptions to find the callback
                 for prefix in self._my_subscriptions:

--- a/volttrontesting/subsystems/test_pubsub_subsystem.py
+++ b/volttrontesting/subsystems/test_pubsub_subsystem.py
@@ -1,6 +1,6 @@
 import gevent
 import pytest
-
+from mock import MagicMock
 from volttron.platform.messaging import topics
 from volttron.platform.messaging.headers import DATE
 from volttron.platform.messaging.health import *
@@ -9,7 +9,6 @@ from volttrontesting.utils.utils import (poll_gevent_sleep,
                                          messages_contains_prefix)
 
 from volttron.platform.vip.agent import PubSub
-
 
 from volttron.platform.vip.agent import Agent
 
@@ -21,12 +20,16 @@ class _publish_from_handler_test_agent(Agent):
 
     @PubSub.subscribe('pubsub', '')
     def onmessage(self, peer, sender, bus, topic, headers, message):
-        self.subscription_results[topic] = {'headers': headers, 'message': message}
+        self.subscription_results[topic] = {'headers': headers,
+                                            'message': message}
         if not topic.startswith("testtopic2/test"):
-            self.vip.pubsub.publish("pubsub", "testtopic2/test", headers={"foo": "bar"}, message="Test message").get(timeout=2.0)
+            self.vip.pubsub.publish("pubsub", "testtopic2/test",
+                                    headers={"foo": "bar"},
+                                    message="Test message").get(timeout=2.0)
 
     def setup_callback(self, topic):
-        self.vip.pubsub.subscribe(peer="pubsub", prefix=topic, callback=self.onmessage).get(timeout=2.0)
+        self.vip.pubsub.subscribe(peer="pubsub", prefix=topic,
+                                  callback=self.onmessage).get(timeout=2.0)
 
     def reset_results(self):
         self.subscription_results = {}
@@ -44,18 +47,72 @@ def test_publish_from_message_handler(volttron_instance):
     """
     test_topic = "testtopic1/test"
     new_agent1 = volttron_instance.build_agent(identity='test_publish1',
-                                              agent_class=_publish_from_handler_test_agent)
+                                               agent_class=_publish_from_handler_test_agent)
 
     new_agent2 = volttron_instance.build_agent(identity='test_publish2')
 
-    #new_agent1.setup_callback("")
+    # new_agent1.setup_callback("")
 
-    new_agent2.vip.pubsub.publish("pubsub", test_topic, headers={}, message="Test message")
+    new_agent2.vip.pubsub.publish("pubsub", test_topic, headers={},
+                                  message="Test message")
 
     poll_gevent_sleep(2, lambda: messages_contains_prefix(test_topic,
                                                           new_agent1.subscription_results))
 
-    assert new_agent1.subscription_results[test_topic]["message"] == "Test message"
+    assert new_agent1.subscription_results[test_topic][
+               "message"] == "Test message"
 
 
+@pytest.mark.pubsub
+def test_multi_unsubscribe(volttron_instance):
+    subscriber_agent = volttron_instance.build_agent()
+    subscriber_agent.subscription_callback = MagicMock(
+        callback='subscription_callback')
+    subscriber_agent.subscription_callback.reset_mock()
 
+    publisher_agent = volttron_instance.build_agent()
+
+    topic_to_check = "testtopic1/test/foo/bar/one"
+    test_topic1 = "testtopic1/test/foo/bar"
+    test_topic2 = "testtopic1/test/foo"
+    test_topic3 = "testtopic1"
+
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic1,
+        callback=subscriber_agent.subscription_callback)
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic2,
+        callback=subscriber_agent.subscription_callback)
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic3,
+        callback=subscriber_agent.subscription_callback)
+    gevent.sleep(1)
+
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=topic_to_check,
+                                       message="test message 1")
+    gevent.sleep(1)
+
+    assert subscriber_agent.subscription_callback.call_count == 3
+    subscriber_agent.subscription_callback.reset_mock()
+
+    subscriber_agent.vip.pubsub.unsubscribe(peer='pubsub',
+                                            prefix="testtopic1/test/foo/bar",
+                                            callback=None)
+    gevent.sleep(1)
+
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=topic_to_check,
+                                       message="test message 2")
+    gevent.sleep(1)
+
+    assert subscriber_agent.subscription_callback.call_count == 2
+    subscriber_agent.subscription_callback.reset_mock()
+
+    subscriber_agent.vip.pubsub.unsubscribe("pubsub", prefix=None,
+                                            callback=None)
+    gevent.sleep(1)
+
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=topic_to_check,
+                                       message="test message 3")
+    gevent.sleep(1)
+
+    assert subscriber_agent.subscription_callback.call_count == 0

--- a/volttrontesting/subsystems/test_pubsub_subsystem.py
+++ b/volttrontesting/subsystems/test_pubsub_subsystem.py
@@ -70,6 +70,10 @@ def test_multi_unsubscribe(volttron_instance):
         callback='subscription_callback')
     subscriber_agent.subscription_callback.reset_mock()
 
+    # test unsubscribe all when there are no subscriptions
+    subscriber_agent.vip.pubsub.unsubscribe("pubsub", prefix=None,
+                                            callback=None)
+
     publisher_agent = volttron_instance.build_agent()
 
     topic_to_check = "testtopic1/test/foo/bar/one"

--- a/volttrontesting/subsystems/test_rmq_pubsub.py
+++ b/volttrontesting/subsystems/test_rmq_pubsub.py
@@ -287,6 +287,10 @@ def test_multi_unsubscribe(volttron_instance):
         callback='subscription_callback')
     subscriber_agent.subscription_callback.reset_mock()
 
+    # test unsubscribe all when there are no subscriptions
+    subscriber_agent.vip.pubsub.unsubscribe("pubsub", prefix=None,
+                                            callback=None)
+
     publisher_agent = volttron_instance.build_agent()
 
     topic_to_check = "testtopic1/test/foo/bar/one"

--- a/volttrontesting/subsystems/test_rmq_pubsub.py
+++ b/volttrontesting/subsystems/test_rmq_pubsub.py
@@ -255,7 +255,6 @@ def test_list_subscribed_reverse(volttron_instance, request):
     test_topic1 = "testtopic1/test/foo/bar"
     test_topic2 = "testtopic1/test/foo"
     test_topic3 = "testtopic1"
-    bus_topic = ""
 
     topic_result_index = 1
     member_result_index = 2
@@ -277,8 +276,8 @@ def test_list_subscribed_reverse(volttron_instance, request):
 
     for result in list_results:
         topic = result[topic_result_index]
-        topics = [test_topic1, test_topic2, test_topic3]
-        assert result[member_result_index] is (True if topic in topics else False)
+        assert topic in [test_topic1, test_topic2, test_topic3]
+        assert result[member_result_index] is True
 
 
 @pytest.mark.pubsub

--- a/volttrontesting/subsystems/test_rmq_pubsub.py
+++ b/volttrontesting/subsystems/test_rmq_pubsub.py
@@ -66,7 +66,8 @@ def subscriber_agent(request, volttron_instance):
 
     test_topic = "testtopic1/test/foo/bar"
     # Agent subscribes to both the desired topic and a topic that is not going to ever be published
-    subscriber_agent.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic, callback=subscriber_agent.callback)
+    subscriber_agent.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic,
+                                          callback=subscriber_agent.callback)
 
     def stop_agent():
         print("In teardown method of publisher_agent")
@@ -99,16 +100,24 @@ def test_granularity(volttron_instance, publisher_agent, request):
         new_agent1_sub.core.stop()
         new_agent2_sub.core.stop()
         new_agent3_sub.core.stop()
+
     request.addfinalizer(stop)
 
-    new_agent1_sub.vip.pubsub.subscribe(peer='pubsub', prefix='testtopic1', callback=new_agent1_sub.callback)
-    new_agent2_sub.vip.pubsub.subscribe(peer='pubsub', prefix='testtopic1/test', callback=new_agent2_sub.callback)
-    new_agent3_sub.vip.pubsub.subscribe(peer='pubsub', prefix='testtopic1/test/foo', callback=new_agent3_sub.callback)
+    new_agent1_sub.vip.pubsub.subscribe(peer='pubsub', prefix='testtopic1',
+                                        callback=new_agent1_sub.callback)
+    new_agent2_sub.vip.pubsub.subscribe(peer='pubsub', prefix='testtopic1/test',
+                                        callback=new_agent2_sub.callback)
+    new_agent3_sub.vip.pubsub.subscribe(peer='pubsub',
+                                        prefix='testtopic1/test/foo',
+                                        callback=new_agent3_sub.callback)
     gevent.sleep(1)
 
-    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g1_topic, headers=None, message="Test G1 Message")
-    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g2_topic, headers=None, message="Test G2 Message")
-    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g3_topic, headers=None, message="Test G3 Message")
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g1_topic,
+                                       headers=None, message="Test G1 Message")
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g2_topic,
+                                       headers=None, message="Test G2 Message")
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=g3_topic,
+                                       headers=None, message="Test G3 Message")
     gevent.sleep(1)
 
     assert new_agent1_sub.callback.call_count == 3
@@ -123,11 +132,13 @@ def test_incorrect_topic(publisher_agent, subscriber_agent):
 
     test_topic = "testtopic1/test/foo/bar"
 
-    subscriber_agent.vip.pubsub.subscribe(peer='pubsub', prefix='incorrecttopic',
+    subscriber_agent.vip.pubsub.subscribe(peer='pubsub',
+                                          prefix='incorrecttopic',
                                           callback=subscriber_agent.callback)
     gevent.sleep(.5)
 
-    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic, headers=None, message="Test message")
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic,
+                                       headers=None, message="Test message")
     gevent.sleep(.5)
 
     # Should get messages from the topic that has messages being published but not from the topic that
@@ -143,17 +154,20 @@ def test_unsubscribe(publisher_agent, subscriber_agent):
 
     # Messages should be recieved by new_agent1 since it has subscribed to test_topic
     for i in range(0, 5):
-        publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic, headers=None, message="Test message")
+        publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic,
+                                           headers=None, message="Test message")
         gevent.sleep(0.01)
         print("count:{}".format(i))
 
     gevent.sleep(0.5)
-    subscriber_agent.vip.pubsub.unsubscribe(peer='pubsub', prefix=test_topic, callback=subscriber_agent.callback)
+    subscriber_agent.vip.pubsub.unsubscribe(peer='pubsub', prefix=test_topic,
+                                            callback=subscriber_agent.callback)
     gevent.sleep(0.5)
 
     # Since agent has unsubscribed from test_topic, these messages should not be recieved
     for x in range(0, 5):
-        publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic, headers=None, message="Test message")
+        publisher_agent.vip.pubsub.publish(peer="pubsub", topic=test_topic,
+                                           headers=None, message="Test message")
         gevent.sleep(0.01)
 
     assert subscriber_agent.callback.call_count <= 5
@@ -169,15 +183,15 @@ def test_irrelevant_unsubscribe(subscriber_agent):
     # Agent has never subscribed to this topic but is attempting to unsubscribe anyway
     # Nothing should happen as a result
     subscriber_agent.vip.pubsub.unsubscribe(peer='pubsub',
-                                      prefix=not_subscribed_topic,
-                                      callback=subscriber_agent.wrong_callback)
+                                            prefix=not_subscribed_topic,
+                                            callback=subscriber_agent.wrong_callback)
     gevent.sleep(0.01)
 
     for i in range(0, 5):
         subscriber_agent.vip.pubsub.publish(peer="pubsub",
-                                      topic=not_subscribed_topic,
-                                      headers=None,
-                                      message="Test message")
+                                            topic=not_subscribed_topic,
+                                            headers=None,
+                                            message="Test message")
         gevent.sleep(0.01)
 
     # Confirm that no messages were ever recieved from the not_subscribed_topic
@@ -201,9 +215,12 @@ def test_list_subscribed(volttron_instance, request):
     test_topic2 = "testtopic1/test/foo/bar/two"
     test_topic3 = "testtopic1/test/foo/bar/three"
 
-    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic1, callback=new_agent1.list_callback)
-    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic2, callback=new_agent1.list_callback)
-    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic3, callback=new_agent1.list_callback)
+    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic1,
+                                    callback=new_agent1.list_callback)
+    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic2,
+                                    callback=new_agent1.list_callback)
+    new_agent1.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic3,
+                                    callback=new_agent1.list_callback)
 
     gevent.sleep(1)
     topic_result_index = 1
@@ -238,13 +255,17 @@ def test_list_subscribed_reverse(volttron_instance, request):
     test_topic1 = "testtopic1/test/foo/bar"
     test_topic2 = "testtopic1/test/foo"
     test_topic3 = "testtopic1"
+    bus_topic = ""
 
     topic_result_index = 1
     member_result_index = 2
 
-    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic1, callback=new_agent2.list_callback)
-    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic2, callback=new_agent2.list_callback)
-    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic3, callback=new_agent2.list_callback)
+    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic1,
+                                    callback=new_agent2.list_callback)
+    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic2,
+                                    callback=new_agent2.list_callback)
+    new_agent2.vip.pubsub.subscribe(peer='pubsub', prefix=test_topic3,
+                                    callback=new_agent2.list_callback)
 
     gevent.sleep(1)
     list_results = new_agent2.vip.pubsub.list(peer='pubsub',
@@ -256,6 +277,49 @@ def test_list_subscribed_reverse(volttron_instance, request):
 
     for result in list_results:
         topic = result[topic_result_index]
-        assert topic in [test_topic1, test_topic2, test_topic3]
-        assert result[member_result_index] == True
+        topics = [test_topic1, test_topic2, test_topic3]
+        assert result[member_result_index] is (True if topic in topics else False)
 
+
+@pytest.mark.pubsub
+def test_multi_unsubscribe(volttron_instance):
+    subscriber_agent = volttron_instance.build_agent()
+    subscriber_agent.subscription_callback = MagicMock(
+        callback='subscription_callback')
+    subscriber_agent.subscription_callback.reset_mock()
+
+    publisher_agent = volttron_instance.build_agent()
+
+    topic_to_check = "testtopic1/test/foo/bar/one"
+    test_topic1 = "testtopic1/test/foo/bar"
+    test_topic2 = "testtopic1/test/foo"
+    test_topic3 = "testtopic1"
+
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic1,
+        callback=subscriber_agent.subscription_callback)
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic2,
+        callback=subscriber_agent.subscription_callback)
+    subscriber_agent.vip.pubsub.subscribe(
+        peer='pubsub', prefix=test_topic3,
+        callback=subscriber_agent.subscription_callback)
+    gevent.sleep(1)
+
+    publisher_agent.vip.pubsub.publish(peer="pubsub",
+                                       topic=topic_to_check,
+                                       message="test message 1")
+    gevent.sleep(1)
+
+    assert subscriber_agent.subscription_callback.call_count == 3
+    subscriber_agent.subscription_callback.reset_mock()
+
+    subscriber_agent.vip.pubsub.unsubscribe("pubsub", prefix=None,
+                                            callback=None)
+    gevent.sleep(1)
+
+    publisher_agent.vip.pubsub.publish(peer="pubsub", topic=topic_to_check,
+                                       message="test message 3")
+    gevent.sleep(1)
+
+    assert subscriber_agent.subscription_callback.call_count == 0


### PR DESCRIPTION
Allowed users to remove all subscription by sending None for prefix and callback to unsubscribe, fixed rmq_pubsub test

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1591 (previously closed)

 response to https://volttron-community.slack.com/archives/C40SDK44E/p1557749359023200

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Local tests for pubsub and rmq pubsub
- [x] Docker tests for pubsub and rmq pubsub

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
