### PR TITLE
Changes to get all rmq certs tests to pass

### DIFF
--- a/volttron/utils/rmq_config_params.py
+++ b/volttron/utils/rmq_config_params.py
@@ -79,6 +79,25 @@ class RMQConfig(object):
             self.load_rmq_config()
         except (IOError, yaml.YAMLError) as exc:
             self.config_opts = {}
+        self._set_default_config()
+
+    def _set_default_config(self):
+        """
+        init with default values
+        :return:
+        """
+        self.config_opts.setdefault('host', "localhost")
+        self.config_opts.setdefault("ssl", "true")
+        self.config_opts.setdefault('amqp-port', 5672)
+        self.config_opts.setdefault('amqp-port-ssl', 5671)
+        self.config_opts.setdefault('mgmt-port', 15672)
+        self.config_opts.setdefault('mgmt-port-ssl', 15671)
+        self.config_opts.setdefault('virtual-host', 'volttron')
+        self.config_opts.setdefault('reconnect-delay', 30)
+        self.config_opts.setdefault('user', self.instance_name + '-admin')
+        rmq_home = os.path.join(os.path.expanduser("~"),
+                                "rabbitmq_server/rabbitmq_server-3.7.7")
+        self.config_opts.setdefault("rmq-home", rmq_home)
 
     def load_rmq_config(self, volttron_home=None):
         """
@@ -110,25 +129,7 @@ class RMQConfig(object):
         except yaml.YAMLError as exc:
             raise
 
-    def set_default_config(self):
-        """
-        Check if basic configuration is available in the config file,
-        if not set default.
-        :return:
-        """
-        self.config_opts.setdefault('host', "localhost")
-        self.config_opts.setdefault("ssl", "true")
-        self.config_opts.setdefault('amqp-port', 5672)
-        self.config_opts.setdefault('amqp-port-ssl', 5671)
-        self.config_opts.setdefault('mgmt-port', 15672)
-        self.config_opts.setdefault('mgmt-port-ssl', 15671)
-        self.config_opts.setdefault('virtual-host', 'volttron')
-        self.config_opts.setdefault('reconnect-delay', 30)
-        self.config_opts.setdefault('user', self.instance_name + '-admin')
-        rmq_home = os.path.join(os.path.expanduser("~"),
-                                "rabbitmq_server/rabbitmq_server-3.7.7")
-        self.config_opts.setdefault("rmq-home", rmq_home)
-        self.write_rmq_config()
+
 
     @property
     def hostname(self):

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -98,9 +98,6 @@ def _start_rabbitmq_without_ssl(rmq_config, conf_file, env=None):
         else:
             os.environ['RABBITMQ_HOME'] = rmq_home
 
-    # Why do we need the below. This would override any custom tcp and management port and we don't want that
-    # rmq_config.set_default_config()
-
     # attempt to stop
     stop_rabbit(rmq_home, env, quite=True)
 

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -264,12 +264,16 @@ class PlatformWrapper:
         # Writes the main volttron config file for this instance.
         store_message_bus_config(self.messagebus, self.instance_name)
 
-        # Necessary for rabbitmq to shutdown the correct rmq messagebus.
-        # This is set during the startup_platform method.
-        self.rabbitmq_config_obj = None
         self.remote_platform_ca = remote_platform_ca
         self.requests_ca_bundle = None
         self.dynamic_agent = None
+
+        if self.messagebus == 'rmq':
+            self.rabbitmq_config_obj = create_rmq_volttron_setup(vhome=self.volttron_home,
+                                                                 ssl_auth=self.ssl_auth,
+                                                                 env=self.env)
+
+            self.certsobj = Certs(os.path.join(self.volttron_home, "certificates"))
 
         self.debug_mode = self.env.get('DEBUG_MODE', False)
         if not self.debug_mode:
@@ -516,15 +520,7 @@ class PlatformWrapper:
         self.local_vip_address = ipc + 'vip.socket'
         self.set_auth_dict(auth_dict)
 
-        if self.messagebus == 'rmq':
-
-            self.rabbitmq_config_obj = create_rmq_volttron_setup(vhome=self.volttron_home,
-                                                                 ssl_auth=self.ssl_auth,
-                                                                 env=self.env)
-
-            self.certsobj = Certs(os.path.join(self.volttron_home, "certificates"))
-
-            if bind_web_address:
+        if self.messagebus == 'rmq' and bind_web_address:
                 self.env['REQUESTS_CA_BUNDLE'] = self.certsobj.cert_file(self.certsobj.root_ca_name)
 
         if self.remote_platform_ca:

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -1125,7 +1125,8 @@ class PlatformWrapper:
             if pid is not None and int(pid) > 0:
                 running_pids.append(int(pid))
         self.remove_all_agents()
-        self.dynamic_agent.vip.rpc(CONTROL, 'shutdown').get()
+        # don't wait indefinetly as shutdown will not throw an error if RMQ is down/has cert errors
+        self.dynamic_agent.vip.rpc(CONTROL, 'shutdown').get(timeout=10)
         self.dynamic_agent.core.stop()
 
         if self.p_process is not None:


### PR DESCRIPTION
Fixes in
- platform wrapper to do rmq single instance setup at init instead of platform start
- rmq config object to set defaults. Without this admin user is gets created as None
- Fixed test_platform_rmq to accommodate changes in platform wrapper, remove irrelevant test case, and added better error handling.
