### PR TITLE
Hotfix: global override tests

### DIFF
--- a/services/core/MasterDriverAgent/tests/test_global_override.py
+++ b/services/core/MasterDriverAgent/tests/test_global_override.py
@@ -182,7 +182,7 @@ def test_set_override(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             device_path)
 
@@ -195,7 +195,7 @@ def test_set_override(config_store, test_agent):
 
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot revert device {} since global override is set'.format(
             device_path)
 
@@ -233,7 +233,7 @@ def test_set_point_after_override_elapsed_interval(config_store, test_agent):
         ).get(timeout=10)
         assert result == new_value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
@@ -270,7 +270,7 @@ def test_set_hierarchical_override(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver1_path)
     gevent.sleep(4)
@@ -367,7 +367,7 @@ def test_set_override_off(config_store, test_agent):
         ).get(timeout=10)
         assert result == value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
@@ -439,7 +439,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver1_device_path)
 
@@ -455,7 +455,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver2_device_path)
 
@@ -473,7 +473,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         assert result == new_value
         print("New value of fake driver2, SampleWritableFloat1: {}".format(new_value))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver2_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
@@ -530,7 +530,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver1_device_path)
 
@@ -546,7 +546,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         ).get(timeout=10)
         assert result == new_value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver2_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
@@ -566,7 +566,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         assert result == new_value
         print("New value of fake driver1, SampleWritableFloat1: {}".format(new_value))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver1_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
@@ -614,7 +614,7 @@ def test_duplicate_override_on(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             fakedriver1_device_path)
 
@@ -660,7 +660,7 @@ def test_indefinite_override_on(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             device_path)
     result = test_agent.vip.rpc.call(
@@ -709,7 +709,7 @@ def test_indefinite_override_after_restart(config_store, test_agent, volttron_in
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'master_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(
             device_path)
     result = test_agent.vip.rpc.call(


### PR DESCRIPTION
# Description

Changes the exc_info comparison made in global override tests to account for change to Python3 Exception class.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All global override tests pass with updating the Exception type comparison.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
