### PR TITLE
 'error' and 'unknown operation' in peerlist

### DIFF
--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -930,6 +930,7 @@ def start_volttron_process(opts):
                               external_address_config=external_address_file,
                               setup_mode=opts.setup_mode,
                               bind_web_address=opts.bind_web_address,
+                              enable_store=False,
                               message_bus='zmq'),
             # For Backward compatibility with VOLTTRON versions <= 4.1
             PubSubWrapper(address=address,

--- a/volttron/platform/vip/rmq_router.py
+++ b/volttron/platform/vip/rmq_router.py
@@ -232,7 +232,7 @@ class RMQRouter(BaseRouter):
                 del message.args[:]
                 message.args = [b'listing']
                 message.args.extend(self._peers)
-            if op == b'list_with_messagebus':
+            elif op == b'list_with_messagebus':
                 _log.debug("Router peerlist request op: list_with_messagebus, {}, {}".format(sender, self._peers))
                 del message.args[:]
                 message.args = [b'listing_with_messagebus']


### PR DESCRIPTION
Found 'error' and 'unknown operation' in list of peers when testing "vctl peerlist" command. This was introduced due to unintentional if-else condition in rmq router. Corrected the if-else error

Fixes #2015

