### PR TITLE
Added yaml.safe_load while reading federation or shovel config file

### DIFF
--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -946,7 +946,7 @@ def _read_config_file(filename):
     data = {}
     try:
         with open(filename, 'r') as yaml_file:
-            data = yaml.load(yaml_file)
+            data = yaml.safe_load(yaml_file)
     except IOError as exc:
         _log.error("Error reading from file: {}".format(filename))
     except yaml.YAMLError as exc:


### PR DESCRIPTION
# Description

Using yaml.safe_load() instead of yaml.load() while reading rabbitmq federation/shovel config file.
