### PR TITLE
Added clarification to readme for using example rabbitmq yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ cause the user user to be prompted for all the required data in the command prom
 vcfg will use that data to generate a rabbitmq_config.yml file in the `VOLTTRON_HOME` 
 directory.
 
+If the above configuration file is being used as a basis, be sure to update it with 
+the hostname of the deployment (this should be the fully qualified domain name
+of the system).
+
 This script creates a new virtual host and creates SSL certificates needed
 for this VOLTTRON instance. These certificates get created under the subdirectory 
 "certificates" in your VOLTTRON home (typically in ~/.volttron). It


### PR DESCRIPTION
# Description

Adds documentation line describing an additional step necessary if using the example rabbitmq yml config file during platform setup.

Fixes #2289

This documentation addresses a problem that can occur when using the example rabbitmq yml config file when setting up a rabbitmq volttron instance using vcfg