### PR TITLE
Fixed space issue which caused error

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -2720,7 +2720,7 @@ def main(argv=sys.argv):
         print_tb = exc.print_tb
         error = exc.message
     except AttributeError as exc:
-         _stderr.write("Invalid command: '{}' or command requires additional arguments\n".format(opts.command))
+        _stderr.write("Invalid command: '{}' or command requires additional arguments\n".format(opts.command))
         parser.print_help()
         return 1
     # except Exception as exc:


### PR DESCRIPTION
# Description

There was an extra space in merge #2199 this addresses that issue.

Fixes #2199 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested running multiple commands without expected arguments

`vctl auth` etc
