### PR TITLE
Added warning for two RMQ instances in VTN server. Fixed spelling and…

### DIFF
--- a/docs/source/core_services/historians/DataMover-Historian.rst
+++ b/docs/source/core_services/historians/DataMover-Historian.rst
@@ -4,10 +4,10 @@ DataMover Historian
 
 DataMover sends data from its platform to a remote platform in cases where
 there is not sufficient resources to store locally. It shares this
-functionality with the :ref:`Forward Historian <ForwardHistorian>`,
+functionality with the :ref:`Forward Historian <Forward-Historian>`,
 However DataMover does not have a goal of data appearing "live" on the
 remote platform. This allows DataMover to be more efficient by both batching
-data and by sending an RCP call to a remote historian instead of publishing
+data and by sending an RPC call to a remote historian instead of publishing
 data on the remote message bus. This allows allows DataMover to be more
 robust by ensuring that the receiving historian is running. If the target is
 unreachable, DataMover will cache data until it is available.
@@ -56,5 +56,4 @@ the agent is disconnected from its target for a long time.
 See Also
 ~~~~~~~~
 
-`Historians <historians>`_
-:ref:`Historians <historians>`
+:ref:`Historians <Historian Index>`

--- a/docs/source/core_services/historians/Forward-Historian.rst
+++ b/docs/source/core_services/historians/Forward-Historian.rst
@@ -57,5 +57,4 @@ the agent is disconnected from its target for a long time.
 See Also
 ~~~~~~~~
 
-`Historians <historians>`_
-:ref:`Historians <historians>`
+:ref:`Historians <Historian Index>`

--- a/docs/source/core_services/historians/index.rst
+++ b/docs/source/core_services/historians/index.rst
@@ -109,8 +109,8 @@ All historians support the following settings:
 By default the base historian will listen to 4 separate root topics
 `datalogger/*`, `record/*`, `analysis/*`, and `device/*`.
 
-Each of root
-topics has a :ref:`specific message syntax <Historian-Topic-Syntax>` that
+Each root
+topic has a :ref:`specific message syntax <Historian-Topic-Syntax>` that
 it is expecting for incoming data.
 
 Messages published to `datalogger`
@@ -121,10 +121,10 @@ graphed easily.
 Messages published to `devices` are data that comes
 directly from drivers.
 
-Messages published to `analysis` are analysis data published by agnets
+Messages published to `analysis` are analysis data published by agents
 in the form of key value pairs.
 
-Finally Messages that are published to `record`
+Finally, messages that are published to `record`
 will be handled as string data and can be customized to the user
 specific situation.
 

--- a/docs/source/core_services/messagebus/RPC.rst
+++ b/docs/source/core_services/messagebus/RPC.rst
@@ -114,7 +114,6 @@ Implementation
 --------------
 
 See the
-`rpc </VOLTTRON/volttron/blob/3.x/volttron/platform/vip/agent/subsystems/rpc.py>`__
-module for implementation details.
+`RPC module <https://github.com/VOLTTRON/volttron/blob/develop/volttron/platform/vip/agent/subsystems/rpc.py>`_ for implementation details.
 
-Also see `RPC by example <RPC-by-example>`__ for additional examples.
+Also see :ref:`Multi-Platform RPC Communication <Multi-Platform-RPC>` and :ref:`RPC in RabbitMQ <RabbitMQ-VOLTTRON>` for additional resources.

--- a/docs/source/core_services/openadr/VtnServerConfig.rst
+++ b/docs/source/core_services/openadr/VtnServerConfig.rst
@@ -5,6 +5,15 @@ OpenADR VTN Server: Installation and Configuration
 
 The Kisensum VTN server is a Django application written in Python 3 and utilizing a Postgres database.
 
+.. warning:: 
+
+    If you are planning to install your VTN server on the same system that contains your VOLTTRON instance 
+    and you are using RabbitMQ with VOLTTRON, you will need to set up a new instance of RabbitMQ for VTN. 
+    In production, the VTN server should be on a different device than VOLTTRON, and as such it is recommended 
+    that your VTN server is in it's own VM or on it's own machine. If you still wish to set up two instances 
+    of RabbitMQ on the same system, please refer to https://www.rabbitmq.com for further details.
+
+
 Get Source Code
 ---------------
 

--- a/examples/ExampleSubscriber/subscriber/subscriber_agent.py
+++ b/examples/ExampleSubscriber/subscriber/subscriber_agent.py
@@ -78,7 +78,7 @@ def subscriber_agent(config_path, **kwargs):
         '''
         This agent demonstrates usage of the 3.0 pubsub service as well as 
         interfacting with the historian. This agent is mostly self-contained, 
-        but requires the histoiran be running to demonstrate the query feature.
+        but requires the historian to be running to demonstrate the query feature.
         '''
     
         def __init__(self, **kwargs):


### PR DESCRIPTION
Added warning for two RMQ instances in the VTN configuration guide.
Fixed spelling and grammar issues in documentation, and modified dead or broken links.