### PR TITLE
alert handle using identity

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ markers =
         actuator: Tests for actuator agent
         actuator_pubsub: Test for actuator agent.
         agent: Testing for core agent operations.
+        alert: Testing alerts from the health subsystem.
         auth: Testing for auth based code.
         control: Control service/aip tests.
         config_store: Configuration store tests.
@@ -19,6 +20,8 @@ markers =
         forwarder: Tests for forwardhistorian
         gevent: Functionality tests for gevent.
         historian: Test cases for historian.
+        health: Testing the health subsystem.
+        heartbeat: Testing the heartbeat subsystem.
         keystore: Test the keystore and known-hosts store.
         mongodb: Tests for mongodb related test code.
         pa: Tests for the platform agent.

--- a/services/core/DNP3Agent/tests/mesa_master_cmd.py
+++ b/services/core/DNP3Agent/tests/mesa_master_cmd.py
@@ -27,6 +27,12 @@
 # favoring by 8minutenergy or Kisensum.
 # }}}
 
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+    
 import cmd
 import logging
 import sys

--- a/services/core/DNP3Agent/tests/mesa_master_test.py
+++ b/services/core/DNP3Agent/tests/mesa_master_test.py
@@ -27,6 +27,12 @@
 # favoring by 8minutenergy or Kisensum.
 # }}}
 
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+
 import json
 
 from collections import OrderedDict

--- a/services/core/DNP3Agent/tests/test_dnp3_agent.py
+++ b/services/core/DNP3Agent/tests/test_dnp3_agent.py
@@ -32,6 +32,12 @@
 # United States Government or any agency thereof.
 # }}}
 
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+
 import gevent
 import json
 import os

--- a/services/core/DNP3Agent/tests/test_functions.py
+++ b/services/core/DNP3Agent/tests/test_functions.py
@@ -1,3 +1,9 @@
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+
 import copy
 
 from dnp3.points import PointDefinitions

--- a/services/core/DNP3Agent/tests/test_mesa_agent.py
+++ b/services/core/DNP3Agent/tests/test_mesa_agent.py
@@ -27,6 +27,12 @@
 # favoring by 8minutenergy or Kisensum.
 # }}}
 
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+
 import gevent
 import json
 import os

--- a/services/core/DNP3Agent/tests/test_points.py
+++ b/services/core/DNP3Agent/tests/test_points.py
@@ -1,3 +1,9 @@
+import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
+
 import copy
 
 from dnp3.points import PointDefinition, ArrayHeadPointDefinition, PointDefinitions, PointValue

--- a/services/core/DNP3Agent/tests/unit_test_point_definitions.py
+++ b/services/core/DNP3Agent/tests/unit_test_point_definitions.py
@@ -28,6 +28,10 @@
 # }}}
 
 import pytest
+try:
+    import dnp3
+except ImportError:
+    pytest.skip("pydnp3 not found!", allow_module_level=True)
 
 from dnp3.points import ArrayHeadPointDefinition, PointDefinitions, PointValue
 from dnp3.mesa.agent import MesaAgent

--- a/volttron/platform/messaging/topics.py
+++ b/volttron/platform/messaging/topics.py
@@ -80,7 +80,7 @@ __copyright__ = 'Copyright (c) 2016, Battelle Memorial Institute'
 __license__ = 'FreeBSD'
 
 ALERTS_BASE = _('alerts')
-ALERTS = _('alerts/{agent_class}/{agent_uuid}') #/{agent_class}/{publickey}/{alert_key}')
+ALERTS = _('alerts/{agent_class}/{agent_identity}') #/{agent_class}/{publickey}/{alert_key}')
 
 HEARTBEAT = _('heartbeats')
 PLATFORM_BASE = _('platform')

--- a/volttron/platform/vip/agent/subsystems/health.py
+++ b/volttron/platform/vip/agent/subsystems/health.py
@@ -88,7 +88,9 @@ class Health(SubsystemBase):
             raise ValueError('statusobj must be a Status object.')
         agent_class = self._owner.__class__.__name__
         fq_identity = get_fq_identity(self._core().identity)
-        topic = topics.ALERTS(agent_class=agent_class, identity=fq_identity)
+        # RMQ and other message buses can't handle '.' because it's used as the separator.  This
+        # causes us to change the alert topic's agent_identity to have '_' rather than '.'.
+        topic = topics.ALERTS(agent_class=agent_class, agent_identity=fq_identity.replace('.', '_'))
         headers = dict(alert_key=alert_key)
 
         self._owner.vip.pubsub.publish("pubsub",

--- a/volttron/platform/vip/agent/subsystems/heartbeat.py
+++ b/volttron/platform/vip/agent/subsystems/heartbeat.py
@@ -112,7 +112,12 @@ class Heartbeat(SubsystemBase):
         Stop an agent's heartbeat.
         """
         if self.enabled:
-            self.scheduled.cancel()
+            # Trap the fact that scheduled may not have been
+            # set yet if the start hasn't been called.
+            try:
+                self.scheduled.cancel()
+            except AttributeError:
+                pass
             self.enabled = False
 
     def restart(self):

--- a/volttrontesting/subsystems/test_health_subsystem.py
+++ b/volttrontesting/subsystems/test_health_subsystem.py
@@ -1,6 +1,8 @@
 import gevent
 import pytest
 
+from mock import MagicMock
+
 from volttron.platform.messaging import topics
 from volttron.platform.messaging.headers import DATE
 from volttron.platform.messaging.health import *
@@ -17,7 +19,31 @@ def onmessage(peer, sender, bus, topic, headers, message):
     print("subscription_results[{}] = {}".format(topic, subscription_results[topic]))
 
 
+@pytest.fixture(scope="module")
+def alert_watcher_agent(volttron_instance):
+    alert_watcher = volttron_instance.build_agent()
+
+    alert_watcher.alert_callback = MagicMock(name="callback")
+    alert_watcher.alert_callback.reset_mock()
+
+    alerts_topic = "alerts"
+    # Agent subscribes to both the desired topic and a topic that is not going to ever be published
+    alert_watcher.vip.pubsub.subscribe(peer='pubsub', prefix=alerts_topic, callback=alert_watcher.alert_callback)
+
+    yield alert_watcher
+
+    alert_watcher.core.stop()
+
+
+@pytest.fixture(scope="module")
+def alerting_agent(volttron_instance):
+    alerting_agent = volttron_instance.build_agent(identity='alerting.agent')
+    yield alerting_agent
+    alerting_agent.core.stop()
+
+
 @pytest.mark.subsystems
+@pytest.mark.health
 def test_can_set_status(volttron_instance):
     """ Tests the ability to change a status by sending a different status
     code.
@@ -59,6 +85,7 @@ def test_can_set_status(volttron_instance):
 
 
 @pytest.mark.subsystems
+@pytest.mark.health
 def test_invalid_status(volttron_instance):
     """ Tests if a non-known status is sent then the sstatus is set to
     bad.
@@ -74,68 +101,78 @@ def test_invalid_status(volttron_instance):
     assert orig_status["status"] == STATUS_GOOD
     with pytest.raises(ValueError):
         new_agent.vip.health.set_status('Bogus')
-    # new_status =Status.from_json(new_agent.vip.health.get_status())
-    # assert STATUS_BAD == new_status.status
 
 
 @pytest.mark.subsystems
-@pytest.mark.xfail(reason="Need to upgrade")
+@pytest.mark.heartbeat
 def test_heartbeat_sending_status(volttron_instance):
     """ Tests the heartbeat message that it has the status.
 
     :param volttron_instance:
     :return:
     """
-    global subscription_results
-    subscription_results.clear()
-    agent_prefix = 'heartbeat/Agent'
-    new_agent = volttron_instance.build_agent(identity='test3')
-    orig_status = new_agent.vip.health.get_status()
-    new_agent.vip.pubsub.subscribe(peer='pubsub',
-                                   prefix=agent_prefix, callback=onmessage)
-    new_agent.vip.heartbeat.start()
-    poll_gevent_sleep(2, lambda: messages_contains_prefix(agent_prefix,
-                                                          subscription_results))
+    heartbeat_agent = volttron_instance.build_agent(identity='heartbeat_agent')
+    heartbeat_watcher = volttron_instance.build_agent(identity='heartbeat_watcher')
+    try:
+        heartbeat_watcher.callback_heartbeat = MagicMock(name='callback')
+        heartbeat_watcher.callback_heartbeat.reset_mock()
+        heartbeat_watcher.vip.pubsub.subscribe(peer='pubsub', prefix='heartbeat',
+                                               callback=heartbeat_watcher.callback_heartbeat).get()
+        gevent.sleep(0.1)
+        heartbeat_agent.vip.heartbeat.enabled = True
+        heartbeat_agent.vip.heartbeat.start_with_period(2)
+        gevent.sleep(0.1)
+        heartbeat_watcher.callback_heartbeat.assert_called_once()
+        heartbeat_watcher.callback_heartbeat.reset_mock()
+        gevent.sleep(2)
+        heartbeat_watcher.callback_heartbeat.assert_called_once()
 
-    print subscription_results
-    message = subscription_results[agent_prefix]['message']
-    headers = subscription_results[agent_prefix]['headers']
-    d = message
-    assert headers[DATE] is not None
-    assert d["last_updated"] is not None
-    assert orig_status["status"] == d["status"]
-    assert orig_status["context"] == d["context"]
+        args = heartbeat_watcher.callback_heartbeat.call_args[0]
+        # args[5] is the message sent during the heartbeat, if it is OK then the word GOOD (STATUS_GOOD)
+        assert STATUS_GOOD == args[5]
+
+    finally:
+        heartbeat_watcher.core.stop()
+        heartbeat_agent.core.stop()
 
 
 @pytest.mark.subsystems
-def test_alert_publish(volttron_instance):
+@pytest.mark.alert
+def test_alert_publish(volttron_instance, alert_watcher_agent, alerting_agent):
     """ Tests the heartbeat message that it has the status.
 
     :param volttron_instance:
     :return:
     """
-    global subscription_results
-    subscription_results.clear()
-    alert_prefix = 'alerts'
-    new_agent = volttron_instance.build_agent(identity='alert1')
-    status = Status.build(BAD_STATUS, "Too many connections!")
-    new_agent.vip.pubsub.subscribe(peer='pubsub',
-                                   prefix='', callback=onmessage)
-    gevent.sleep(0.3)
-    orig_status = new_agent.vip.health.send_alert("too_many", status)
-    poll_gevent_sleep(2, lambda: messages_contains_prefix(alert_prefix,
-                                                          subscription_results))
-    print("THE SUBSCRIPTIONS ARE: {}".format(subscription_results))
-    if not messages_contains_prefix(alert_prefix, subscription_results):
-        pytest.fail('prefix not found')
 
-    headers = subscription_results['alerts/Agent']['headers']
-    message = subscription_results['alerts/Agent']['message']
+    try:
+        # pubsub topics always have the following signature
+        # peer, sender, bus,  topic, headers, message
+        # so the arugments taht should be passed to the alert callback should be the following
+        alerting_agent.vip.health.send_alert("Foo/Bar", Status.build(STATUS_BAD))
+        gevent.sleep(0.1)
+        assert alert_watcher_agent.alert_callback.call_count == 1
+        alert_watcher_agent.alert_callback.assert_called_once()
+        args = alert_watcher_agent.alert_callback.call_args[0]
+        # Peer
+        assert 'pubsub' == args[0]
+        # sender (i.e. the agent that is alerting)
+        assert alerting_agent.core.identity == args[1]
+        # topic (note topic now has _ instead of dots
+        expected_topic = 'alerts/Agent/{}.{}'.format(volttron_instance.instance_name, alerting_agent.core.identity)
+        expected_topic = expected_topic.replace('.', '_')
+        assert expected_topic == args[3]
+        # header
+        assert 'alert_key' in args[4]
+        assert 'Foo/Bar' == args[4]['alert_key']
+        # message
+        status = Status.from_json(args[5])
+        assert status.context is None
+        assert status.status == 'BAD'
+        assert status.last_updated is not None
 
-    assert "too_many", headers['alert_key']
-    passed_status = Status.from_json(message)
-    assert status.status == passed_status.status
-    assert status.context == passed_status.context
-    assert status.last_updated == passed_status.last_updated
+    finally:
+        alert_watcher_agent.alert_callback.reset_mock()
+
 
 


### PR DESCRIPTION
# Description

This PR addresses an issue that was introduced when alerts started using identities instead of guid of the installed agent.  This issue is relevant when an agent attempts to send an alert due to agent health.

Note in the alert topic that is raised during the send_alert call, the identity has a string replacement for '.' to '_'.  This change allows rmq and other message buses that use a '.' delimiter to correctly subscribe to the alerts (such as EmailerAgent).

Fixes #2009 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

test_health_subsystem now has a test which tests the contents of the alerts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
