### PR TITLE
Added support for timescaleDB  and updated docs

### DIFF
--- a/docs/source/core_services/historians/SQL-Historian.rst
+++ b/docs/source/core_services/historians/SQL-Historian.rst
@@ -155,7 +155,7 @@ SQLHistorianAgent to use a remote PostgreSQL database.
 TimescaleDB Support
 ++++++++++++++++++++++++++
 
-Both of the above PosgreSQL connection types can make
+Both of the above PostgreSQL connection types can make
 use of TimescaleDB's high performance Hypertable backend
 for the primary timeseries table. The agent assumes you
 have completed the TimescaleDB installation and setup

--- a/docs/source/core_services/historians/SQL-Historian.rst
+++ b/docs/source/core_services/historians/SQL-Historian.rst
@@ -157,9 +157,12 @@ TimescaleDB Support
 
 Both of the above PosgreSQL connection types can make
 use of TimescaleDB's high performance Hypertable backend
-for the primary timeseries table. To use, simply add
-'timescale_dialect: true' to the connection params
-in the Agent Config as below
+for the primary timeseries table. The agent assumes you
+have completed the TimescaleDB installation and setup
+the database by following the instructions here:
+https://docs.timescale.com/latest/getting-started/setup
+To use, simply add 'timescale_dialect: true' to the 
+connection params in the Agent Config as below
 
 ::
     {

--- a/docs/source/core_services/historians/SQL-Historian.rst
+++ b/docs/source/core_services/historians/SQL-Historian.rst
@@ -70,3 +70,128 @@ will respect a rooted or relative path to the database.
         }
     }
 
+
+PostgreSQL and Redshift
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Installation notes
+------------------
+
+1. The PostgreSQL database driver supports recent PostgreSQL versions.
+   It was tested on 10.x, but should work with 9.x and 11.x.
+
+2. The user must have SELECT, INSERT, and UPDATE privileges on historian
+   tables.
+
+3. The tables in the database are created as part of the execution of
+   the SQLHistorianAgent, but this will fail if the database user does not
+   have CREATE privileges.
+
+4. Care must be exercised when using multiple historians with the same
+   database. This configuration may be used only if there is no overlap in
+   the topics handled by each instance. Otherwise, duplicate topic IDs
+   may be created, producing strange results.
+
+5. Redshift databases do not support unique constraints. Therefore, it is
+   possible that tables may contain some duplicate data. The Redshift driver
+   handles this by using distinct queries. It does not remove duplicates
+   from the tables.
+
+Dependencies
+------------
+
+The PostgreSQL and Redshift database drivers require the **psycopg2** Python package.
+
+    From an activated shell execute:
+
+        pip install psycopg2-binary
+
+Configuration
+-------------
+
+The following are minimal configuration files for using a psycopg2-based
+historian. Other options are available and are documented
+http://initd.org/psycopg/docs/module.html
+**Not all parameters have been tested, use at your own risk**.
+
+Local PostgreSQL Database
++++++++++++++++++++++++++
+
+The following snippet demonstrates how to configure the
+SQLHistorianAgent to use a PostgreSQL database on the local system
+that is configured to use Unix domain sockets. The user executing
+volttron must have appropriate privileges.
+
+::
+    {
+        "connection": {
+            "type": "postgresql",
+            "params": {
+                "dbname": "volttron"
+            }
+        }
+    }
+
+Remote PostgreSQL Database
+++++++++++++++++++++++++++
+
+The following snippet demonstrates how to configure the
+SQLHistorianAgent to use a remote PostgreSQL database.
+
+::
+    {
+        "connection": {
+            "type": "postgresql",
+            "params": {
+                "dbname": "volttron",
+                "host": "historian.example.com",
+                "port": 5432,
+                "user": "volttron",
+                "password": "secret"
+            }
+        }
+    }
+
+TimescaleDB Support
+++++++++++++++++++++++++++
+
+Both of the above PosgreSQL connection types can make
+use of TimescaleDB's high performance Hypertable backend
+for the primary timeseries table. To use, simply add
+'timescale_dialect: true' to the connection params
+in the Agent Config as below
+
+::
+    {
+        "connection": {
+            "type": "postgresql",
+            "params": {
+                "dbname": "volttron",
+                "host": "historian.example.com",
+                "port": 5432,
+                "user": "volttron",
+                "password": "secret",
+                "timescale_dialect": true
+            }
+        }
+    }
+
+Redshift Database
++++++++++++++++++
+
+The following snippet demonstrates how to configure the
+SQLHistorianAgent to use a Redshift database.
+
+::
+    {
+        "connection": {
+            "type": "redshift",
+            "params": {
+                "dbname": "volttron",
+                "host": "historian.example.com",
+                "port": 5432,
+                "user": "volttron",
+                "password": "secret"
+            }
+        }
+    }

--- a/services/core/SQLHistorian/README.rst
+++ b/services/core/SQLHistorian/README.rst
@@ -177,7 +177,7 @@ SQLHistorianAgent to use a remote PostgreSQL database.
 TimescaleDB Support
 ++++++++++++++++++++++++++
 
-Both of the above PosgreSQL connection types can make
+Both of the above PostgreSQL connection types can make
 use of TimescaleDB's high performance Hypertable backend
 for the primary timeseries table. The agent assumes you
 have completed the TimescaleDB installation and setup

--- a/services/core/SQLHistorian/README.rst
+++ b/services/core/SQLHistorian/README.rst
@@ -174,6 +174,30 @@ SQLHistorianAgent to use a remote PostgreSQL database.
         }
     }
 
+TimescaleDB Support
+++++++++++++++++++++++++++
+
+Both of the above PosgreSQL connection types can make
+use of TimescaleDB's high performance Hypertable backend
+for the primary timeseries table. To use, simply add
+'timescale_dialect: true' to the connection params
+in the Agent Config as below
+
+::
+    {
+        "connection": {
+            "type": "postgresql",
+            "params": {
+                "dbname": "volttron",
+                "host": "historian.example.com",
+                "port": 5432,
+                "user": "volttron",
+                "password": "secret",
+                "timescale_dialect": true
+            }
+        }
+    }
+
 Redshift Database
 +++++++++++++++++
 

--- a/services/core/SQLHistorian/README.rst
+++ b/services/core/SQLHistorian/README.rst
@@ -179,9 +179,12 @@ TimescaleDB Support
 
 Both of the above PosgreSQL connection types can make
 use of TimescaleDB's high performance Hypertable backend
-for the primary timeseries table. To use, simply add
-'timescale_dialect: true' to the connection params
-in the Agent Config as below
+for the primary timeseries table. The agent assumes you
+have completed the TimescaleDB installation and setup
+the database by following the instructions here:
+https://docs.timescale.com/latest/getting-started/setup
+To use, simply add 'timescale_dialect: true' to the 
+connection params in the Agent Config as below
 
 ::
     {

--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -19,6 +19,7 @@
 import ast
 import contextlib
 import logging
+import copy
 
 import pytz
 import psycopg2
@@ -43,16 +44,15 @@ For method details please refer to base class
 """
 class PostgreSqlFuncts(DbDriver):
     def __init__(self, connect_params, table_names):
-        _log.debug(connect_params)
         if table_names:
             self.data_table = table_names['data_table']
             self.topics_table = table_names['topics_table']
             self.meta_table = table_names['meta_table']
             self.agg_topics_table = table_names.get('agg_topics_table')
             self.agg_meta_table = table_names.get('agg_meta_table')
-        if "timescale_dialect" in connect_params.keys():
-            _log.debug("timescale in connect params")
-            self.timescale_dialect = connect_params.get("timescale_dialect")
+        connect_params = copy.deepcopy(connect_params)
+        if "timescale_dialect" in connect_params:
+            self.timescale_dialect = connect_params.get("timescale_dialect", False)
             del connect_params["timescale_dialect"]
         else:
             self.timescale_dialect = False
@@ -116,9 +116,10 @@ class PostgreSqlFuncts(DbDriver):
                 'UNIQUE (topic_id, ts)'
             ')').format(Identifier(self.data_table)))
         if self.timescale_dialect:
+            _log.debug("trying to create hypertable")
             self.execute_stmt(SQL(
-                'SELECT create_hypertable({}, ts)').format(
-                Identifier(self.data_table)))
+                "SELECT create_hypertable({}, 'ts')").format(
+                Literal(self.data_table)))
             self.execute_stmt(SQL(
                 'CREATE INDEX ON {} (topic_id, ts)').format(
                 Identifier(self.data_table)))


### PR DESCRIPTION
# Description

Added support for using the TimescaleDB Hypertable backend for the PostgreSQL historian
Also updated readthedocs to include postgresql historian documentation.



## Type of change


- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Installed a fresh copy of PostgreSQL11 and installed TimescaleDB with it. Ran agent and confirmed table is created with hypertable extension and indexes enabled


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
