### PR TITLE
listeneragentwithruntime

### DIFF
--- a/examples/ListenerAgent/config
+++ b/examples/ListenerAgent/config
@@ -7,4 +7,6 @@
     # verbosity is decreased from left to right above
     # default: INFO
     "log-level": "INFO"
+    # stop time in seconds
+    "runtime_limit":30
 }

--- a/examples/ListenerAgent/config
+++ b/examples/ListenerAgent/config
@@ -1,12 +1,10 @@
 {
-	
-
     "agentid": "listener1",
     "message": "hello",
+    # stop time in seconds
+    "runtime_limit":30,
     # log-level can be DEBUG, INFO, WARN or ERROR
     # verbosity is decreased from left to right above
     # default: INFO
     "log-level": "INFO"
-    # stop time in seconds
-    "runtime_limit":30
 }

--- a/examples/ListenerAgent/listener/agent.py
+++ b/examples/ListenerAgent/listener/agent.py
@@ -53,7 +53,6 @@ __version__ = '3.3'
 DEFAULT_MESSAGE = 'Listener Message'
 DEFAULT_AGENTID = "listener"
 DEFAULT_HEARTBEAT_PERIOD = 5
-RUNTIME_LIMIT = 600
 
 
 class ListenerAgent(Agent):
@@ -97,7 +96,6 @@ class ListenerAgent(Agent):
     @Core.receiver('onsetup')
     def onsetup(self, sender, **kwargs):
         # Demonstrate accessing a value from the config file
-        self.start_time = datetime.datetime.now()
         _log.info(self.config.get('message', DEFAULT_MESSAGE))
         self._agent_id = self.config.get('agentid')
 

--- a/examples/ListenerAgent/listener/agent.py
+++ b/examples/ListenerAgent/listener/agent.py
@@ -62,22 +62,20 @@ class ListenerAgent(Agent):
 
     def __init__(self, config_path, **kwargs):
         super().__init__(**kwargs)
-        self.flag = True
         self.config = utils.load_config(config_path)
         self._agent_id = self.config.get('agentid', DEFAULT_AGENTID)
         self._message = self.config.get('message', DEFAULT_MESSAGE)
         self._heartbeat_period = self.config.get('heartbeat_period',
                                                  DEFAULT_HEARTBEAT_PERIOD)
-        try:
-            self.runtime_limit = int(self.config.get('runtime_limit', ''))
-            self.stop_time = datetime.datetime.now() + datetime.timedelta(seconds=self.runtime_limit)
-            _log.debug('Listener agent will stop at {}'.format(self.stop_time))
-        except:
-            _log.debug('Runtime limit is not given')
-            self.flag = False
 
-        if self.flag:
-            self.core.schedule(self.stop_time, self.core.stop)
+        runtime_limit = int(self.config.get('runtime_limit', 0))
+        if runtime_limit and runtime_limit > 0:
+            stop_time = datetime.datetime.now() + datetime.timedelta(seconds=runtime_limit)
+            _log.info('Listener agent will stop at {}'.format(stop_time))
+            self.core.schedule(stop_time, self.core.stop)
+        else:
+            _log.info('No valid runtime_limit configured; listener agent will run until manually stopped')
+
         try:
             self._heartbeat_period = int(self._heartbeat_period)
         except:


### PR DESCRIPTION
# Description
Adds runtime_limit option to have Listener agent automatically stop after a specified max interval. If not defined (None), the agent would run indefinitely (current behavior). 

Fixes #2231 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update


# How Has This Been Tested?

This update is tested on my virtual machine for the 30 and 120-second intervals. This function is also tested without the runtime_limit criteria on the config file. 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
