### PR TITLE
More fixes to Issue#2011. Enables gevent version of pika to installed…

### DIFF
--- a/optional_requirements.json
+++ b/optional_requirements.json
@@ -36,6 +36,6 @@
     "--rabbitmq": {
         "help": "Installs requirements for the rabbitmq server",
         "packages": ["wget==3.2", "cryptography==2.2.2",
-        "git+git://github.com/shwethanidd/pika.git@gevent_connection_adapter#egg=pika"]
+        "gevent-pika==0.2"]
     }
 }


### PR DESCRIPTION
… from pypi

# Description

Gevent connection adapter version of pika (gevent-pika) is added to pypi repository. Now we can install it directly in the optional_requirements.json.

Also tested with "pip install gevent-pika"
Fixes #2011
