### PR TITLE
modified for restarting playback and wrapping metadata as dict

### DIFF
--- a/examples/DataPublisher/datapublisher/agent.py
+++ b/examples/DataPublisher/datapublisher/agent.py
@@ -215,7 +215,7 @@ class Publisher(Agent):
         results = defaultdict(dict)
         for topic, point in name_map.values():
             unit_type = Publisher._get_unit(point, unittype_map)
-            results[topic][point] = unit_type
+            results[topic][point] = {"unit": unit_type}
         return results
 
     def build_maps(self, fieldnames, base_path):
@@ -350,7 +350,7 @@ class Publisher(Agent):
             # Reset data frequency counter.
             self._next_allowed_publish = None
             if not isinstance(self._input_data, list):
-                handle = open(self._input_data, 'rb')
+                handle = open(self._input_data, 'r')
                 self._data = csv.DictReader(handle)
 
     @RPC.export


### PR DESCRIPTION
# Description
Modify the DataPublisher agent for restarting playback and wrapping metadata as dict.

Fixes #2321

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I tested the modification with the following configuration:

> 

"remember_playback": false,
"reset_playback": true,
"replay_data": true,
"topic_separator": "/"

> 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
