### PR TITLE
Docs: Fix Spelling Error

### DIFF
--- a/docs/source/overview/version-history.rst
+++ b/docs/source/overview/version-history.rst
@@ -82,7 +82,7 @@ RabbitMQ Message Bus
 
     - Client code for integrating non-VOLTTRON applications with the message bus
        available at: https://github.com/VOLTTRON/external-clients-for-rabbitmq
-    - Includes support for MQTT, non-VOLTTRON Python, and Java based Rabbit MQ
+    - Includes support for MQTT, non-VOLTTRON Python, and Java-based RabbitMQ
       clients
 
 Config store secured


### PR DESCRIPTION
Small change to remove space in RabbitMQ.

Doc-change only.