### PR TITLE
Minor documentation revision to DataPublisher agent.

### DIFF
--- a/examples/DataPublisher/README.rst
+++ b/examples/DataPublisher/README.rst
@@ -48,9 +48,10 @@ Configuration
         },
         # Path to input CSV file.
         # May also be a list of records or reference to a CSV file in the config store.
-        # Large CSV files should be referenced by file name and not
-        # stored in the config store.
-        "input_data": "econ_test2.csv",
+        # Large CSV files should be referenced by file name and not stored in the config store.
+        # If the filename is used, the full file path is required. This can be found using
+        # the `pwd` command.
+        "input_data": "test.csv",
         # Publish interval in seconds
         "publish_interval": 1,
 

--- a/examples/DataPublisher/README.rst
+++ b/examples/DataPublisher/README.rst
@@ -52,6 +52,7 @@ Configuration
         # If the filename is used, the full file path is required. This can be found using
         # the `pwd` command.
         "input_data": "test.csv",
+
         # Publish interval in seconds
         "publish_interval": 1,
 

--- a/examples/DataPublisher/test.config
+++ b/examples/DataPublisher/test.config
@@ -29,9 +29,10 @@
     },
     # Path to input CSV file.
     # May also be a list of records or reference to a CSV file in the config store.
-    # Large CSV files should be referenced by file name and not
-    # stored in the config store.
-    "input_data": "econ_test2.csv",
+    # Large CSV files should be referenced by file name and not stored in the config store.
+    # If the filename is used, the full file path is required. This can be found using
+    # the pwd command.
+    "input_data": "test.csv",
     # Publish interval in seconds
     "publish_interval": 1,
 

--- a/examples/DataPublisher/test.config
+++ b/examples/DataPublisher/test.config
@@ -33,6 +33,7 @@
     # If the filename is used, the full file path is required. This can be found using
     # the pwd command.
     "input_data": "test.csv",
+    
     # Publish interval in seconds
     "publish_interval": 1,
 


### PR DESCRIPTION
Added note in DataPublisher example config and README to alert the user to the need for the full filepath when specifying an input file.

Response to #2275 