### PR TITLE
Added all_platform configuration to historian

### DIFF
--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -1,9 +1,9 @@
 {
-    "agentid": "sqlhistorian-sqlite",
     "connection": {
         "type": "sqlite",
         "params": {
-            "database": "~/.volttron/data/historian.sqlite"
+            "database": "/tmp/tmpGOh9f1/historian.sqlite"
         }
-    }
+    },
+    "all_platforms":"true"
 }

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -5,5 +5,5 @@
             "database": "~/.volttron/data/historian.sqlite"
         }
     },
-    "all_platforms":"true"
+    "all_platforms":True
 }

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -2,7 +2,7 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            "database": "/tmp/tmpGOh9f1/historian.sqlite"
+            "database": "~/.volttron/data/historian.sqlite"
         }
     },
     "all_platforms":"true"

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -5,5 +5,5 @@
             "database": "~/.volttron/data/historian.sqlite"
         }
     },
-    "all_platforms":True
+    "all_platforms":true
 }

--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -164,10 +164,12 @@ def load_config(config_path):
             raise
 
 
-def load_platform_config():
+def load_platform_config(vhome=None):
     """Loads the platform config file if the path exists."""
     config_opts = {}
-    path = os.path.join(get_home(), 'config')
+    if not vhome:
+        vhome = get_home()
+    path = os.path.join(vhome, 'config')
     if os.path.exists(path):
         parser = ConfigParser()
         parser.read(path)
@@ -177,8 +179,8 @@ def load_platform_config():
     return config_opts
 
 
-def get_platform_instance_name(prompt=False):
-    platform_config = load_platform_config()
+def get_platform_instance_name(vhome=None, prompt=False):
+    platform_config = load_platform_config(vhome)
 
     instance_name = platform_config.get('instance-name', None)
     if instance_name is not None:
@@ -194,8 +196,10 @@ def get_platform_instance_name(prompt=False):
             if os.path.isfile('/etc/hostname'):
                 with open('/etc/hostname') as f:
                     instance_name = f.read().strip()
-
-                    store_message_bus_config(get_messagebus(), instance_name)
+                bus = platform_config.get('message-bus')
+                if bus is None:
+                    bus = get_messagebus()
+                store_message_bus_config(bus, instance_name)
             else:
                 err = "No instance-name is configured in $VOLTTRON_HOME/config. Please set instance-name in " \
                       "$VOLTTRON_HOME/config"

--- a/volttron/platform/certs.py
+++ b/volttron/platform/certs.py
@@ -370,7 +370,7 @@ class Certs(object):
             if not os.path.exists(p):
                 os.makedirs(p, 0o755)
 
-    def ca_cert(self, pem_encoded=False):
+    def ca_cert(self, public_bytes=False):
         """
         Get the X509 CA certificate.
         :return: the CA certificate of current volttron instance
@@ -378,9 +378,9 @@ class Certs(object):
         if not self.ca_exists():
             raise CertError("ca certificate doesn't exist")
 
-        return self.cert(self.root_ca_name, pem_encoded=pem_encoded)
+        return self.cert(self.root_ca_name, public_bytes=public_bytes)
 
-    def cert(self, name, remote=False, pem_encoded=False):
+    def cert(self, name, remote=False, public_bytes=False):
         """
         Get the X509 certificate based upon the name
         :param name: name of the certificate to be loaded
@@ -398,7 +398,7 @@ class Certs(object):
             raise CertError("invalid certificate path {}".format(
                 cert_file))
         cert = _load_cert(cert_file)
-        if pem_encoded:
+        if public_bytes:
             return cert.public_bytes(serialization.Encoding.PEM)
 
         return _load_cert(cert_file)
@@ -724,7 +724,7 @@ class Certs(object):
     def rebuild_requests_ca_bundle(self):
         with open(self.remote_cert_bundle_file(), 'wb') as fp:
             # First include this platforms ca
-            fp.write(self.ca_cert(pem_encoded=True))
+            fp.write(self.ca_cert(public_bytes=True))
             for f in os.listdir(self.remote_cert_dir):
                 # based upon the call to the safe_remote_info from subsystem.auth file
                 # there will be a _ca added to the instance name on the other side of the

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -930,9 +930,7 @@ class RMQCore(Core):
             raise ValueError("Agent's VIP identity is not set")
         else:
             try:
-                _log.debug("INSTANCE_NAME:{0}, GET_INSTANCE_NAME:{1}".format(
-                    self.instance_name, get_platform_instance_name(self.volttron_home)))
-                if self.instance_name == get_platform_instance_name(self.volttron_home):
+                if self.instance_name == get_platform_instance_name():
                     param = self.rmq_mgmt.build_agent_connection(self.identity,
                                                                  self.instance_name)
                 else:
@@ -995,7 +993,7 @@ class RMQCore(Core):
             else:
                 _log.debug("Router not bound to RabbitMQ yet, waiting for 2 seconds before sending hello {}".
                            format(self.identity))
-                self.spawn_later(5, hello)
+                self.spawn_later(2, hello)
 
         # Connect to RMQ broker. Register a callback to get notified when
         # connection is confirmed

--- a/volttron/platform/vip/agent/core.py
+++ b/volttron/platform/vip/agent/core.py
@@ -930,7 +930,9 @@ class RMQCore(Core):
             raise ValueError("Agent's VIP identity is not set")
         else:
             try:
-                if self.instance_name == get_platform_instance_name():
+                _log.debug("INSTANCE_NAME:{0}, GET_INSTANCE_NAME:{1}".format(
+                    self.instance_name, get_platform_instance_name(self.volttron_home)))
+                if self.instance_name == get_platform_instance_name(self.volttron_home):
                     param = self.rmq_mgmt.build_agent_connection(self.identity,
                                                                  self.instance_name)
                 else:
@@ -993,7 +995,7 @@ class RMQCore(Core):
             else:
                 _log.debug("Router not bound to RabbitMQ yet, waiting for 2 seconds before sending hello {}".
                            format(self.identity))
-                self.spawn_later(2, hello)
+                self.spawn_later(5, hello)
 
         # Connect to RMQ broker. Register a callback to get notified when
         # connection is confirmed

--- a/volttron/platform/vip/agent/subsystems/hello.py
+++ b/volttron/platform/vip/agent/subsystems/hello.py
@@ -86,11 +86,14 @@ class Hello(SubsystemBase):
         _log.info('{0} Requesting hello from peer ({1})'.format(self.core().identity, peer))
         result = next(self._results)
         connection = self.core().connection
-        try:
-            connection.send_vip(peer, b'hello', args=[b'hello'], msg_id=result.ident)
-        except ZMQError as exc:
-            if exc.errno == ENOTSOCK:
-                _log.error("Socket send on non socket {}".format(self.core().identity))
+        if not connection:
+            _log.error("Connection object not yet created".format(self.core().identity))
+        else:
+            try:
+                connection.send_vip(peer, b'hello', args=[b'hello'], msg_id=result.ident)
+            except ZMQError as exc:
+                if exc.errno == ENOTSOCK:
+                    _log.error("Socket send on non socket {}".format(self.core().identity))
 
         return result
 

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -100,7 +100,7 @@ def volttron_instance_module_web(request):
 @pytest.fixture(scope="module",
                 params=(
                     dict(messagebus='zmq', ssl_auth=False),
-                    rmq_skipif(dict(messagebus='rmq', ssl_auth=True))
+                    rmq_skipif(dict(messagebus='rmq', ssl_auth=True)),
                 ))
 def volttron_instance(request, **kwargs):
     """Fixture that returns a single instance of volttron platform for testing
@@ -302,7 +302,8 @@ def volttron_multi_messagebus(request):
         if source.messagebus == 'rmq':
             # The _ca is how the auth subsystem saves the remote cert from discovery.  We
             # are effectively doing that here instead of making the discovery call.
-            source.certsobj.save_remote_cert(sink.certsobj.root_ca_name+"_ca", sink.certsobj.ca_cert(pem_encoded=True))
+            source.certsobj.save_remote_cert(sink.certsobj.root_ca_name + "_ca", sink.certsobj.ca_cert(
+                public_bytes=True))
     else:
         source = build_wrapper(source_address,
                                ssl_auth=ssl_auth,

--- a/volttrontesting/platform/web/test_discovery.py
+++ b/volttrontesting/platform/web/test_discovery.py
@@ -24,5 +24,5 @@ def test_discovery_endpoint(volttron_instance_web):
     assert wrapper.instance_name == info.instance_name
     assert wrapper.vip_address == info.vip_address
     if wrapper.messagebus == 'rmq':
-        ca_cert = wrapper.certsobj.ca_cert(pem_encoded=True)
+        ca_cert = wrapper.certsobj.ca_cert(public_bytes=True)
         assert ca_cert == info.rmq_ca_cert

--- a/volttrontesting/services/historian/test_multiplatform.py
+++ b/volttrontesting/services/historian/test_multiplatform.py
@@ -1,0 +1,406 @@
+# -*- coding: utf-8 -*- {{{
+# vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
+#
+# Copyright 2017, Battelle Memorial Institute.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This material was prepared as an account of work sponsored by an agency of
+# the United States Government. Neither the United States Government nor the
+# United States Department of Energy, nor Battelle, nor any of their
+# employees, nor any jurisdiction or organization that has cooperated in the
+# development of these materials, makes any warranty, express or
+# implied, or assumes any legal liability or responsibility for the accuracy,
+# completeness, or usefulness or any information, apparatus, product,
+# software, or process disclosed, or represents that its use would not infringe
+# privately owned rights. Reference herein to any specific commercial product,
+# process, or service by trade name, trademark, manufacturer, or otherwise
+# does not necessarily constitute or imply its endorsement, recommendation, or
+# favoring by the United States Government or any agency thereof, or
+# Battelle Memorial Institute. The views and opinions of authors expressed
+# herein do not necessarily state or reflect those of the
+# United States Government or any agency thereof.
+#
+# PACIFIC NORTHWEST NATIONAL LABORATORY operated by
+# BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY
+# under Contract DE-AC05-76RL01830
+# }}}
+"""
+pytest test cases base historian to test all_platform configuration.
+By default all_platform is set to False and historian subscribes only to topics from local message bus.
+When all_platforms=True, historian will subscribe to topics from all connected platforms
+
+"""
+import json
+import os
+import random
+from datetime import datetime
+
+import gevent
+import pytest
+
+from volttron.platform import get_services_core
+from volttron.platform.agent import utils
+from volttron.platform.messaging import headers as headers_mod
+from volttrontesting.fixtures.volttron_platform_fixtures import build_wrapper
+from volttrontesting.utils.utils import get_rand_vip, get_hostname_and_random_port
+from volttrontesting.utils.platformwrapper import PlatformWrapper
+from volttrontesting.fixtures.volttron_platform_fixtures import get_rand_vip, \
+    get_rand_ip_and_port
+from volttron.utils.rmq_setup import start_rabbit, stop_rabbit
+from volttron.platform.agent.utils import execute_command
+
+@pytest.fixture(scope="module")
+def federated_rmq_instances(request, **kwargs):
+    """
+    Create two rmq based volttron instances. One to act as producer of data and one to act as consumer of data
+
+    :return: 2 volttron instances - (producer, consumer) that are federated
+    """
+    downstream_vip = get_rand_vip()
+    downstream = build_wrapper(downstream_vip,
+                               ssl_auth=True,
+                               messagebus='rmq',
+                               should_start=False,
+                               **kwargs)
+    upstream_vip = get_rand_vip()
+    upstream = build_wrapper(upstream_vip,
+                             ssl_auth=True,
+                             messagebus='rmq',
+                             should_start=False,
+                             **kwargs)
+
+    # upstream.certsobj.save_remote_cert(downstream.certsobj.root_ca_name +"_ca", downstream.certsobj.ca_cert(public_bytes=True))
+    # downstream.certsobj.save_remote_cert(upstream.certsobj.root_ca_name +"_ca", upstream.certsobj.ca_cert(public_bytes=True))
+
+    # exchange CA certs
+    stop_rabbit(rmq_home=downstream.rabbitmq_config_obj.rmq_home, env=downstream.env, quite=True)
+    stop_rabbit(rmq_home=upstream.rabbitmq_config_obj.rmq_home, env=upstream.env, quite=True)
+
+    with open(os.path.join(upstream.certsobj.cert_dir, upstream.instance_name + "-root-ca.crt"), "r") as uf:
+        with open(os.path.join(downstream.certsobj.cert_dir, downstream.instance_name + "-trusted-cas.crt"), "a") as df:
+            df.write(uf.read())
+
+    with open(os.path.join(downstream.certsobj.cert_dir, downstream.instance_name + "-root-ca.crt"), "r") as df:
+        with open(os.path.join(upstream.certsobj.cert_dir, upstream.instance_name + "-trusted-cas.crt"), "a") as uf:
+            uf.write(df.read())
+
+    start_rabbit(rmq_home=downstream.rabbitmq_config_obj.rmq_home, env=downstream.env)
+    gevent.sleep(8)  # wait for volttron to reconnect
+    start_rabbit(rmq_home=upstream.rabbitmq_config_obj.rmq_home, env=upstream.env)
+    gevent.sleep(8)  # wait for volttron to reconnect
+
+    try:
+
+        # add downstream user ON UPSTREAM and give permissions
+        # ~/rabbitmq_server/rabbitmq_server-3.7.7/sbin/rabbitmqctl add_user <user> <password>
+        # ~/rabbitmq_server/rabbitmq_server-3.7.7/sbin/rabbitmqctl set_permissions -p <vhost> <user> ".*" ".*" ".*"
+        cmd = [os.path.join(upstream.rabbitmq_config_obj.rmq_home, "sbin/rabbitmqctl")]
+        cmd.extend(['add_user', downstream.instance_name + "-admin", "test"])
+        execute_command(cmd, env=upstream.env, err_prefix="Error creating user in upstream server")
+
+        cmd = [os.path.join(upstream.rabbitmq_config_obj.rabbitmq_config['rmq-home'], "sbin/rabbitmqctl")]
+        cmd.extend(['set_permissions', "-p", upstream.rabbitmq_config_obj.rabbitmq_config["virtual-host"]])
+        cmd.extend([downstream.instance_name + "-admin", '".*"', '".*"', '".*"'])
+        execute_command(cmd, env=upstream.env, err_prefix="Error setting user permission in upstream server")
+        gevent.sleep(1)
+
+        upstream.startup_platform(upstream_vip)
+        gevent.sleep(10)
+        print("After upstream start")
+        downstream.startup_platform(downstream_vip)
+        gevent.sleep(5)
+
+        # create federation config and setup federation
+        content = """federation-upstream:
+        {host}:
+            port: {port}
+            virtual-host: {vhost}
+        """
+
+        config_path = os.path.join(downstream.volttron_home, "federation.config")
+        with open(config_path, 'w') as conf:
+            conf.write(content.format(host=downstream.rabbitmq_config_obj.rabbitmq_config["host"],
+                                      port=downstream.rabbitmq_config_obj.rabbitmq_config["amqp-port-ssl"],
+                                      vhost=downstream.rabbitmq_config_obj.rabbitmq_config["virtual-host"]))
+        # downstream.setup_federation(config_path)
+
+    except Exception as e:
+        print("Exception setting up federation: {}".format(e))
+        upstream.shutdown_platform()
+        downstream.shutdown_platform()
+        raise e
+
+    yield upstream, downstream
+
+    # upstream.shutdown_platform()
+    downstream.shutdown_platform()
+
+
+@pytest.fixture(scope="module")
+def get_zmq_volttron_instances(request):
+    """ Fixture to get more than 1 volttron instance for test
+    Use this fixture to get more than 1 volttron instance for test. This
+    returns a function object that should be called with number of instances
+    as parameter to get a list of volttron instnaces. The fixture also
+    takes care of shutting down all the instances at the end
+
+    Example Usage:
+
+    def test_function_that_uses_n_instances(get_volttron_instances):
+        instance1, instance2, instance3 = get_volttron_instances(3)
+
+    @param request: pytest request object
+    @return: function that can used to get any number of
+        volttron instances for testing.
+    """
+    all_instances = []
+
+    def get_n_volttron_instances(n, should_start=True, address_file=True):
+        get_n_volttron_instances.count = n
+        vip_addresses = []
+        web_addresses = []
+        instances = []
+        names = []
+
+        for i in range(0, n):
+            address = get_rand_vip()
+            web_address = "http://{}".format(get_rand_ip_and_port())
+            vip_addresses.append(address)
+            web_addresses.append(web_address)
+            nm = 'platform{}'.format(i + 1)
+            names.append(nm)
+
+        for i in range(0, n):
+            address = vip_addresses[i]
+            web_address = web_addresses[i]
+            wrapper = PlatformWrapper(messagebus='zmq', ssl_auth=False)
+
+            addr_file = os.path.join(wrapper.volttron_home, 'external_address.json')
+            if address_file:
+                with open(addr_file, 'w') as f:
+                    json.dump(web_addresses, f)
+                    gevent.sleep(.1)
+            wrapper.startup_platform(address, bind_web_address=web_address, setupmode=True)
+            wrapper.skip_cleanup = True
+            instances.append(wrapper)
+
+        gevent.sleep(11)
+        for i in range(0, n):
+            instances[i].shutdown_platform()
+
+        gevent.sleep(1)
+        # del instances[:]
+        for i in range(0, n):
+            address = vip_addresses.pop(0)
+            web_address = web_addresses.pop(0)
+            print address, web_address
+            instances[i].startup_platform(address, bind_web_address=web_address)
+            instances[i].allow_all_connections()
+        gevent.sleep(11)
+        instances = instances if n > 1 else instances[0]
+
+        get_n_volttron_instances.instances = instances
+        return instances
+
+    return get_n_volttron_instances
+
+
+@pytest.mark.historian
+@pytest.mark.multiplatform
+def test_all_platform_subscription_zmq(request, get_zmq_volttron_instances):
+
+    upstream, downstream, downstream2 = get_zmq_volttron_instances(3)
+
+    gevent.sleep(5)
+
+    # setup consumer on downstream1. One with all_platform=True another False
+
+    hist_config = {"connection":
+                       {"type": "sqlite",
+                        "params": {
+                            "database": downstream.volttron_home +
+                                        "/historian.sqlite"}},
+                   "all_platforms": True
+                   }
+    hist_id = downstream.install_agent(
+        vip_identity='platform.historian',
+        agent_dir=get_services_core("SQLHistorian"),
+        config_file=hist_config,
+        start=True)
+    gevent.sleep(1)
+    query_agent = downstream.build_agent()
+    gevent.sleep(1)
+
+    hist2_config = {"connection":
+                        {"type": "sqlite",
+                         "params": {
+                             "database": downstream2.volttron_home +
+                                         "/historian2.sqlite"}},
+                    }
+    hist2_id = downstream2.install_agent(
+        vip_identity='unused.historian',
+        agent_dir=get_services_core("SQLHistorian"),
+        config_file=hist2_config,
+        start=True)
+    query_agent2 = downstream2.build_agent()
+    gevent.sleep(2)
+
+    print "publish"
+
+    producer = upstream.build_agent()
+    gevent.sleep(2)
+    DEVICES_ALL_TOPIC = "devices/Building/LAB/Device/all"
+
+    oat_reading = random.uniform(30, 100)
+    mixed_reading = oat_reading + random.uniform(-5, 5)
+    damper_reading = random.uniform(0, 100)
+
+    float_meta = {'units': 'F', 'tz': 'UTC', 'type': 'float'}
+    percent_meta = {'units': '%', 'tz': 'UTC', 'type': 'float'}
+
+    # Create a message for all points.
+    all_message = [{'OutsideAirTemperature': oat_reading,
+                    'MixedAirTemperature': mixed_reading,
+                    'DamperSignal': damper_reading},
+                   {'OutsideAirTemperature': float_meta,
+                    'MixedAirTemperature': float_meta,
+                    'DamperSignal': percent_meta
+                    }]
+
+    # Create timestamp
+    now = utils.format_timestamp(datetime.utcnow())
+
+    # now = '2015-12-02T00:00:00'
+    headers = {
+        headers_mod.DATE: now, headers_mod.TIMESTAMP: now
+    }
+    print("Published time in header: " + now)
+
+    producer.vip.pubsub.publish('pubsub',
+                                DEVICES_ALL_TOPIC,
+                                headers=headers,
+                                message=all_message).get(timeout=10)
+
+    gevent.sleep(5)
+
+    ## Query from consumer to verify
+
+    result = query_agent.vip.rpc.call("platform.historian",
+                                      'query',
+                                      topic="Building/LAB/Device/OutsideAirTemperature",
+                                      count=1).get(timeout=100)
+    print("QUERY RESULT : {}" .format(result))
+    assert (result['values'][0][1] == oat_reading)
+    assert set(result['metadata'].items()) == set(float_meta.items())
+    gevent.sleep(1)
+
+    result = query_agent2.vip.rpc.call("unused.historian",
+                                       'query',
+                                       topic="Building/LAB/Device/OutsideAirTemperature",
+                                       count=1).get(timeout=100)
+    print("QUERY RESULT : {}".format(result))
+    assert not result
+
+    downstream.stop_agent(hist_id)
+    downstream2.stop_agent(hist2_id)
+    query_agent.core.stop()
+    query_agent2.core.stop()
+    producer.core.stop()
+    gevent.sleep(1)
+    upstream.shutdown_platform()
+    downstream.shutdown_platform()
+    downstream2.shutdown_platform()
+
+
+@pytest.mark.historian
+@pytest.mark.multiplatform
+def test_all_platform_subscription_rmq(request, federated_rmq_instances):
+    pass
+    # try:
+    #     upstream, downstream = federated_rmq_instances
+    #     gevent.sleep(5)
+    #     assert upstream.is_running()
+    #     assert downstream.is_running()
+    #
+    #     # setup consumer on downstream1. One with all_platform=True another False
+    #
+    #     hist_config = {"connection":
+    #                        {"type": "sqlite",
+    #                         "params": {
+    #                             "database": downstream.volttron_home +
+    #                                         "/historian.sqlite"}},
+    #                    "all_platforms": True
+    #                    }
+    #     hist_id = downstream.install_agent(
+    #         vip_identity='platform.historian',
+    #         agent_dir=get_services_core("SQLHistorian"),
+    #         config_file=hist_config,
+    #         start=True)
+    #
+    #     assert downstream.is_running()
+    #     assert downstream.is_agent_running(hist_id)
+    #     query_agent = downstream.dynamic_agent
+    #     gevent.sleep(2)
+    #
+    #     print "publish"
+    #     producer = upstream.dynamic_agent
+    #     gevent.sleep(2)
+    #     DEVICES_ALL_TOPIC = "devices/Building/LAB/Device/all"
+    #
+    #     oat_reading = random.uniform(30, 100)
+    #     mixed_reading = oat_reading + random.uniform(-5, 5)
+    #     damper_reading = random.uniform(0, 100)
+    #
+    #     float_meta = {'units': 'F', 'tz': 'UTC', 'type': 'float'}
+    #     percent_meta = {'units': '%', 'tz': 'UTC', 'type': 'float'}
+    #
+    #     # Create a message for all points.
+    #     all_message = [{'OutsideAirTemperature': oat_reading,
+    #                     'MixedAirTemperature': mixed_reading,
+    #                     'DamperSignal': damper_reading},
+    #                    {'OutsideAirTemperature': float_meta,
+    #                     'MixedAirTemperature': float_meta,
+    #                     'DamperSignal': percent_meta
+    #                     }]
+    #
+    #     # Create timestamp
+    #     now = utils.format_timestamp(datetime.utcnow())
+    #     # now = '2015-12-02T00:00:00'
+    #     headers = {
+    #         headers_mod.DATE: now, headers_mod.TIMESTAMP: now
+    #     }
+    #     print("Published time in header: " + now)
+    #
+    #     producer.vip.pubsub.publish('pubsub',
+    #                                 DEVICES_ALL_TOPIC,
+    #                                 headers=headers,
+    #                                 message=all_message).get(timeout=10)
+    #     gevent.sleep(5)
+    #
+    #     ## Query from consumer to verify
+    #
+    #     result = query_agent.vip.rpc.call("platform.historian",
+    #                                       'query',
+    #                                       topic="Building/LAB/Device/OutsideAirTemperature",
+    #                                       count=1).get(timeout=100)
+    #     print("QUERY RESULT : {}".format(result))
+    #     assert (result['values'][0][1] == oat_reading)
+    #     assert set(result['metadata'].items()) == set(float_meta.items())
+    #     gevent.sleep(1)
+    # finally:
+    #     if downstream:
+    #         downstream.stop_agent(hist_id)
+    #     if producer:
+    #         producer.core.stop()
+

--- a/volttrontesting/testutils/test_multimessagebus_fixture.py
+++ b/volttrontesting/testutils/test_multimessagebus_fixture.py
@@ -32,13 +32,13 @@ def test_correct_remote_ca_specified(web_bound_correctly):
         with open(source.requests_ca_bundle) as f:
             requests_ca_content = f.read()
 
-        data = sink.certsobj.ca_cert(pem_encoded=True)
+        data = sink.certsobj.ca_cert(public_bytes=True)
         assert data in requests_ca_content
         if source.messagebus == 'zmq':
             assert data == requests_ca_content
 
         if source.messagebus == 'rmq':
-            assert data != source.certsobj.ca_cert(pem_encoded=True)
+            assert data != source.certsobj.ca_cert(public_bytes=True)
 
 
 def test_can_connect_web_using_remote_platform_ca(web_bound_correctly):

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -411,8 +411,8 @@ class PlatformWrapper:
             event = gevent.event.Event()
             gevent.spawn(agent.core.run, event)  # .join(0)
             event.wait(timeout=2)
-            gevent.sleep(1)
-            hello = agent.vip.hello().get(timeout=5)
+            gevent.sleep(2)
+            hello = agent.vip.hello().get(timeout=15)
 
             #self.logit('Got hello response {}'.format(hello))
         agent.publickey = publickey
@@ -1063,6 +1063,20 @@ class PlatformWrapper:
             retries += 1
             time.sleep(timeout_seconds)
         return running
+
+    def setup_federation(self, config_path):
+        """
+        Set up federation using the given config path
+        :param config_path: path to federation config yml file.
+        """
+        _log.debug("Setting up federation using config : {}".format(config_path))
+
+        cmd = ['vcfg']
+        cmd.extend(['--vhome', self.volttron_home, '--instance-name', self.instance_name,'--rabbitmq',
+                    "federation", config_path])
+        execute_command(cmd, env=self.env, logger=_log,
+                              err_prefix="Error setting up federation")
+
 
     def restart_platform(self):
         self.startup_platform(vip_address=self.vip_address,

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -318,6 +318,7 @@ class PlatformWrapper:
                          publickey=None, secretkey=None, serverkey=None,
                          capabilities=[], **kwargs):
         self.logit('Building connection to {}'.format(peer))
+        os.environ.update(self.env)
         self.allow_all_connections()
 
         if address is None:
@@ -445,9 +446,12 @@ class PlatformWrapper:
             pass
 
     def add_vc(self):
+        os.environ.update(self.env)
+
         return add_volttron_central(self)
 
     def add_vcp(self):
+        os.environ.update(self.env)
         return add_volttron_central_platform(self)
 
     def is_auto_csr_enabled(self):
@@ -1084,8 +1088,8 @@ class PlatformWrapper:
         execute_command(cmd, env=self.env, logger=_log,
                               err_prefix="Error setting up federation")
 
-
     def restart_platform(self):
+        self.shutdown_platform()
         self.startup_platform(vip_address=self.vip_address,
                               bind_web_address=self.bind_web_address,
                               volttron_central_address=self.volttron_central_address,
@@ -1143,6 +1147,11 @@ class PlatformWrapper:
         running on the platform, then shutdown, then if any of the listed agent
         pids are still running then kill them.
         """
+
+        # Update OS env to current platform's env so get_home() call will result
+        # in correct home director. Without this when more than one test instance are created, get_home()
+        # will return home dir of last started platform wrapper instance
+        os.environ.update(self.env)
 
         # Handle cascading calls from multiple levels of fixtures.
         if self._instance_shutdown:

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -368,7 +368,10 @@ class PlatformWrapper:
         :return:
         """
         self.logit("Building generic agent.")
-
+        # Update OS env to current platform's env so get_home() call will result
+        # in correct home director. Without this when more than one test instance are created, get_home()
+        # will return home dir of last started platform wrapper instance
+        os.environ.update(self.env)
         use_ipc = kwargs.pop('use_ipc', False)
 
         if serverkey is None:
@@ -491,6 +494,10 @@ class PlatformWrapper:
                          setupmode=False,
                          agent_monitor_frequency=600,
                          timeout=60):
+        # Update OS env to current platform's env so get_home() call will result
+        # in correct home director. Without this when more than one test instance are created, get_home()
+        # will return home dir of last started platform wrapper instance
+        os.environ.update(self.env)
         self.vip_address = vip_address
         self.mode = mode
         self.volttron_central_address = volttron_central_address
@@ -537,7 +544,7 @@ class PlatformWrapper:
                     cf.write(f.read())
 
             self.env['REQUESTS_CA_BUNDLE'] = ca_bundle_file
-
+            os.environ['REQUESTS_CA_BUNDLE'] = self.env['REQUESTS_CA_BUNDLE']
         # This file will be passed off to the main.py and available when
         # the platform starts up.
         self.requests_ca_bundle = self.env.get('REQUESTS_CA_BUNDLE')
@@ -828,7 +835,7 @@ class PlatformWrapper:
             Should this overwrite the current or not.
         :return:
         """
-
+        os.environ.update(self.env)
         assert self.is_running(), "Instance must be running to install agent."
         assert agent_wheel or agent_dir, "Invalid agent_wheel or agent_dir."
         assert isinstance(startup_time, int), "Startup time should be an integer."
@@ -1092,8 +1099,14 @@ class PlatformWrapper:
         maintain the context of the platform.
         :return:
         """
+
         if not self.is_running():
             return
+
+        # Update OS env to current platform's env so get_home() call will result
+        # in correct home director. Without this when more than one test instance are created, get_home()
+        # will return home dir of last started platform wrapper instance
+        os.environ.update(self.env)
 
         self.dynamic_agent.vip.rpc(CONTROL, "shutdown").get()
         self.dynamic_agent.core.stop()


### PR DESCRIPTION
Added all_platform configuration to historian. By default this will be false. Added test case to test this using both multiple zmq instances and multiple rmq instance. Testing with rmq, required adding federation setup capability to platform wrapper and fixing handling of os.environ when there is more than one volttron platformwrapper instance used within a test case. 
