### PR TITLE
Fixes issue#2318 

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -705,28 +705,6 @@ def create_file_if_missing(path, permission=0o660, contents=None):
             if e.errno != errno.EEXIST:
                 raise
     try:
-        open(path)
-    except IOError as exc:
-        if exc.errno != errno.ENOENT:
-            raise
-        _log.debug('missing file %s', path)
-        _log.info('creating file %s', path)
-        fd = os.open(path, os.O_CREAT | os.O_WRONLY, permission)
-        try:
-            if contents:
-                os.write(fd, contents)
-        finally:
-            os.close(fd)
-
-def create_file_if_missing(path, permission=0o660, contents=None):
-    dirname = os.path.dirname(path)
-    if dirname and not os.path.exists(dirname):
-        try:
-            os.makedirs(dirname)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
-    try:
         with open(path) as fd:
             pass
     except IOError as exc:

--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -705,6 +705,28 @@ def create_file_if_missing(path, permission=0o660, contents=None):
             if e.errno != errno.EEXIST:
                 raise
     try:
+        open(path)
+    except IOError as exc:
+        if exc.errno != errno.ENOENT:
+            raise
+        _log.debug('missing file %s', path)
+        _log.info('creating file %s', path)
+        fd = os.open(path, os.O_CREAT | os.O_WRONLY, permission)
+        try:
+            if contents:
+                os.write(fd, contents)
+        finally:
+            os.close(fd)
+
+def create_file_if_missing(path, permission=0o660, contents=None):
+    dirname = os.path.dirname(path)
+    if dirname and not os.path.exists(dirname):
+        try:
+            os.makedirs(dirname)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+    try:
         with open(path) as fd:
             pass
     except IOError as exc:
@@ -716,8 +738,11 @@ def create_file_if_missing(path, permission=0o660, contents=None):
         success = False
         try:
             if contents:
-                os.write(fd, contents if isinstance(contents, bytes) else contents.encode("utf-8"))
+                contents = contents if isinstance(contents, bytes) else contents.encode("utf-8")
+                os.write(fd, contents)
                 success = True
+        except Exception as e:
+            raise e
         finally:
             os.close(fd)
         return success

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -625,7 +625,7 @@ class AIPplatform(object):
             os.mkdir(data_dir)
         return data_dir
 
-    def create_agent_data_dir(self, agent_uuid):
+    def create_agent_data_dir_if_missing(self, agent_uuid):
         new_agent_data_dir = self._get_agent_data_dir(self.agent_dir(agent_uuid))
         return new_agent_data_dir
 

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -531,7 +531,8 @@ class AIPplatform(object):
                 self.set_agent_user_permissions(created_user,
                                                 agent_uuid,
                                                 agent_path)
-
+            _log.info("Creating agent data direectory: {}".format(agent_path))
+            #agent_data_dir = self._get_agent_data_dir(agent_path)
         except Exception:
             shutil.rmtree(agent_path)
             raise
@@ -623,6 +624,10 @@ class AIPplatform(object):
         if not os.path.exists(data_dir):
             os.mkdir(data_dir)
         return data_dir
+
+    def create_agent_data_dir(self, agent_uuid):
+        new_agent_data_dir = self._get_agent_data_dir(self.agent_dir(agent_uuid))
+        return new_agent_data_dir
 
     def _get_data_dir(self, agent_path, agent_name):
         pkg = UnpackedPackage(agent_path)

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -563,6 +563,8 @@ def find_agent_data_dir(opts, agent_uuid):
         if x.endswith("agent-data"):
             agent_data_dir = os.path.join(opts.aip.agent_dir(agent_uuid), x)
             break
+    if not agent_data_dir:
+        agent_data_dir = opts.aip.create_agent_data_dir(agent_uuid)
     return agent_data_dir
 
 

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -558,13 +558,8 @@ def restore_agent_data_from_tgz(source_file, output_dir):
 
 
 def find_agent_data_dir(opts, agent_uuid):
-    agent_data_dir = None
-    for x in os.listdir(opts.aip.agent_dir(agent_uuid)):
-        if x.endswith("agent-data"):
-            agent_data_dir = os.path.join(opts.aip.agent_dir(agent_uuid), x)
-            break
-    if not agent_data_dir:
-        agent_data_dir = opts.aip.create_agent_data_dir(agent_uuid)
+    # Find agent-data directory path, create if missing
+    agent_data_dir = opts.aip.create_agent_data_dir_if_missing(agent_uuid)
     return agent_data_dir
 
 

--- a/volttron/platform/vip/socket.py
+++ b/volttron/platform/vip/socket.py
@@ -85,7 +85,13 @@ def nonblocking(sock):
 
 def encode_key(key):
     '''Base64-encode and return a key in a URL-safe manner.'''
-    assert len(key) in (32, 40)
+    if len(key) % 4 != 0:
+        return key
+    key = key if isinstance(key, bytes) else key.encode("utf-8")
+    try:
+        assert len(key) in (32, 40)
+    except AssertionError:
+        raise AssertionError("Assertion error while encoding key:{}, len:{}".format(key, len(key)))
     if len(key) == 40:
         key = z85.decode(key)
     return base64.urlsafe_b64encode(key)[:-1].decode("ASCII")

--- a/volttron/platform/vip/socket.py
+++ b/volttron/platform/vip/socket.py
@@ -85,6 +85,7 @@ def nonblocking(sock):
 
 def encode_key(key):
     '''Base64-encode and return a key in a URL-safe manner.'''
+    # There is no easy way to test if key is already base64 encoded and ASCII decoded. This seems the best way.
     if len(key) % 4 != 0:
         return key
     key = key if isinstance(key, bytes) else key.encode("utf-8")


### PR DESCRIPTION
This PR fixes two underlying problems. When the agent gets upgraded, the same public key and secret key is being used. But the secret key was getting encoded twice which was causing assertion error. The second problem was "agent-data" directory was not created when agent is reinstalled to copy over saved agent data files. Fixed both the issues.

Fixes #2318 
