### PR TITLE
Updated rmq dependencies

### DIFF
--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-list=( artful bionic  precise artful sid stretch buster trusty weezy xenial yakkety zesty )
+list=( bionic  artful stretch buster trusty xenial )
 
 function exit_on_error {
     rc=$?
@@ -70,12 +70,13 @@ function install_on_debian {
     echo "installing ERLANG"
     $prefix apt-get install apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git
     $prefix apt-get purge -yf erlang*
+    # Add the signing key
+    wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | sudo apt-key add -
 
-    wget -O - 'https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc' | $prefix apt-key add -
-
-    if [ ! -f "/etc/apt/sources.list.d/bintray.erlang.list" ]; then
-      echo "deb https://dl.bintray.com/rabbitmq/debian $DIST erlang-21.x"|$prefix tee --append /etc/apt/sources.list.d/bintray.erlang.list
+    if [ ! -f "/etc/apt/sources.list.d/erlang.solutions.list" ]; then
+        echo "deb https://packages.erlang-solutions.com/ubuntu $DIST contrib" | sudo tee /etc/apt/sources.list.d/erlang.solutions.list
     fi
+
     $prefix apt-get update
     $prefix apt-get install -yf
     $prefix apt-get install -y erlang-base erlang-diameter erlang-eldap erlang-ssl erlang-crypto erlang-asn1 erlang-public-key


### PR DESCRIPTION
# Description

Use erlang-solutions server rather than the link from bintray.  This seems to be a better standard for erlang distributions.

Fixes #2023



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with xenial xfce distribution.  
