### PR TITLE
fixed rabbitmq optional installs on bootstrap in new env. 

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -398,6 +398,7 @@ def main(argv=sys.argv):
             data = json.load(optional_arguments)
             for arg, vals in data.items():
                 if arg == '--rabbitmq':
+                    optional_args.append(arg)
                     po.add_argument(
                         '--rabbitmq', action='store', const=default_rmq_dir,
                         nargs='?',

--- a/optional_requirements.json
+++ b/optional_requirements.json
@@ -22,7 +22,7 @@
     },
     "--databases": {
         "help": "Installs support for all known databases",
-        "packages": ["pymongo", "mysql-connector-python-rf"]
+        "packages": ["pymongo", "mysql-connector-python-rf", "crate"]
     },
     "--documentation": {
         "help": "Installs requirements for building the documentation",


### PR DESCRIPTION
Issue:
optional installs of rabbitmq did not get installed when running 
`python bootstrap.py --rabbitmq` in a brand new environment (i.e. no env folder and volttron.egg-info folder)

Fix:
fixed rabbitmq optional installs on bootstrap in new env by adding the optional arguments to the list of packages to be installed 
Also added crate to list of optional requirements for --databases

Test:
Tested running bootstrap.py with --rabbitmq and other optional arguments in a new environment 