### PR TITLE
Fixed bug with improperly implemented inherited methods in CSV Driver Examples and Update Walkthrough

### DIFF
--- a/docs/source/devguides/walkthroughs/Driver-Creation-Walkthrough.rst
+++ b/docs/source/devguides/walkthroughs/Driver-Creation-Walkthrough.rst
@@ -50,7 +50,7 @@ single request. First create the csv interface class boilerplate.
 
 .. code-block:: python
 
-    class Interface(BaseInterface):
+    class Interface(BasicRevert, BaseInterface):
         def __init__(self, **kwargs):
             super(Interface, self).__init__(**kwargs)
 
@@ -60,10 +60,10 @@ single request. First create the csv interface class boilerplate.
         def get_point(self, point_name):
             pass
 
-        def set_point(self, point_name, value):
+        def _set_point(self, point_name, value):
             pass
 
-        def scrape_all(self):
+        def _scrape_all(self):
             pass
 
 This class should inherit from the BaseInterface, and at a minimum implement the configure, get_point, set_point, and
@@ -106,6 +106,9 @@ Name" specifying the name of the register, and "Point Value", the current value 
 
 .. code-block:: python
 
+
+    _log = logging.getLogger(__name__)
+
     CSV_FIELDNAMES = ["Point Name", "Point Value"]
     CSV_DEFAULT = [
         {
@@ -121,6 +124,12 @@ Name" specifying the name of the register, and "Point Value", the current value 
             "Point Value": "testpoint"
         }
     ]
+    type_mapping = {"string": str,
+                    "int": int,
+                    "integer": int,
+                    "float": float,
+                    "bool": bool,
+                    "boolean": bool}
 
     class Interface(BasicRevert, BaseInterface):
     def __init__(self, **kwargs):
@@ -192,14 +201,14 @@ correct register to read from or write to, and instruct the register to perform 
         register = self.get_register_by_name(point_name)
         return register.get_state()
 
-    def set_point(self, point_name, value):
+    def _set_point(self, point_name, value):
         register = self.get_register_by_name(point_name)
         if register.read_only:
             raise IOError("Trying to write to a point configured read only: " + point_name)
         register.set_state(value)
         return register.get_state()
 
-    def scrape_all(self):
+    def _scrape_all(self):
         result = {}
         read_registers = self.get_registers_by_type("byte", True)
         write_registers = self.get_registers_by_type("byte", False)

--- a/examples/CSVDriver/csvdriver.py
+++ b/examples/CSVDriver/csvdriver.py
@@ -184,7 +184,7 @@ class Interface(BasicRevert, BaseInterface):
         # then return that register's state
         return register.get_state()
 
-    def set_point(self, point_name, value):
+    def _set_point(self, point_name, value):
         """
         Read the value of the register which matches the passed point name
         :param point_name: The point name of the register the user wishes to set
@@ -199,7 +199,7 @@ class Interface(BasicRevert, BaseInterface):
         # set the state, and return the new value
         return register.set_state(value)
 
-    def scrape_all(self):
+    def _scrape_all(self):
         """
         Loop over all of the registers configured for this device, then return a mapping of register name to its value
         :return: Results dictionary of the form {<register point name>: <register value>, ...}


### PR DESCRIPTION
# Description

Fixes improperly named inherited methods in example code which leads to the driver failing to start on the Volttron platform.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested manually using master driver/listener and actuator/test CSV driver agents
