### PR TITLE
Fix platformwrapper.py wrapper command in Develop branch tests

### DIFF
--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -677,7 +677,7 @@ class PlatformWrapper:
 
         log = os.path.join(self.volttron_home, 'volttron.log')
 
-        cmd = ['env/bin/volttron']
+        cmd = ['volttron']
         # if msgdebug:
         #     cmd.append('--msgdebug')
         if enable_logging:


### PR DESCRIPTION
# Description

***Issue Bug Fix*** #2201 

When running an agent test using `pytest`, the following exception is raised:
```
..
                    except:
                        exc_type, exc_value, tb = sys.exc_info()
                        # Save the traceback and attach it to the exception object
                        exc_lines = traceback.format_exception(exc_type,
                                                               exc_value,
                                                               tb)
                        exc_value.child_traceback = ''.join(exc_lines)
                        os.write(errpipe_write, pickle.dumps(exc_value))
    
                    finally:
                        # Make sure that the process exits no matter what.
                        # The return code does not matter much as it won't be
                        # reported to the application
                        os._exit(1)
    
                # Parent
                self._child_created = True
                if gc_was_enabled:
                    gc.enable()
            finally:
                # be sure the FD is closed no matter what
                os.close(errpipe_write)
    
            # self._devnull is not always defined.
            devnull_fd = getattr(self, '_devnull', None)
            if p2cread != -1 and p2cwrite != -1 and p2cread != devnull_fd:
                os.close(p2cread)
            if c2pwrite != -1 and c2pread != -1 and c2pwrite != devnull_fd:
                os.close(c2pwrite)
            if errwrite != -1 and errread != -1 and errwrite != devnull_fd:
                os.close(errwrite)
            if devnull_fd is not None:
                os.close(devnull_fd)
            # Prevent a double close of these fds from __init__ on error.
            self._closed_child_pipe_fds = True
    
            # Wait for exec to fail or succeed; possibly raising exception
            errpipe_read = FileObject(errpipe_read, 'rb')
            data = errpipe_read.read()
        finally:
            if hasattr(errpipe_read, 'close'):
                errpipe_read.close()
            else:
                os.close(errpipe_read)
    
        if data != b"":
            self.wait()
            child_exception = pickle.loads(data)
            for fd in (p2cwrite, c2pread, errread):
                if fd is not None and fd != -1:
                    os.close(fd)
            if isinstance(child_exception, OSError):
                child_exception.filename = executable
                if hasattr(child_exception, '_failed_chdir'):
                    child_exception.filename = cwd
>           raise child_exception
E           FileNotFoundError: [Errno 2] No such file or directory: 'env/bin/volttron'

../../../../../.local/share/virtualenvs/volttron/lib/python3.6/site-packages/gevent/subprocess.py:1505: FileNotFoundError

```  
This change was introduced in privision commit [a60e2ba42eae666c0e758da938f950955017f0dc](https://github.com/VOLTTRON/volttron/commit/a60e2ba42eae666c0e758da938f950955017f0dc#diff-4373f8064e95357f42c4ee5dba695683R666)

However, before this update, the tests ran without an error. 
 
Fixes # (issue)

## Type of change
Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
