### PR TITLE
Fixed bug when using vctl auth add

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1169,14 +1169,11 @@ def add_auth(opts):
         # Remove unspecified options so the default parameters are used
         fields = {k: v for k, v in fields.items() if v}
         fields['enabled'] = not opts.disabled
-        print("fields of capabilities: {}".format(fields["capabilities"]))
         entry = AuthEntry(**fields)
     else:
         # No options were specified, use interactive wizard
         responses = _ask_for_auth_fields()
         entry = AuthEntry(**responses)
-        print("fields of capabilities: {}".format(responses["capabilities"]))
-
 
     if opts.add_known_host:
         if entry.address is None:


### PR DESCRIPTION
Removed debug statements that were causing a bug to occur when no capability was specified when using **vctl auth add**.
When capability was not specified, these print statements caused this error:
**auth: error: 'capabilities'**
Removing them fixes the issue.