### PR TITLE
Updated required packages documentation to correct package names on C…

### DIFF
--- a/docs/source/setup/VOLTTRON-Prerequisites.rst
+++ b/docs/source/setup/VOLTTRON-Prerequisites.rst
@@ -35,10 +35,10 @@ command:
 .. code-block:: bash
 
    sudo yum update
-   sudo yum install make automake gcc gcc-c++ kernel-devel python3.6-devel pythone3.6-venv openssl openssl-devel libevent-devel git
+   sudo yum install make automake gcc gcc-c++ kernel-devel python3-devel openssl openssl-devel libevent-devel git
 
 .. note::
-   The above commands are specific to 3.6, however you could use 3.6 or greater in them.
+   Python 3.6 or greater is required.
 
 If you have an agent which requires the pyodbc package, install the
 following:
@@ -46,9 +46,24 @@ following:
 -  freetds-bin
 -  unixodbc-dev
 
-::
+On **Debian-based systems** these can be installed with the following command:
+
+.. code-block:: bash
 
     sudo apt-get install freetds-bin  unixodbc-dev
+
+On **Redhat or CentOS systems**, these can be installed from the Extra Packages for Enterprise Linux (EPEL) repository:
+
+.. code-block:: bash
+
+    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    sudo yum install freetds unixODBC-devel
+
+.. note::
+    The above command to install the EPEL repository is for Centos/Redhat 8. Change the number to match your OS version.
+
+    EPEL packages are included in Fedora repositories, so installing EPEL is not required on Fedora.
+
 
 Possible issues
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
…entos. Added RHEL/CentOS instructions for freetds and unixodbc packages.

# Description

Updated documentation for installation requirements. RHEL/CentOS 8 do not have packages called "python3.6-devel" and "python3.6-venv". Venv is now included in the Python standard library. Debian based systems still break it into its own package, but Redhat systems do not. There is, technically a "python36-devel" (no dot) package, but other versions of python will not be available in the repo, so python3-devel is better.  Along the way, I also added instructions for instaling the freetds and unixODBC packages on Redhat systems.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Documenation formatting was checked in PyCharm.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
