### PR TITLE
Updated admin endpoints

### DIFF
--- a/examples/StandAloneListener/settings.py
+++ b/examples/StandAloneListener/settings.py
@@ -24,13 +24,13 @@ _params = {
 	# command 'vctl auth add' Provide this agent's public key when prompted
 	# for credential.
 
-	'agent_public': 'dpu13XKPvGB3XJNVUusCNn2U0kIWcuyDIP5J8mAgBQ0',
-	'agent_secret': 'Hlya-6BvfUot5USdeDHZ8eksDkWgEEHABs1SELmQhMs',
+	'agent_public': 'rn_V3vxTLMwaIRUEIAIHee4-qM8X70irDThcn_TX6FA',
+	'agent_secret': 'DY4FhighTlv9UjKlCNIh-1WKp-M5nIHJacWsPZ0ixEs',
 	
 	# Public server key from the remote platform.  This can be
 	# obtained using the command:
 	# volttron-ctl auth serverkey
-	'server_key': 'IyeU43nMmB2SfKTtSArCMfR6YWTMKLPjD1G6j93DVHA'
+	'server_key': 'R2aY0t4gAMnpl0dL44bmrTdMmgXN16hvconvIiHFows'
 }
 
 def remote_url():

--- a/volttron/platform/agent/known_identities.py
+++ b/volttron/platform/agent/known_identities.py
@@ -54,7 +54,7 @@ PLATFORM_MARKET_SERVICE = 'platform.market'
 
 CONTROL = 'control'
 CONTROL_CONNECTION = 'control.connection'
-MASTER_WEB = 'master.web'
+MASTER_WEB = 'master_web'
 CONFIGURATION_STORE = 'config.store'
 PLATFORM_DRIVER = 'platform.driver'
 

--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -52,7 +52,7 @@ from gevent.fileobject import FileObject
 from zmq import green as zmq
 
 from volttron.platform import jsonapi
-from volttron.platform.agent.known_identities import VOLTTRON_CENTRAL_PLATFORM, CONTROL
+from volttron.platform.agent.known_identities import VOLTTRON_CENTRAL_PLATFORM, CONTROL, MASTER_WEB
 from volttron.platform.vip.agent.errors import VIPError
 from volttron.platform.vip.pubsubservice import ProtectedPubSubTopics
 from .agent.utils import strip_comments, create_file_if_missing, watch_file
@@ -106,6 +106,7 @@ class AuthService(Agent):
         self._protected_topics_for_rmq = ProtectedPubSubTopics()
         self._setup_mode = setup_mode
         self._auth_failures = []
+        self._auth_denied = []
 
         def topics():
             return defaultdict(set)
@@ -289,6 +290,8 @@ class AuthService(Agent):
                         _log.debug("AUTH response: {}".format(response))
                         sock.send_multipart(response)
                     else:
+                        if type(userid) == bytes:
+                            userid = userid.decode("utf-8")
                         self._update_auth_failures(domain, address, kind, credentials[0], userid)
 
                     try:
@@ -375,8 +378,66 @@ class AuthService(Agent):
                     return entry.capabilities, entry.groups, entry.roles
 
     @RPC.export
+    @RPC.allow(capabilities="allow_auth_modifications")
+    def approve_authorization_failure(self, user_id):
+        """RPC method
+
+        Approves a previously failed authorization
+
+        :param user_id: user id field from VOLTTRON Interconnect Protocol
+        :type user_id: str
+        """
+        for pending in self._auth_failures:
+            if user_id == pending['user_id']:
+                self._update_auth_entry(
+                    pending['domain'],
+                    pending['address'],
+                    pending['mechanism'],
+                    pending['credentials'],
+                    pending['user_id']
+                    )
+                del self._auth_failures[self._auth_failures.index(pending)]
+
+    @RPC.export
+    @RPC.allow(capabilities="allow_auth_modifications")
+    def deny_authorization_failure(self, user_id):
+        """RPC method
+
+        Denies a previously failed authorization
+
+        :param user_id: user id field from VOLTTRON Interconnect Protocol
+        :type user_id: str
+        """
+        for pending in self._auth_failures:
+            if user_id == pending['user_id']:
+                self._auth_denied.append(pending)
+                del self._auth_failures[self._auth_failures.index(pending)]
+
+    @RPC.export
+    @RPC.allow(capabilities="allow_auth_modifications")
+    def delete_authorization_failure(self, user_id):
+        """RPC method
+
+        Denies a previously failed authorization
+
+        :param user_id: user id field from VOLTTRON Interconnect Protocol
+        :type user_id: str
+        """
+        for pending in self._auth_failures:
+            if user_id == pending['user_id']:
+                del self._auth_failures[self._auth_failures.index(pending)]
+
+        for pending in self._auth_denied:
+            if user_id == pending['user_id']:
+                del self._auth_denied[self._auth_denied.index(pending)]
+
+    @RPC.export
     def get_authorization_failures(self):
         return list(self._auth_failures)
+
+    @RPC.export
+    def get_authorization_denied(self):
+        return list(self._auth_denied)
 
     def _get_authorizations(self, user_id, index):
         """Convenience method for getting authorization component by index"""
@@ -444,6 +505,15 @@ class AuthService(Agent):
             _log.error('ERROR: %s\n' % str(err))
 
     def _update_auth_failures(self, domain, address, mechanism, credential, user_id):
+        for entry in self._auth_denied:
+            # Check if failure entry has been denied. If so, increment the failure's denied count
+            if ((entry['domain'] == domain) and
+                    (entry['address'] == address) and
+                    (entry['mechanism'] == mechanism) and
+                    (entry['credentials'] == credential)):
+                entry['retries'] += 1
+                return
+
         for entry in self._auth_failures:
             # Check if failure entry exists. If so, increment the failure count
             if ((entry['domain'] == domain) and

--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -387,16 +387,29 @@ class AuthService(Agent):
         :param user_id: user id field from VOLTTRON Interconnect Protocol
         :type user_id: str
         """
-        for pending in self._auth_failures:
-            if user_id == pending['user_id']:
-                self._update_auth_entry(
-                    pending['domain'],
-                    pending['address'],
-                    pending['mechanism'],
-                    pending['credentials'],
-                    pending['user_id']
-                    )
-                del self._auth_failures[self._auth_failures.index(pending)]
+        if len(self._auth_failures) > 0:
+            for pending in self._auth_failures:
+                if user_id == pending['user_id']:
+                    self._update_auth_entry(
+                        pending['domain'],
+                        pending['address'],
+                        pending['mechanism'],
+                        pending['credentials'],
+                        pending['user_id']
+                        )
+                    del self._auth_failures[self._auth_failures.index(pending)]
+
+        if len(self._auth_denied) > 0:
+            for pending in self._auth_denied:
+                if user_id == pending['user_id']:
+                    self._update_auth_entry(
+                        pending['domain'],
+                        pending['address'],
+                        pending['mechanism'],
+                        pending['credentials'],
+                        pending['user_id']
+                        )
+                    del self._auth_denied[self._auth_denied.index(pending)]
 
     @RPC.export
     @RPC.allow(capabilities="allow_auth_modifications")
@@ -408,10 +421,11 @@ class AuthService(Agent):
         :param user_id: user id field from VOLTTRON Interconnect Protocol
         :type user_id: str
         """
-        for pending in self._auth_failures:
-            if user_id == pending['user_id']:
-                self._auth_denied.append(pending)
-                del self._auth_failures[self._auth_failures.index(pending)]
+        if len(self._auth_failures) > 0:
+            for pending in self._auth_failures:
+                if user_id == pending['user_id']:
+                    self._auth_denied.append(pending)
+                    del self._auth_failures[self._auth_failures.index(pending)]
 
     @RPC.export
     @RPC.allow(capabilities="allow_auth_modifications")
@@ -423,13 +437,14 @@ class AuthService(Agent):
         :param user_id: user id field from VOLTTRON Interconnect Protocol
         :type user_id: str
         """
-        for pending in self._auth_failures:
-            if user_id == pending['user_id']:
-                del self._auth_failures[self._auth_failures.index(pending)]
-
-        for pending in self._auth_denied:
-            if user_id == pending['user_id']:
-                del self._auth_denied[self._auth_denied.index(pending)]
+        if len(self._auth_failures) > 0:
+            for pending in self._auth_failures:
+                if user_id == pending['user_id']:
+                    del self._auth_failures[self._auth_failures.index(pending)]
+        if len(self._auth_denied) > 0:
+            for pending in self._auth_denied:
+                if user_id == pending['user_id']:
+                    del self._auth_denied[self._auth_denied.index(pending)]
 
     @RPC.export
     def get_authorization_failures(self):

--- a/volttron/platform/certs.py
+++ b/volttron/platform/certs.py
@@ -446,8 +446,9 @@ class Certs(object):
         pending_csr = []
         for c in os.listdir(self.csr_pending_dir):
             if c.endswith('.json'):
-                with open(os.path.join(self.csr_pending_dir, c)) as fp:
-                    pending_csr.append(jsonapi.loads(fp.read()))
+                if os.stat(os.path.join(self.csr_pending_dir, c)).st_size != 0:
+                    with open(os.path.join(self.csr_pending_dir, c)) as fp:
+                        pending_csr.append(jsonapi.loads(fp.read()))
 
         return pending_csr
 
@@ -526,7 +527,7 @@ class Certs(object):
 
         cert = self.sign_csr(csrfile)
         self.save_remote_cert(common_name, cert)
-        meta = jsonapi.loads(open(metafile, 'rb').read())
+        meta = jsonapi.loads(open(metafile, 'r').read())
         meta['status'] = 'APPROVED'
         with open(metafile, 'w') as fp:
             fp.write(jsonapi.dumps(meta))
@@ -552,10 +553,10 @@ class Certs(object):
             raise ValueError("Bad state unknown CSR for common_name {}".format(common_name))
 
         self.delete_remote_cert(common_name)
-        meta = jsonapi.loads(open(metafile, 'rb').read())
+        meta = jsonapi.loads(open(metafile, 'r').read())
         meta['status'] = 'DENIED'
 
-        with open(metafile, 'wb') as fp:
+        with open(metafile, 'w') as fp:
             fp.write(jsonapi.dumps(meta))
 
     def sign_csr(self, csr_file):

--- a/volttron/platform/instance_setup.py
+++ b/volttron/platform/instance_setup.py
@@ -661,7 +661,7 @@ def is_file_readable(file_path, log=True):
 def do_vcp():
     global config_opts
     is_vc = False
-    vctl_list_process = Popen(['vctl','list'], env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    vctl_list_process = Popen(['vctl', 'list'], env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     vctl_list = vctl_list_process.communicate()
     vctl_list_output = ''.join([v.decode('utf-8') for v in vctl_list])
 

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -1044,15 +1044,15 @@ def start_volttron_process(opts):
                           comments='Automatically added by platform on start')
         AuthFile().add(entry, overwrite=True)
 
-        # MASTER_WEB did not work on RMQ. Referred to agent as master
-        # Added this auth to allow RPC calls for credential authentication
-        # when using the RMQ messagebus.
-        ks_masterweb = KeyStore(KeyStore.get_agent_keystore_path('master'))
-        entry = AuthEntry(credentials=encode_key(decode_key(ks_masterweb.public)),
-                          user_id='master',
-                          capabilities=['allow_auth_modifications'],
-                          comments='Automatically added by platform on start')
-        AuthFile().add(entry, overwrite=True)
+        # # MASTER_WEB did not work on RMQ. Referred to agent as master
+        # # Added this auth to allow RPC calls for credential authentication
+        # # when using the RMQ messagebus.
+        # ks_masterweb = KeyStore(KeyStore.get_agent_keystore_path('master'))
+        # entry = AuthEntry(credentials=encode_key(decode_key(ks_masterweb.public)),
+        #                   user_id='master',
+        #                   capabilities=['allow_auth_modifications'],
+        #                   comments='Automatically added by platform on start')
+        # AuthFile().add(entry, overwrite=True)
 
 
         events = [gevent.event.Event() for service in services]

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -1037,6 +1037,12 @@ def start_volttron_process(opts):
                 web_secret_key=opts.web_secret_key
             ))
 
+        entry = AuthEntry(credentials=services[3].core.publickey,
+                          user_id=MASTER_WEB,
+                          capabilities=['allow_auth_modifications'],
+                          comments='Automatically added by platform on start')
+        AuthFile().add(entry, overwrite=True)
+
         events = [gevent.event.Event() for service in services]
         tasks = [gevent.spawn(service.core.run, event)
                  for service, event in zip(services, events)]

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -1037,11 +1037,23 @@ def start_volttron_process(opts):
                 web_secret_key=opts.web_secret_key
             ))
 
-        entry = AuthEntry(credentials=services[3].core.publickey,
+        ks_masterweb = KeyStore(KeyStore.get_agent_keystore_path(MASTER_WEB))
+        entry = AuthEntry(credentials=encode_key(decode_key(ks_masterweb.public)),
                           user_id=MASTER_WEB,
                           capabilities=['allow_auth_modifications'],
                           comments='Automatically added by platform on start')
         AuthFile().add(entry, overwrite=True)
+
+        # MASTER_WEB did not work on RMQ. Referred to agent as master
+        # Added this auth to allow RPC calls for credential authentication
+        # when using the RMQ messagebus.
+        ks_masterweb = KeyStore(KeyStore.get_agent_keystore_path('master'))
+        entry = AuthEntry(credentials=encode_key(decode_key(ks_masterweb.public)),
+                          user_id='master',
+                          capabilities=['allow_auth_modifications'],
+                          comments='Automatically added by platform on start')
+        AuthFile().add(entry, overwrite=True)
+
 
         events = [gevent.event.Event() for service in services]
         tasks = [gevent.spawn(service.core.run, event)

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -229,6 +229,7 @@ class AdminEndpoints(object):
                                                         True)
             data = dict(status=self._certs.get_csr_status(common_name),
                         cert=self._certs.get_cert_from_csr(common_name))
+            data['cert'] = data['cert'].decode('utf-8')
         except ValueError as e:
             data = dict(status="ERROR", message=e.message)
 
@@ -269,7 +270,7 @@ class AdminEndpoints(object):
             _log.debug("Creating credential and permissions for user: {}".format(user_id))
             self._rpc_caller.call(AUTH, 'approve_authorization_failure', user_id)
             data = dict(status='APPROVED',
-                        message="The administrator has denied the request")
+                        message="The administrator has approved the request")
         except ValueError as e:
             data = dict(status="ERROR", message=e.message)
 

--- a/volttron/platform/web/master_web_service.py
+++ b/volttron/platform/web/master_web_service.py
@@ -177,6 +177,10 @@ class MasterWebService(Agent):
     @RPC.export
     def get_user_claims(self, bearer):
         from volttron.platform.web import get_user_claim_from_bearer
+        if self.core.messagebus == 'rmq':
+            return get_user_claim_from_bearer(bearer,
+                                              tls_public_key=self._certs.get_cert_public_key(
+                                                           get_fq_identity(self.core.identity)))
         if self.web_ssl_cert is not None:
             return get_user_claim_from_bearer(bearer,
                                               tls_public_key=CertWrapper.get_cert_public_key(self.web_ssl_cert))
@@ -670,7 +674,7 @@ class MasterWebService(Agent):
             for rt in self._csr_endpoints.get_routes():
                 self.registeredroutes.append(rt)
 
-        # Register the admin endpoinds regardless of whether there is an ssl context
+        # Register the admin endpoints regardless of whether there is an ssl context
         # or not.
         for rt in self._admin_endpoints.get_routes():
             self.registeredroutes.append(rt)

--- a/volttron/platform/web/templates/login.html
+++ b/volttron/platform/web/templates/login.html
@@ -38,8 +38,16 @@
                             $("#status").show();
                         },
                         200: function(response){
-                            document.cookie = "Bearer="+response.responseText+"; secure=True; path=/";
-                            window.location=window.location.origin + "/admin/pending_csrs.html";
+                            if(location.protocol != 'https:'){
+                                console.log("HTTP")
+                                document.cookie = "Bearer="+response.responseText+"; secure=False; path=/";
+                            }
+                            else{
+                                console.log("HTTPS")
+                                document.cookie = "Bearer="+response.responseText+"; secure=True; path=/";
+                            }
+
+                            window.location=window.location.origin + "/admin/pending_auth_reqs.html";
                         }
                     }
 

--- a/volttron/platform/web/templates/pending_auth_reqs.html
+++ b/volttron/platform/web/templates/pending_auth_reqs.html
@@ -1,0 +1,248 @@
+{% extends "base.html" %}
+{% block title %}Certificate Requests{% endblock %}
+{% block cs %}
+    <style>
+        ul { list-style: none; margin-top:20px;}
+        #status{ color: red; font-weight: bold;}
+        .csr-row{width: 200px; margin-top:10px; float:left;}
+    </style>
+{% endblock %}
+{% block content %}
+    <h1>Certificate Requests</h1>
+    {% if not csrs %}
+        <div>No Certificate Requests</div>
+    {% else %}
+        <div id="status"></div>
+        <ul>
+        {% for c in csrs %}
+            <li>
+                <div class="csr-row" data-common_name="{{c.identity}}">
+                    <a class="approve"
+                       data-common_name="{{c.identity}}"
+                       data-status="{{c.status}}" href="#">Approve</a>
+                    <a class="deny"
+                       data-common_name="{{c.identity}}"
+                       data-status="{{c.status}}" href="#">Deny</a>
+                    <a class="delete"
+                       data-common_name="{{c.identity}}"
+                       data-status="{{c.status}}" href="#">Delete</a>
+                </div>
+                <div style="float: left;">
+                    <!-- {{c}}<br /> -->
+                    Status: {{c.status}}<br />
+                    Common Name: {{c.identity}}<br/>
+                    Remote IP: {{c.remote_ip_address}}<br/>
+                </div>
+                <div style="float:none;"></div>
+            </li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+
+    <h1>ZMQ Keys Pending Authorization</h1>
+    {% if auths|length < 1 %}
+        <div>No ZMQ keys requiring authorization at this time.</div>
+    {% else %}
+        <div id="status_zmq"></div>
+        <ul>
+        {% for auth in auths %}
+            <li>
+                <div class="csr-row" data-common_name="{{auth.user_id}}">
+                    <a class="approve_credential"
+                       data-common_name="{{auth.user_id}}"
+                       data-status="PENDING" href="#">Approve</a>
+                    <a class="deny_credential"
+                       data-common_name="{{auth.user_id}}"
+                       data-status="PENDING" href="#">Deny</a>
+                    <a class="delete_credential"
+                       data-common_name="{{auth.user_id}}"
+                       data-status="PENDING" href="#">Delete</a>
+                </div>
+                <div style="float: left;">
+                    <!-- {{c}}<br /> -->
+                    Status: PENDING<br />
+                    Common Name: {{auth.user_id}}<br/>
+                    Remote IP: {{auth.address}}<br/>
+                </div>
+                <div style="float:none;"></div>
+            </li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+        <div id="status_zmq"></div>
+        <ul>
+        {% for auth in denied_auths %}
+            <li>
+                <div class="csr-row" data-common_name="{{auth.user_id}}">
+                    <a class="delete_denied"
+                       data-common_name="{{auth.user_id}}"
+                       data-status="DENIED" href="#">Delete</a>
+                </div>
+                <div style="float: left;">
+                    <!-- {{c}}<br /> -->
+                    Status: DENIED<br />
+                    Common Name: {{auth.user_id}}<br/>
+                    Remote IP: {{auth.address}}<br/>
+                </div>
+                <div style="float:none;"></div>
+            </li>
+        {% endfor %}
+        </ul>
+{% endblock %}
+{% block js %}
+    <script language="JavaScript">
+
+        function set_status(new_text){
+            $("#status").html(new_text);
+            $("#status").show();
+        }
+
+        $(document).ready(() => {
+            if (localStorage.status) {
+                set_status(localStorage.status);
+                localStorage.removeItem("status")
+            }
+            else{
+                $("#status").hide();
+            }
+
+            $('a.approve').each((i, obj)=>{
+                if (obj.getAttribute('data-status') === 'APPROVED'){
+                    obj.setAttribute('hidden', true);
+                }
+            });
+
+            $('a.deny').each((i, obj)=>{
+                if (obj.getAttribute('data-status') === 'DENIED'){
+                    obj.setAttribute('hidden', true);
+                }
+            });
+
+            $('a.approve').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var common_name = element.data("common_name");
+                var url = "/admin/api/approve_csr/"+ common_name;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status = data['status']+ " for "+common_name;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.deny').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var common_name = element.data("common_name");
+                var url = "/admin/api/deny_csr/"+ common_name;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status = data['status']+ " for "+common_name;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.delete').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var common_name = element.data("common_name");
+                var url = "/admin/api/delete_csr/"+ common_name;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status = data['status']+ " for "+common_name;
+                        location.reload();
+                    }
+                })  ;
+
+                return false;
+            });
+
+            $('a.approve_credential').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var user_id = element.data("common_name");
+                var url = "/admin/api/approve_credential/"+ user_id;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.deny_credential').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var user_id = element.data("common_name");
+                var url = "/admin/api/deny_credential/"+ user_id;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.delete_credential').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var user_id = element.data("common_name");
+                var url = "/admin/api/delete_credential/"+ user_id;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.delete_denied').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var user_id = element.data("common_name");
+                var url = "/admin/api/delete_credential/"+ user_id;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        location.reload();
+                    }
+                });
+
+                return false;
+            });
+        });
+    </script>
+{% endblock %}
+{% block content_zmq %}
+
+
+{% endblock %}
+{% block js_zmq %}
+    <script language="JavaScript">
+
+        function set_status(new_text){
+            $("#status").html(new_text);
+            $("#status").show();
+        }
+
+    </script>
+{% endblock %}

--- a/volttron/platform/web/templates/pending_auth_reqs.html
+++ b/volttron/platform/web/templates/pending_auth_reqs.html
@@ -38,7 +38,7 @@
         {% endfor %}
         </ul>
     {% endif %}
-
+    <div style="float: left;">
     <h1>ZMQ Keys Pending Authorization</h1>
     {% if auths|length < 1 %}
         <div>No ZMQ keys requiring authorization at this time.</div>
@@ -61,7 +61,7 @@
                 <div style="float: left;">
                     <!-- {{c}}<br /> -->
                     Status: PENDING<br />
-                    Common Name: {{auth.user_id}}<br/>
+                    Public Key: {{auth.user_id}}<br/>
                     Remote IP: {{auth.address}}<br/>
                 </div>
                 <div style="float:none;"></div>
@@ -69,11 +69,14 @@
         {% endfor %}
         </ul>
     {% endif %}
-        <div id="status_zmq"></div>
+        <div id="status_zmq_denied"></div>
         <ul>
         {% for auth in denied_auths %}
             <li>
                 <div class="csr-row" data-common_name="{{auth.user_id}}">
+                    <a class="approve_denied"
+                       data-common_name="{{auth.user_id}}"
+                       data-status="DENIED" href="#">Approve</a>
                     <a class="delete_denied"
                        data-common_name="{{auth.user_id}}"
                        data-status="DENIED" href="#">Delete</a>
@@ -88,6 +91,7 @@
             </li>
         {% endfor %}
         </ul>
+    </div>
 {% endblock %}
 {% block js %}
     <script language="JavaScript">
@@ -100,11 +104,16 @@
         $(document).ready(() => {
             if (localStorage.status) {
                 set_status(localStorage.status);
-                localStorage.removeItem("status")
+                localStorage.removeItem("status");
             }
             else{
                 $("#status").hide();
             }
+
+            if (localStorage.zmq_approve) {
+                localStorage.removeItem("zmq_approve");
+                location.reload(true);
+                }
 
             $('a.approve').each((i, obj)=>{
                 if (obj.getAttribute('data-status') === 'APPROVED'){
@@ -127,7 +136,7 @@
                     url: url,
                     success: (data) => {
                         localStorage.status = data['status']+ " for "+common_name;
-                        location.reload();
+                        location.reload(true);
                     }
                 });
 
@@ -174,11 +183,10 @@
                 $.get({
                     url: url,
                     success: (data) => {
-                        localStorage.status_zmq = data['status']+ " for "+user_id;
-                        location.reload();
+                        localStorage.zmq_approve = data['status']+ " for "+user_id;
+                        location.reload(true);
                     }
                 });
-
                 return false;
             });
 
@@ -190,7 +198,7 @@
                 $.get({
                     url: url,
                     success: (data) => {
-                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        localStorage.status = data['status']+ " for "+user_id;
                         location.reload();
                     }
                 });
@@ -206,8 +214,24 @@
                 $.get({
                     url: url,
                     success: (data) => {
-                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        localStorage.status = data['status']+ " for "+user_id;
                         location.reload();
+                    }
+                });
+
+                return false;
+            });
+
+            $('a.approve_denied').click(function (e){
+                e.preventDefault();
+                var element = $(this);
+                var user_id = element.data("common_name");
+                var url = "/admin/api/approve_credential/"+ user_id;
+                $.get({
+                    url: url,
+                    success: (data) => {
+                        localStorage.zmq_approve = data['status']+ " for "+user_id;
+                        location.reload(true);
                     }
                 });
 
@@ -222,7 +246,7 @@
                 $.get({
                     url: url,
                     success: (data) => {
-                        localStorage.status_zmq = data['status']+ " for "+user_id;
+                        localStorage.status = data['status']+ " for "+user_id;
                         location.reload();
                     }
                 });
@@ -230,19 +254,5 @@
                 return false;
             });
         });
-    </script>
-{% endblock %}
-{% block content_zmq %}
-
-
-{% endblock %}
-{% block js_zmq %}
-    <script language="JavaScript">
-
-        function set_status(new_text){
-            $("#status").html(new_text);
-            $("#status").show();
-        }
-
     </script>
 {% endblock %}

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -312,7 +312,7 @@ def get_test_volttron_home(messagebus: str, web_https=False, web_http=False, has
                            config_params: dict = None,
                            env_options: dict = None):
     """
-    Create a full volttronn_Home test environment with all of the options availalbe in the environment
+    Create a full volttronn_Home test environment with all of the options available in the environment
     (os.environ) and configuration file (volttron_home/config) in order to test from.
 
     @param messagebus:

--- a/volttrontesting/platform/auth_control_test.py
+++ b/volttrontesting/platform/auth_control_test.py
@@ -93,6 +93,27 @@ def test_approve_authorization_failure(mock_auth_service, test_auth):
 
 
 @pytest.mark.control
+def test_approve_denied_authorization_failure(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    assert len(mock_auth._auth_failures) == 1
+    assert len(mock_auth._auth_denied) == 0
+
+    mock_auth.deny_authorization_failure(auth['user_id'])
+    assert len(mock_auth._auth_denied) == 1
+    assert len(mock_auth._auth_failures) == 0
+
+    mock_auth.approve_authorization_failure(auth['user_id'])
+    assert len(mock_auth.auth_entries) == 0
+
+    mock_auth.read_auth_file()
+    assert len(mock_auth.auth_entries) == 1
+    assert len(mock_auth._auth_denied) == 0
+
+
+@pytest.mark.control
 def test_deny_authorization_failure(mock_auth_service, test_auth):
     mock_auth = mock_auth_service
     auth = test_auth

--- a/volttrontesting/platform/auth_control_test.py
+++ b/volttrontesting/platform/auth_control_test.py
@@ -2,9 +2,11 @@ import gevent
 import os
 import re
 import subprocess
-
 import pytest
-
+from mock import MagicMock
+from volttrontesting.utils.utils import AgentMock
+from volttron.platform.vip.agent import Agent
+from volttron.platform.auth import AuthService
 from volttron.platform.auth import AuthEntry
 from volttron.platform import jsonapi
 
@@ -36,6 +38,102 @@ _auth_entry4 = AuthEntry(
     capabilities=['test4_cap1', 'test4_cap2'],
     comments='test4 comment', enabled=False)
 
+
+@pytest.fixture()
+def mock_auth_service():
+    AuthService.__bases__ = (AgentMock.imitate(Agent, Agent()), )
+    yield AuthService(
+        auth_file=MagicMock(), protected_topics_file=MagicMock(), setup_mode=MagicMock(), aip=MagicMock())
+
+
+@pytest.fixture()
+def test_auth():
+    auth = {
+        "domain": "test_domain",
+        "address": "test_address",
+        "mechanism": "NULL",
+        "credentials": None,
+        "user_id": "test_auth",
+        "capabilities": ["test_caps"],
+        "groups": ["test_group"],
+        "roles": ["test_roles"],
+        "comments": "test_comment"
+    }
+    yield auth
+
+
+def test_get_authorization_failures(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    auth_failure = mock_auth.get_authorization_failures()[0]
+    assert auth['domain'] == auth_failure['domain']
+    assert auth['address'] == auth_failure['address']
+    assert auth['mechanism'] == auth_failure['mechanism']
+    assert auth['credentials'] == auth_failure['credentials']
+    assert auth['user_id'] == auth_failure['user_id']
+    assert auth_failure['retries'] == 1
+
+
+@pytest.mark.control
+def test_approve_authorization_failure(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    assert len(mock_auth._auth_failures) == 1
+
+    mock_auth.approve_authorization_failure(auth['user_id'])
+    assert len(mock_auth.auth_entries) == 0
+
+    mock_auth.read_auth_file()
+    assert len(mock_auth.auth_entries) == 1
+    assert len(mock_auth._auth_failures) == 0
+
+
+@pytest.mark.control
+def test_deny_authorization_failure(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    assert len(mock_auth._auth_failures) == 1
+    assert len(mock_auth._auth_denied) == 0
+
+    mock_auth.deny_authorization_failure(auth['user_id'])
+    assert len(mock_auth._auth_denied) == 1
+    assert len(mock_auth._auth_failures) == 0
+
+
+@pytest.mark.control
+def test_delete_authorization_failure(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    assert len(mock_auth._auth_failures) == 1
+    assert len(mock_auth._auth_denied) == 0
+    mock_auth.delete_authorization_failure(auth['user_id'])
+    assert len(mock_auth._auth_failures) == 0
+    assert len(mock_auth._auth_denied) == 0
+
+
+@pytest.mark.control
+def test_delete_denied_authorization_failure(mock_auth_service, test_auth):
+    mock_auth = mock_auth_service
+    auth = test_auth
+    mock_auth._update_auth_failures(
+        auth['domain'], auth['address'], auth['mechanism'], auth['credentials'], auth['user_id'])
+    assert len(mock_auth._auth_failures) == 1
+    assert len(mock_auth._auth_denied) == 0
+
+    mock_auth.deny_authorization_failure(auth['user_id'])
+    assert len(mock_auth._auth_denied) == 1
+    assert len(mock_auth._auth_failures) == 0
+
+    mock_auth.delete_authorization_failure(auth['user_id'])
+    assert len(mock_auth._auth_denied) == 0
 
 
 
@@ -370,3 +468,4 @@ def _remove_known_host(platform, host):
     p = subprocess.Popen(args, env=env, stdin=subprocess.PIPE, universal_newlines=True)
     p.communicate()
     assert p.returncode == 0
+

--- a/volttrontesting/platform/test_platform_web.py
+++ b/volttrontesting/platform/test_platform_web.py
@@ -1,6 +1,8 @@
 import logging
 
 import gevent
+
+from volttron.platform.agent.known_identities import MASTER_WEB
 from volttron.platform.vip.agent import Agent
 from volttrontesting.utils.platformwrapper import start_wrapper_platform
 from volttron.utils import get_hostname
@@ -255,7 +257,7 @@ def test_register_path_route(web_instance):
 
     webdir, index_html = _build_web_dir(vi.volttron_home)
     agent = vi.build_agent(use_ipc=True)
-    agent.vip.rpc.call('master.web',
+    agent.vip.rpc.call(MASTER_WEB,
                        'register_path_route', '', webdir).get(timeout=5)
     response = requests.get(vi.bind_web_address+"/index.html")
     assert index_html == response.text

--- a/volttrontesting/services/test_masterweb.py
+++ b/volttrontesting/services/test_masterweb.py
@@ -39,6 +39,8 @@ from volttrontesting.fixtures.cert_fixtures import certs_profile_1
 MasterWebService.__bases__ = (AgentMock.imitate(Agent, Agent()),)
 
 
+#TODO add tests for new RPC calls
+
 @pytest.fixture()
 def master_web_service():
     serverkey = "serverkey"


### PR DESCRIPTION
Added the ability to manage zmq credentials from the admin webpage when using https.
Works with both zmq and rabbitmq message buses.
Changed master.web to master_web for MasterWebServices identity.