### PR TITLE
Fix display of warning without a rabbitmq_conf file

### DIFF
--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -590,13 +590,14 @@ def setup_rabbitmq_volttron(setup_type, verbose=False, prompt=False, instance_na
     if setup_type in ["all", "single"]:
         invalid = False
         # Verify that the rmq_conf_file if exists is removed before continuing.
-        message = f"A rabbitmq conf file f{rmq_conf_file} already exists.\n" \
-            "In order for setup to proceed it must be removed.\n"
-        print(message)
-        while os.path.exists(rmq_conf_file):
-            value = prompt_response(f"Remove {rmq_conf_file}? ", y_or_n)
-            if value in y:
-                os.remove(rmq_conf_file)
+        message = f"A rabbitmq conf file {rmq_conf_file} already exists.\n" \
+                  "In order for setup to proceed it must be removed.\n"
+        if os.path.exists(rmq_conf_file):
+            print(message)
+            while os.path.exists(rmq_conf_file):
+                value = prompt_response(f"Remove {rmq_conf_file}? ", y_or_n)
+                if value in y:
+                    os.remove(rmq_conf_file)
 
         _start_rabbitmq_without_ssl(rmq_config, rmq_conf_file, env=env)
         _log.debug("Creating rabbitmq virtual hosts and required users for "


### PR DESCRIPTION
# Description

The warning during settup of rabbitmq was displaying even though there may not have been one present

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

