### PR TITLE
Fix/vctl config edit wrong file mode

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1556,7 +1556,7 @@ def edit_config(opts):
 
     # Write raw data to temp file
     # This will not work on Windows, FYI
-    with tempfile.NamedTemporaryFile(suffix=".txt") as f:
+    with tempfile.NamedTemporaryFile(suffix=".txt", mode="r+") as f:
         f.write(raw_data)
         f.flush()
 


### PR DESCRIPTION
# Description

When attempting to edit a file in the configuration store via vctl config edit ... an exception is thrown.

Fixes #2190 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Attempt to edit a file via `vctl config edit ...`, the file should open up in nano or the editor of your choice.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
