### PR TITLE
Fixing issue#2330. Deserializing integers in frame_serialization is i…

### DIFF
--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -687,7 +687,6 @@ class PubSub(SubsystemBase):
             elif len(response) == 1: #bool
                 response = struct.unpack('?', response.encode('utf-8'))
                 response = response[0]
-            _log.info("PUBSUB response: {}".format(response))
             if result:
                 result.set(response)
 

--- a/volttron/platform/vip/agent/subsystems/pubsub.py
+++ b/volttron/platform/vip/agent/subsystems/pubsub.py
@@ -680,7 +680,14 @@ class PubSub(SubsystemBase):
                 self._pubsubwithrpc.clear_parameters()
                 del self._pubsubwithrpc
             response = message.args[1]
-            #_log.debug("Message result: {}".format(response))
+            import struct
+            if len(response) == 4: #integer
+                response = struct.unpack('I', response.encode('utf-8'))
+                response = response[0]
+            elif len(response) == 1: #bool
+                response = struct.unpack('?', response.encode('utf-8'))
+                response = response[0]
+            _log.info("PUBSUB response: {}".format(response))
             if result:
                 result.set(response)
 

--- a/volttron/utils/frame_serialization.py
+++ b/volttron/utils/frame_serialization.py
@@ -82,7 +82,7 @@ def deserialize_frames(frames: List[Frame]) -> List:
 def serialize_frames(data: List[Any]) -> List[Frame]:
     frames = []
 
-    # _log.debug("Serializing: {}".format(data))
+    #_log.info("Serializing: {}".format(data))
     for x in data:
         try:
             if isinstance(x, list) or isinstance(x, dict):
@@ -91,6 +91,8 @@ def serialize_frames(data: List[Any]) -> List[Frame]:
                 frames.append(x)
             elif isinstance(x, bytes):
                 frames.append(Frame(x))
+            elif isinstance(x, bool):
+                frames.append(struct.pack("?", x))
             elif isinstance(x, int):
                 frames.append(struct.pack("I", x))
             elif isinstance(x, float):
@@ -98,13 +100,13 @@ def serialize_frames(data: List[Any]) -> List[Frame]:
             elif x is None:
                 frames.append(Frame(x))
             else:
+                #_log.info("serialize_frames:{}".format(x))
                 frames.append(Frame(x.encode('utf-8')))
         except TypeError as e:
             import sys
             sys.exit(0)
         except AttributeError as e:
             import sys
-            # _log.debug("Serializing: {}".format(data))
             sys.exit(0)
     return frames
 


### PR DESCRIPTION
# Description
De-serialization of integers/booleans in frame_serialization.py is limited to str. From str, we need unpack the structure object to get integer/boolean. The fix is added in pubsub.py to unpack accordingly.

Fixes #2330 
