### PR TITLE
Dev volttron

### DIFF
--- a/services/core/VolttronCentral/tests/test_vc_autoregister.py
+++ b/services/core/VolttronCentral/tests/test_vc_autoregister.py
@@ -42,15 +42,15 @@ def multi_messagebus_vc_vcp(volttron_multi_messagebus):
                                             "json").get()
     # "manage_store", opts.identity, opts.name, file_contents, config_type = opts.config_type
 
-    yield vcp_instance, vc_instance
+    yield vcp_instance, vc_instance, vcp_uuid
 
     vcp_instance.remove_agent(vcp_uuid)
     vc_instance.remove_agent(vc_uuid)
 
 
-def test_able_to_register(multi_messagebus_vc_vcp):
+def test_able_to_register_unregister(multi_messagebus_vc_vcp):
     gevent.sleep(10)
-    vcp_instance, vc_instance = multi_messagebus_vc_vcp
+    vcp_instance, vc_instance, vcp_uuid = multi_messagebus_vc_vcp
 
     apitester = APITester(vc_instance)
 
@@ -61,3 +61,10 @@ def test_able_to_register(multi_messagebus_vc_vcp):
 
     assert platform['name'] == vcp_instance.instance_name
 
+    vcp_instance.stop_agent(vcp_uuid)
+
+    gevent.sleep(12)
+    assert not vcp_instance.is_agent_running(vcp_uuid)
+#    print(vc_instance.dynamic_agent.vip.peerlist().get(timeout=10))
+    platforms = apitester.list_platforms()
+    assert len(platforms) == 0

--- a/services/core/VolttronCentral/tests/test_webapi.py
+++ b/services/core/VolttronCentral/tests/test_webapi.py
@@ -23,25 +23,28 @@ def auto_registered_local(vc_and_vcp_together):
     yield webapi
 
 
-@pytest.mark.dev
 def test_platform_list(auto_registered_local):
     webapi = auto_registered_local
 
     assert len(webapi.list_platforms()) == 1
 
-# @pytest.mark.dev
-# def test_platform_inspect(auto_registered_local):
-#     webapi = auto_registered_local
-#     platforms = webapi.list_platforms()
-#     platform_uuid = platforms[0]["uuid"]
-#
-#     agents = webapi.list_agents(platform_uuid)
-#
-#     for agent in agents:
-#         agent_uuid = agent['uuid']
-#         result = webapi.inspect((platform_uuid, agent_uuid))
-#         print result
-#         assert result == False
+
+def test_platform_inspect(auto_registered_local):
+    webapi = auto_registered_local
+    platforms = webapi.list_platforms()
+    platform_uuid = platforms[0]["uuid"]
+
+    agents = webapi.list_agents(platform_uuid)
+
+    for agent in agents:
+        agent_uuid = agent['uuid']
+        result = webapi.inspect(platform_uuid, agent_uuid)
+        print result
+        method = 'health.get_status'
+        assert method in result['methods']
+        # status = webapi.do_rpc('platforms.uuid.{}.agents.uuid.{}.methods.{}'.format(platform_uuid, agent_uuid, method))
+        # assert status['status'] == 'BAD'
+
 
 @pytest.fixture(scope="module")
 def vc_vcp_platforms():

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -1230,7 +1230,7 @@ class VolttronCentralPlatform(Agent):
                     self.get_instance_uuid()))
             gevent.sleep(1)
             try:
-                self._vc_connection.core.stop(timeput=5)
+                self._vc_connection.core.stop(timeout=5)
             except:
                 _log.error("killing _vc_connection connection")
             finally:

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -400,7 +400,6 @@ class VolttronCentralPlatform(Agent):
                 self._vc_connection = self.vip.auth.connect_remote_platform(
                     address=self._vc_address,
                     serverkey=self._vc_serverkey,
-                    rmq_ca_cert=self._vc_rmq_ca_cert,
                     agent_class=VCConnection
                 )
 
@@ -416,7 +415,7 @@ class VolttronCentralPlatform(Agent):
 
             # Break out of the loop if we have successfully connect to the
             # remote platform.
-            if self._vc_connection is not None:
+            if self._vc_connection is not None and isinstance(self._vc_connection, Agent):
                 self._vc_connection.set_main_agent(self)
                 self._still_connected()
                 self._publish_stats()

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -264,7 +264,7 @@ class ControlService(BaseAgent):
         # Send message to router that agent is shutting down
         frames = [bytes(identity)]
 
-        #self.core.connection.send_vip(b'', 'agentstop', frames, copy=False)
+        self.core.connection.send_vip(b'', 'agentstop', args=frames, copy=False)
 
     @RPC.export
     def restart_agent(self, uuid):
@@ -315,7 +315,7 @@ class ControlService(BaseAgent):
         frames = [bytes(identity)]
 
         # Send message to router that agent is shutting down
-        #self.core.connection.send_vip(b'', 'agentstop', args=frames)
+        self.core.connection.send_vip(b'', 'agentstop', args=frames, copy=False)
         self._aip.remove_agent(uuid, remove_auth=remove_auth)
 
     @RPC.export

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -264,7 +264,7 @@ class ControlService(BaseAgent):
         # Send message to router that agent is shutting down
         frames = [bytes(identity)]
 
-        self.core.connection.send_vip(b'', 'agentstop', frames, copy=False)
+        #self.core.connection.send_vip(b'', 'agentstop', frames, copy=False)
 
     @RPC.export
     def restart_agent(self, uuid):
@@ -315,7 +315,7 @@ class ControlService(BaseAgent):
         frames = [bytes(identity)]
 
         # Send message to router that agent is shutting down
-        self.core.connection.send_vip(b'', 'agentstop', args=frames)
+        #self.core.connection.send_vip(b'', 'agentstop', args=frames)
         self._aip.remove_agent(uuid, remove_auth=remove_auth)
 
     @RPC.export

--- a/volttron/platform/vip/agent/__init__.py
+++ b/volttron/platform/vip/agent/__init__.py
@@ -58,7 +58,7 @@ class Agent(object):
                      enable_channel, enable_fncs, message_bus):
             self.peerlist = PeerList(core)
             self.ping = Ping(core)
-            self.rpc = RPC(core, owner)
+            self.rpc = RPC(core, owner, self.peerlist)
             self.hello = Hello(core)
             if message_bus == 'rmq':
                 self.pubsub = RMQPubSub(core, self.rpc, self.peerlist, owner)

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -828,6 +828,9 @@ class ZMQCore(Core):
 
         yield gevent.spawn(vip_loop)
         # pre-stop
+        if self.connected:
+            frames = [bytes(self.identity)]
+            self.connection.send_vip(b'', 'agentstop', args=frames)
         yield
         # pre-finish
         try:

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -303,6 +303,7 @@ class BasicCore(object):
         self.onfinish.send(self)
 
     def stop(self, timeout=None):
+        _log.debug("Stop: XXX")
         def halt():
             self._stop_event.set()
             self.greenlet.join(timeout)
@@ -773,6 +774,7 @@ class ZMQCore(Core):
                     except Exception as exc:
                         _log.debug("Error in closing the socket: {}".format(exc.message))
 
+
         self.onconnected.connect(hello_response)
         self.ondisconnected.connect(close_socket)
 
@@ -830,7 +832,7 @@ class ZMQCore(Core):
         # pre-stop
         if self.connected:
             frames = [bytes(self.identity)]
-            self.connection.send_vip(b'', 'agentstop', args=frames)
+            gevent.spawn(self.connection.send_vip, b'', 'agentstop', args=frames)
         yield
         # pre-finish
         try:
@@ -1029,6 +1031,9 @@ class RMQCore(Core):
                             handle(message)
 
         yield gevent.spawn(vip_loop)
+        if self.connected:
+            frames = [bytes(self.identity)]
+            self.connection.send_vip(b'', 'agentstop', args=frames)
         # pre-stop
         yield
         # pre-finish

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -303,7 +303,6 @@ class BasicCore(object):
         self.onfinish.send(self)
 
     def stop(self, timeout=None):
-        _log.debug("BASICCORE STOP METHOD called")
 
         def halt():
             self._stop_event.set()

--- a/volttron/platform/vip/agent/subsystems/auth.py
+++ b/volttron/platform/vip/agent/subsystems/auth.py
@@ -79,7 +79,7 @@ class Auth(SubsystemBase):
 
         core.onsetup.connect(onsetup, self)
 
-    def connect_remote_platform(self, address, serverkey=None, rmq_ca_cert=None, agent_class=None):
+    def connect_remote_platform(self, address, serverkey=None, agent_class=None):
         """
         Atempts to connect to a remote platform to exchange data.
 
@@ -135,11 +135,6 @@ class Auth(SubsystemBase):
                                 secretkey=secretkey,
                                 message_bus='zmq',
                                 address=address)
-
-        elif parsed_address.scheme in ('amqp', 'amqps'):
-            # Rabbitmq connection
-            # TODO use known host rather than
-            pass
         elif parsed_address.scheme in ('https', 'http'):
             try:
                 # TODO: Use known host instead of looking up for discovery info if possible.

--- a/volttron/platform/vip/agent/subsystems/peerlist.py
+++ b/volttron/platform/vip/agent/subsystems/peerlist.py
@@ -45,6 +45,7 @@ from .base import SubsystemBase
 from ..dispatch import Signal
 from ..results import ResultsDictionary
 from volttron.platform.vip.socket import Message
+from volttron.platform.agent import json as jsonapi
 from zmq import ZMQError
 from zmq.green import ENOTSOCK
 
@@ -76,28 +77,44 @@ class PeerList(SubsystemBase):
                 _log.error("Socket send on non socket {}".format(self.core().identity))
         return result
 
-    def add_peer(self, peer):
+    def add_peer(self, peer, message_bus=None):
         connection = self.core().connection
         result = next(self._results)
-
+        if not message_bus:
+            message_bus = self.core().messagebus
         try:
             connection.send_vip(b'',
                                 b'peerlist',
-                                args=[b'add', bytes(peer)],
+                                args=[b'add', bytes(peer), bytes(message_bus)],
                                 msg_id=result.ident)
         except ZMQError as exc:
             if exc.errno == ENOTSOCK:
                 _log.error("Socket send on non socket {}".format(self.core().identity))
         return result
 
-    def drop_peer(self, peer):
+    def drop_peer(self, peer, message_bus=None):
+        connection = self.core().connection
+        result = next(self._results)
+        if not message_bus:
+            message_bus = self.core().messagebus
+        try:
+            connection.send_vip(b'',
+                                b'peerlist',
+                                args=[b'drop', bytes(peer), bytes(message_bus)],
+                                msg_id=result.ident)
+        except ZMQError as exc:
+            if exc.errno == ENOTSOCK:
+                _log.error("Socket send on non socket {}".format(self.core().identity))
+        return result
+
+    def list_with_messagebus(self):
         connection = self.core().connection
         result = next(self._results)
 
         try:
             connection.send_vip(b'',
                                 b'peerlist',
-                                args=[b'drop', bytes(peer)],
+                                args=[b'list_with_messagebus'],
                                 msg_id=result.ident)
         except ZMQError as exc:
             if exc.errno == ENOTSOCK:
@@ -118,13 +135,27 @@ class PeerList(SubsystemBase):
             except IndexError:
                 _log.error('missing peerlist identity in %s operation', op)
                 return
-            getattr(self, 'on' + op).send(self, peer=peer)
+            message_bus = None
+            try:
+                message_bus = bytes(message.args[2])
+            except IndexError:
+                pass
+            if message_bus:
+                getattr(self, 'on' + op).send(self, peer=peer, message_bus=message_bus)
+            else:
+                getattr(self, 'on' + op).send(self, peer=peer)
         elif op == b'listing':
             try:
                 result = self._results.pop(bytes(message.id))
             except KeyError:
                 return
             result.set([bytes(arg) for arg in message.args[1:]])
+        elif op == b'listing_with_messagebus':
+            try:
+                result = self._results.pop(bytes(message.id))
+            except KeyError:
+                return
+            result.set(jsonapi.loads(message.args[1]))
         else:
             _log.error('unknown peerlist subsystem operation == {}'.format(op))
 

--- a/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/rmq_pubsub.py
@@ -356,7 +356,8 @@ class RMQPubSub(BasePubSub):
                 topic = item[1]
                 if test(topic):
                     member = self.core().identity in peer
-                    results.append(('', topic, member))
+                    if not subscribed or member:
+                        results.append(('', topic, member))
         self.core().spawn_later(0.01, self.set_result, async_result.ident, results)
         return async_result
 

--- a/volttron/platform/vip/agent/subsystems/rpc.py
+++ b/volttron/platform/vip/agent/subsystems/rpc.py
@@ -189,7 +189,7 @@ class Dispatcher(jsonrpc.Dispatcher):
 
 
 class RPC(SubsystemBase):
-    def __init__(self, core, owner):
+    def __init__(self, core, owner, peerlist_subsys):
         self.core = weakref.ref(core)
         self._owner = owner
         self.context = None
@@ -201,6 +201,8 @@ class RPC(SubsystemBase):
         core.register('external_rpc', self._handle_external_rpc_subsystem, self._handle_error)
         self._isconnected = True
         self._message_bus = self.core().messagebus
+        self.peerlist_subsystem = peerlist_subsys
+        self.peer_list = {}
 
         def export(member):   # pylint: disable=redefined-outer-name
             for name in annotations(member, set, 'rpc.exports'):
@@ -218,9 +220,27 @@ class RPC(SubsystemBase):
 
     def _connected(self, sender, **kwargs):
         self._isconnected =True
+        # Registering to 'onadd' and 'ondrop' signals to get notified whenever new peer is added/removed
+        self.peerlist_subsystem.onadd.connect(self._add_new_peer)
+        self.peerlist_subsystem.ondrop.connect(self._drop_new_peer)
 
     def _disconnected(self, sender, **kwargs):
         self._isconnected = False
+
+    def _add_new_peer(self, sender, **kwargs):
+        try:
+            peer = kwargs.pop('peer')
+            message_bus = kwargs.pop('message_bus')
+            self.peer_list[peer] = message_bus
+        except KeyError:
+            pass
+
+    def _drop_new_peer(self, sender, **kwargs):
+        try:
+            peer = kwargs.pop('peer')
+            self.peer_list.pop(peer)
+        except KeyError:
+            pass
 
     def _iterate_exports(self):
         '''Iterates over exported methods and adds authorization checks
@@ -254,16 +274,16 @@ class RPC(SubsystemBase):
         op = message.args[0].bytes
         rpc_msg = jsonapi.loads(message.args[1].bytes)
         try:
-            #_log.debug("EXT_RPC subsystem handler IN message {0}, {1}".format(message.peer, rpc_msg))
+            # _log.debug("EXT_RPC subsystem handler IN message {0}, {1}".format(message.peer, rpc_msg))
             method_args = rpc_msg['args']
             #message.args = [method_args]
             message.args = method_args
             dispatch = self._dispatcher.dispatch
-            #_log.debug("External RPC IN message args {}".format(message))
+            # _log.debug("External RPC IN message args {}".format(message))
 
             responses = [response for response in (
                 dispatch(bytes(msg), message) for msg in message.args) if response]
-            #_log.debug("External RPC Resonses {}".format(responses))
+            # _log.debug("External RPC Resonses {}".format(responses))
             if responses:
                 message.user = ''
                 try:
@@ -304,7 +324,22 @@ class RPC(SubsystemBase):
             message.args = responses
             try:
                 if self._isconnected:
-                    self.core().connection.send_vip_object(message, copy=False)
+                    if self._message_bus == 'zmq':
+                        self.core().connection.send_vip_object(message, copy=False)
+                    else:
+                        # Agent is running on RMQ message bus.
+                        # Adding backward compatibility support for ZMQ. Check if the peer
+                        # is running on ZMQ bus. If yes, send RPC message to proxy router
+                        # agent to forward using ZMQ message bus connection
+                        try:
+                            msg_bus = self.peer_list[message.peer]
+                        except KeyError:
+                            msg_bus = self._message_bus
+                        if msg_bus == 'zmq':
+                            # If peer connected to ZMQ bus, send via proxy router agent
+                            self.core().connection.send_vip_object_via_proxy(message)
+                        else:
+                            self.core().connection.send_vip_object(message, copy=False)
             except ZMQError as exc:
                 if exc.errno == ENOTSOCK:
                     _log.debug("Socket send on non socket {}".format(self.core().identity))
@@ -365,10 +400,9 @@ class RPC(SubsystemBase):
             return
 
         if self._message_bus == 'zmq':
-            if platform == '':#local platform
+            if platform == '': #local platform
                 subsystem = b'RPC'
                 frames.append(request)
-                #self.core().socket.send_vip(peer, 'RPC', [request], msg_id=ident)
             else:
                 frames = []
                 op = b'send_platform'
@@ -389,13 +423,25 @@ class RPC(SubsystemBase):
             except ZMQError as exc:
                 if exc.errno == ENOTSOCK:
                     _log.debug("Socket send on non socket {}".format(self.core().identity))
-            #_log.debug("RPC subsystem: External platform RPC msg: {}".format(frames))
+            # _log.debug("RPC subsystem: External platform RPC msg: {}".format(frames))
         else:
-            self.core().connection.send_vip(peer,
-                                            b'RPC',
-                                            args=[request],
-                                            msg_id=ident,
-                                            platform=platform)
+            # Agent running on RMQ message bus.
+            # Adding backward compatibility support for ZMQ. Check if peer
+            # is running on ZMQ bus. If yes, send RPC message to proxy router agent to
+            # forward over ZMQ message bus connection
+            try:
+                peer_msg_bus = self.peer_list[peer]
+            except KeyError:
+                peer_msg_bus = self._message_bus
+            if peer_msg_bus == 'zmq':
+                # peer connected to ZMQ bus, send via proxy router agent
+                self.core().connection.send_via_proxy(peer, b'RPC', msg_id=ident, args=[request])
+            else:
+                self.core().connection.send_vip(peer,
+                                                b'RPC',
+                                                args=[request],
+                                                msg_id=ident,
+                                                platform=platform)
 
         return result
 
@@ -431,23 +477,27 @@ class RPC(SubsystemBase):
             except ZMQError as exc:
                 if exc.errno == ENOTSOCK:
                     _log.debug("Socket send on non socket {}".format(self.core().identity))
-
-        elif self._message_bus == 'rmq':
-            self.core().connection.send_vip_object(Message(peer=peer,
-                                                           subsystem=b'RPC',
-                                                           args=[request],
-                                                           platform=platform))
         else:
-            return
-
-        if self._isconnected:
+            # Agent running on RMQ message bus.
+            # Adding backward compatibility support for ZMQ. Check if peer
+            # is running on ZMQ bus. If yes, send RPC message to proxy router agent to
+            # forward over ZMQ message bus connection
             try:
-                self.core().connection.send_vip(b'',
+                peer_msg_bus = self.peer_list[peer]
+            except KeyError:
+                #self.peer_list = self.peerlist_subsystem.list_with_messagebus().get(2)
+                #_log.debug("PEERS: {}".format(self.peer_list))
+                peer_msg_bus = self._message_bus
+            if peer_msg_bus == 'zmq':
+                # peer connected to ZMQ bus, send via proxy router agent
+                self.core().connection.send_via_proxy(peer,
+                                                      b'RPC',
+                                                      args=[request])
+            else:
+                self.core().connection.send_vip(peer,
                                                 b'RPC',
-                                                args=[request])
-            except ZMQError as exc:
-                if exc.errno == ENOTSOCK:
-                    _log.debug("Socket send on non socket {}".format(self.core().identity))
+                                                args=[request],
+                                                platform=platform)
 
     @dualmethod
     def allow(self, method, capabilities):
@@ -471,7 +521,7 @@ class RPC(SubsystemBase):
             def get_status():
                 ...
 
-        Multiple capabilies can be provided in a list:
+        Multiple capabilities can be provided in a list:
         .. code-block:: python
 
             @RPC.allow(['can_read_status', 'can_call_my_methods'])
@@ -485,3 +535,4 @@ class RPC(SubsystemBase):
                     annotate(method, set, 'rpc.allow_capabilities', cap)
             return method
         return decorate
+    

--- a/volttron/platform/vip/proxy_zmq_router.py
+++ b/volttron/platform/vip/proxy_zmq_router.py
@@ -210,7 +210,7 @@ class ZMQProxyRouter(Agent):
         """
         zmq_frames = []
         frames = jsonapi.loads(body)
-        _log.debug("Frames: {}".format(frames))
+
         for frame in frames:
             zmq_frames.append(bytes(frame))
         try:

--- a/volttron/platform/vip/rmq_router.py
+++ b/volttron/platform/vip/rmq_router.py
@@ -96,6 +96,7 @@ class RMQRouter(BaseRouter):
         """
         self.default_user_id = default_user_id
         self._peers = set()
+        self._peers_with_messagebus = dict()
         self.addresses = [Address(addr) for addr in set(addresses)]
         self.local_address = Address(local_address)
         self._address = address
@@ -173,20 +174,23 @@ class RMQRouter(BaseRouter):
     def issue(self, topic, frames, extra=None):
         pass
 
-    def _add_peer(self, peer):
+    def _add_peer(self, peer, message_bus='rmq'):
+        _log.debug("NEW PEER: {}".format(peer))
         if peer == self._identity:
             return
         if peer in self._peers:
             return
-        self._distribute(b'peerlist', b'add', peer)
+        self._distribute(b'peerlist', b'add', peer, message_bus)
         self._peers.add(peer)
+        self._peers_with_messagebus[peer] = message_bus
 
-    def _drop_peer(self, peer):
+    def _drop_peer(self, peer, message_bus='rmq'):
         try:
             self._peers.remove(peer)
+            self._peers_with_messagebus[peer] = message_bus
         except KeyError:
             return
-        self._distribute(b'peerlist', b'drop', peer)
+        self._distribute(b'peerlist', b'drop', peer, message_bus)
 
     def route(self, message):
         '''Route one message and return.
@@ -229,12 +233,26 @@ class RMQRouter(BaseRouter):
                 del message.args[:]
                 message.args = [b'listing']
                 message.args.extend(self._peers)
+            if op == b'list_with_messagebus':
+                _log.debug("Router peerlist request op: list_with_messagebus, {}, {}".format(sender, self._peers))
+                del message.args[:]
+                message.args = [b'listing_with_messagebus']
+                message.args.append(jsonapi.dumps(self._peers_with_messagebus))
+                _log.debug("Router peerlist request op: list_with_messagebus, {}, {}".format(sender, self._peers))
             elif op == b'add':
                 peer = message.args[1]
-                self._add_peer(peer=peer)
+                try:
+                    message_bus = message.args[2]
+                except IndexError:
+                    message_bus = 'rmq'
+                self._add_peer(peer=peer, message_bus=message_bus)
             elif op == b'drop':
                 peer = message.args[1]
-                self._drop_peer(peer=peer)
+                try:
+                    message_bus = message.args[2]
+                except IndexError:
+                    message_bus = 'rmq'
+                self._drop_peer(peer=peer, message_bus=message_bus)
             else:
                 error = (b'unknown' if op else b'missing') + b' operation'
                 message.args.extend([b'error', error])
@@ -243,6 +261,7 @@ class RMQRouter(BaseRouter):
                 self.stop()
                 raise KeyboardInterrupt()
         elif subsystem == b'agentstop':
+            _log.debug("ROUTER received agent stop {}".format(sender))
             try:
                 drop = message.args[0]
                 self._drop_peer(drop)
@@ -310,7 +329,10 @@ class RMQRouter(BaseRouter):
         message = Message(peer=None, subsystem=parts[0], args=parts[1:])
         for peer in self._peers:
             message.peer = peer
-            self.connection.send_vip_object(message)
+            if self._peers_with_messagebus[peer] == 'rmq':
+                self.connection.send_vip_object(message)
+            else:
+                self.connection.send_vip_object_via_proxy(message)
 
     def _make_user_access_tokens(self, identity):
         tokens = dict()

--- a/volttron/platform/vip/rmq_router.py
+++ b/volttron/platform/vip/rmq_router.py
@@ -175,7 +175,6 @@ class RMQRouter(BaseRouter):
         pass
 
     def _add_peer(self, peer, message_bus='rmq'):
-        _log.debug("NEW PEER: {}".format(peer))
         if peer == self._identity:
             return
         if peer in self._peers:

--- a/volttron/platform/vip/zmq_connection.py
+++ b/volttron/platform/vip/zmq_connection.py
@@ -108,7 +108,8 @@ class ZMQConnection(BaseConnection):
 
     def send_vip(self, peer, subsystem, args=None, msg_id=b'',
                  user=b'', via=None, flags=0, copy=True, track=False):
-        self.socket.send_vip(peer, subsystem, args, msg_id, user, via, flags, copy, track)
+        self.socket.send_vip(peer, subsystem, args=args, msg_id=msg_id, user=user,
+                             via=via, flags=flags, copy=copy, track=track)
 
     def recv_vip_object(self, flags=0, copy=True, track=False):
         return self.socket.recv_vip_object(flags, copy, track)
@@ -116,7 +117,7 @@ class ZMQConnection(BaseConnection):
     def disconnect(self):
         self.socket.disconnect(self._url)
 
-    def close_connection(self, linger=1):
+    def close_connection(self, linger=5):
         """This method closes ZeroMQ socket"""
         self.socket.close(linger)
         _log.debug("********************************************************************")

--- a/volttron/platform/vip/zmq_connection.py
+++ b/volttron/platform/vip/zmq_connection.py
@@ -62,7 +62,7 @@ import green as vip
 
 from volttron.platform.vip.rmq_connection import BaseConnection
 from volttron.platform.vip.socket import Message
-
+_log = logging.getLogger(__name__)
 
 class ZMQConnection(BaseConnection):
     """
@@ -119,4 +119,7 @@ class ZMQConnection(BaseConnection):
     def close_connection(self, linger=1):
         """This method closes ZeroMQ socket"""
         self.socket.close(linger)
+        _log.debug("********************************************************************")
+        _log.debug("Closing connection to ZMQ: {}".format(self._identity))
+        _log.debug("********************************************************************")
 


### PR DESCRIPTION
# Description
This PR fixes backward compatibility issue with 2 instances, one running on ZMQ bus and other running on RMQ bus. If agent on RMQ bus wants to make RPC call on agent running on ZMQ bus, it needs to know the on which bus it is running. Peerlist now contains 'messagebus' as metadata information.

This PR also fixes the issue of peerlist not getting updated when agent.core.stop() is explicitly called. An 'agentstop' message is sent to router inside stop() to notify that agent is shutting down.

Fixes #2006 
Fixes #2007 
