### PR TITLE
Develop

### DIFF
--- a/docs/source/core_services/historians/Forward-Historian.rst
+++ b/docs/source/core_services/historians/Forward-Historian.rst
@@ -38,6 +38,7 @@ Put the result into the following example
 (Note the example uses a local IP address)
 
 ::
+
     {
         "agentid": "forwarder",
         "destination-vip": "tcp://127.0.0.1:22916",


### PR DESCRIPTION
# Description

The rst documentation for the ForwarderHistorian had a syntax error preventing an example code block from rendering correctly in the sphinx docs.

Fixes - there is no open issue, I could go open one

## Type of change

Please delete options that are not relevant.

- documentation syntax fix

# How Has This Been Tested?

- The github rst rendering system reproduces the sphinx rendering on RTD, the updated file renders correctly there.
~ I have not configured my own RTD build or attempted to build the docs locally

**Test Configuration**:
NA

# Checklist:
It isn't clear that most of this checklist is applicable as this change is only to the documentation. Is there an explicit style guideline, if so could we link it in the PR template?

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
