### PR TITLE
Develop

### DIFF
--- a/docs/source/core_services/historians/index.rst
+++ b/docs/source/core_services/historians/index.rst
@@ -104,11 +104,22 @@ All historians support the following settings:
             "capture_device_data": ["devices/campus/building/device/all"],
             "capture_analysis_data": ["analysis/application_data/example"],
             "capture_record_data": ["example"]
-        }
+        },
+        # To restrict the points processed by a historian for a device or set of devices (i.e., this configuration
+        # parameter only filters data on topics with base 'devices).  If the 'device' is in the
+        # topic (e.g.,'devices/campus/building/device/all') then only points in the list will be passed to the
+        # historians capture_data method, and processed by the historian for storage in its database (or forwarded to a
+        # remote platform (in the case of the ForwardHistorian).  The key in the device_data_filter dictionary can
+        # be made more restrictive (e.g., "device/subdevice") to limit unnecessary searches through topics that may not
+        # contain the point(s) of interest.
+        "device_data_filter":
+            {
+                "device": ["point_name1", "point_name2"]
+            }
     }
 
 By default the base historian will listen to 4 separate root topics
-`datalogger/*`, `record/*`, `analysis/*`, and `device/*`.
+`datalogger/*`, `record/*`, `analysis/*`, and `devices/*`.
 
 Each root
 topic has a :ref:`specific message syntax <Historian-Topic-Syntax>` that

--- a/services/core/ForwardHistorian/forwarder/agent.py
+++ b/services/core/ForwardHistorian/forwarder/agent.py
@@ -227,7 +227,10 @@ class ForwardHistorian(BaseHistorian):
         except Exception as e:
             _log.debug("Error handling device_data_filter. {}".format(e))
             msg = message
-        self.capture_data(peer, sender, bus, topic, headers, msg)
+        if not msg:
+            _log.debug("Topic: {} - is not in configured to be forwarded".format(topic))
+        else:
+            self.capture_data(peer, sender, bus, topic, headers, msg)
 
     def _capture_log_data(self, peer, sender, bus, topic, headers, message):
         self.capture_data(peer, sender, bus, topic, headers, message)

--- a/services/core/ForwardHistorian/forwarder/agent.py
+++ b/services/core/ForwardHistorian/forwarder/agent.py
@@ -206,7 +206,28 @@ class ForwardHistorian(BaseHistorian):
 
     # Redirect the normal capture functions to capture_data.
     def _capture_device_data(self, peer, sender, bus, topic, headers, message):
-        self.capture_data(peer, sender, bus, topic, headers, message)
+        parts = topic.split('/')
+        device = '/'.join(parts[1:-1])
+        # msg = [{data},{meta}] format
+        msg = [{}, {}]
+        try:
+            # If the filter is empty pass all data.
+            if self._device_data_filter:
+                for _filter, point_list in self._device_data_filter.items():
+                    # If filter is not empty only topics that contain the key
+                    # will be kept.
+                    if _filter in device:
+                        for point in point_list:
+                            # Only points in the point list will be added to the message payload
+                            if point in message[0]:
+                                msg[0][point] = message[0][point]
+                                msg[1][point] = message[1][point]
+            else:
+                msg = message
+        except Exception as e:
+            _log.debug("Error handling device_data_filter. {}".format(e))
+            msg = message
+        self.capture_data(peer, sender, bus, topic, headers, msg)
 
     def _capture_log_data(self, peer, sender, bus, topic, headers, message):
         self.capture_data(peer, sender, bus, topic, headers, message)

--- a/services/core/ForwardHistorian/forwarder/agent.py
+++ b/services/core/ForwardHistorian/forwarder/agent.py
@@ -227,7 +227,7 @@ class ForwardHistorian(BaseHistorian):
         except Exception as e:
             _log.debug("Error handling device_data_filter. {}".format(e))
             msg = message
-        if not msg:
+        if not msg[0]:
             _log.debug("Topic: {} - is not in configured to be forwarded".format(topic))
         else:
             self.capture_data(peer, sender, bus, topic, headers, msg)

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -1,0 +1,18 @@
+{
+    "connection": {
+        "type": "sqlite",
+        "params": {
+            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
+            # in secure mode as this will be only directory in which agent will have write access
+            # In regular mode it will be under install_dir/data for backward compatibility
+            "database": "historian_test.sqlite"
+        }
+        # When capturing device data only capture topics with AHU (e.g., "devices/CAMPUS/BUILDING/AHU1/all"
+        # When a topic does contain AHU, only store points in the  point list to the database for that topic.
+        "device_data_filter": {
+            "AHU": ["OutdoorAirTemperature"]
+        },
+        "capture_device_data": true
+    },
+    "all_platforms":true
+}

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -7,12 +7,12 @@
             # In regular mode it will be under install_dir/data for backward compatibility
             "database": "historian_test.sqlite"
         }
-        # When capturing device data only capture topics with AHU (e.g., "devices/CAMPUS/BUILDING/AHU1/all"
-        # When a topic does contain AHU, only store points in the  point list to the database for that topic.
-        "device_data_filter": {
-            "AHU": ["OutdoorAirTemperature"]
-        },
-        "capture_device_data": true
     },
+    # When capturing device data only capture topics with AHU (e.g., "devices/CAMPUS/BUILDING/AHU1/all"
+    # When a topic does contain AHU, only store points in the  point list to the database for that topic.
+    "device_data_filter": {
+        "AHU": ["OutdoorAirTemperature"]
+    },
+    "capture_device_data": true,
     "all_platforms":true
 }

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -858,8 +858,8 @@ class BaseHistorianAgent(Agent):
                                 msg[1][point] = message[1][point]
             else:
                 msg = message
-        except:
-            _log.debug("Error handling device_data_filter.")
+        except Exception as e:
+            _log.debug("Error handling device_data_filter. {}".format(e))
             msg = message
 
         self._capture_data(peer, sender, bus, topic, headers, msg, device)

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -366,7 +366,7 @@ class BaseHistorianAgent(Agent):
                  storage_limit_gb=None,
                  sync_timestamp=False,
                  custom_topics={},
-                 data_filter={},
+                 device_data_filter={},
                  all_platforms=False,
                  **kwargs):
 

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -861,8 +861,10 @@ class BaseHistorianAgent(Agent):
         except Exception as e:
             _log.debug("Error handling device_data_filter. {}".format(e))
             msg = message
-
-        self._capture_data(peer, sender, bus, topic, headers, msg, device)
+        if not msg:
+            _log.debug("Topic: {} - is not in configured to be stored in db".format(topic))
+        else:
+            self._capture_data(peer, sender, bus, topic, headers, msg, device)
 
     def _capture_analysis_data(self, peer, sender, bus, topic, headers,
                                message):

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -583,7 +583,7 @@ class BaseHistorianAgent(Agent):
                                    custom_topics_list)
 
         self.stop_process_thread()
-        self.device_data_filter = config.get("device_data_filter")
+        self._device_data_filter = config.get("device_data_filter")
         try:
             self.configure(config)
         except Exception as e:
@@ -845,11 +845,11 @@ class BaseHistorianAgent(Agent):
         msg = {}
         try:
             # If the filter is empty pass all data.
-            if self.device_data_filter:
-                for filter, point_list  in self.device_data_filter.items():
+            if self._device_data_filter:
+                for _filter, point_list  in self._device_data_filter.items():
                     # If filter is not empty only topics that contain the key
                     # will be kept.
-                    if filter in device:
+                    if _filter in device:
                         for point in point_list:
                             # Only points in the point list will be added to the message payload
                             if point in message[0]:

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -842,7 +842,8 @@ class BaseHistorianAgent(Agent):
         # we strip it off to get the base device
         parts = topic.split('/')
         device = '/'.join(parts[1:-1])
-        msg = {}
+        # msg = [{data},{meta}] format
+        msg = [{},{}]
         try:
             # If the filter is empty pass all data.
             if self._device_data_filter:
@@ -860,6 +861,7 @@ class BaseHistorianAgent(Agent):
         except:
             _log.debug("Error handling device_data_filter.")
             msg = message
+
         self._capture_data(peer, sender, bus, topic, headers, msg, device)
 
     def _capture_analysis_data(self, peer, sender, bus, topic, headers,

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -844,7 +844,7 @@ class BaseHistorianAgent(Agent):
         device = '/'.join(parts[1:-1])
         try:
             if self.device_data_filter:
-                for filter, point_list  in self.data_filter.items():
+                for filter, point_list  in self.device_data_filter.items():
                     if filter in device:
                         for point in point_list:
                             if point in message[0]:

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -843,11 +843,11 @@ class BaseHistorianAgent(Agent):
         parts = topic.split('/')
         device = '/'.join(parts[1:-1])
         # msg = [{data},{meta}] format
-        msg = [{},{}]
+        msg = [{}, {}]
         try:
             # If the filter is empty pass all data.
             if self._device_data_filter:
-                for _filter, point_list  in self._device_data_filter.items():
+                for _filter, point_list in self._device_data_filter.items():
                     # If filter is not empty only topics that contain the key
                     # will be kept.
                     if _filter in device:
@@ -861,7 +861,7 @@ class BaseHistorianAgent(Agent):
         except Exception as e:
             _log.debug("Error handling device_data_filter. {}".format(e))
             msg = message
-        if not msg:
+        if not msg[0]:
             _log.debug("Topic: {} - is not in configured to be stored in db".format(topic))
         else:
             self._capture_data(peer, sender, bus, topic, headers, msg, device)

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -842,11 +842,16 @@ class BaseHistorianAgent(Agent):
         # we strip it off to get the base device
         parts = topic.split('/')
         device = '/'.join(parts[1:-1])
+        msg = {}
         try:
+            # If the filter is empty pass all data.
             if self.device_data_filter:
                 for filter, point_list  in self.device_data_filter.items():
+                    # If filter is not empty only topics that contain the key
+                    # will be kept.
                     if filter in device:
                         for point in point_list:
+                            # Only points in the point list will be added to the message payload
                             if point in message[0]:
                                 msg[0][point] = message[0][point]
                                 msg[1][point] = message[1][point]
@@ -855,7 +860,7 @@ class BaseHistorianAgent(Agent):
         except:
             _log.debug("Error handling device_data_filter.")
             msg = message
-        self._capture_data(peer, sender, bus, topic, headers, message, device)
+        self._capture_data(peer, sender, bus, topic, headers, msg, device)
 
     def _capture_analysis_data(self, peer, sender, bus, topic, headers,
                                message):

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*- {{{
 # vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
 #
-# Copyright 2019, Battelle Memorial Institute.
+# Copyright 2017, Battelle Memorial Institute.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -219,13 +219,13 @@ the same date over again.
 
 """
 
-
+from __future__ import absolute_import, print_function
 
 import logging
 import sqlite3
 import threading
 import weakref
-from queue import Queue, Empty
+from Queue import Queue, Empty
 from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -246,7 +246,7 @@ from volttron.platform.vip.agent import *
 from volttron.platform.vip.agent import compat
 from volttron.platform.vip.agent.subsystems.query import Query
 
-from volttron.platform.async_ import AsyncCall
+from volttron.platform.async import AsyncCall
 
 from volttron.platform.messaging.health import (STATUS_BAD,
                                                 STATUS_UNKNOWN,
@@ -256,29 +256,25 @@ from volttron.platform.messaging.health import (STATUS_BAD,
 
 try:
     import ujson
-    from volttron.platform.jsonapi import dumps as _dumps, loads as _loads
+    from zmq.utils.jsonapi import dumps as _dumps, loads as _loads
 
     def dumps(data):
         try:
             return ujson.dumps(data, double_precision=15)
-        except Exception:
+        except:
             return _dumps(data)
 
     def loads(data_string):
         try:
             return ujson.loads(data_string, precise_float=True)
-        except Exception:
+        except:
             return _loads(data_string)
 except ImportError:
-    from volttron.platform.jsonapi import dumps, loads
+    from zmq.utils.jsonapi import dumps, loads
 
 from volttron.platform.agent import utils
 
 _log = logging.getLogger(__name__)
-
-
-# Build the parser
-time_parser = None
 
 ACTUATOR_TOPIC_PREFIX_PARTS = len(topics.ACTUATOR_VALUE.split('/'))
 ALL_REX = re.compile('.*/all$')
@@ -300,7 +296,7 @@ def add_timing_data_to_header(headers, agent_id, phase):
 
     agent_timing_data[phase] = utils.format_timestamp(utils.get_aware_utc_now())
 
-    values = list(agent_timing_data.values())
+    values = agent_timing_data.values()
 
     if len(values) < 2:
         return 0.0
@@ -366,6 +362,7 @@ class BaseHistorianAgent(Agent):
                  storage_limit_gb=None,
                  sync_timestamp=False,
                  custom_topics={},
+                 data_filter={},
                  all_platforms=False,
                  **kwargs):
 
@@ -433,6 +430,7 @@ class BaseHistorianAgent(Agent):
                                 "storage_limit_gb": storage_limit_gb,
                                 "history_limit_days": history_limit_days,
                                 "custom_topics": custom_topics,
+                                "device_data_filter": device_data_filter,
                                 "all_platforms": self._all_platforms
                                }
 
@@ -537,7 +535,7 @@ class BaseHistorianAgent(Agent):
             return
 
         query = Query(self.core)
-        self.instance_name = query.query('instance-name').get()
+        self.instance_name = query.query(b'instance-name').get()
 
         # Reset replace map.
         self._topic_replace_map = {}
@@ -581,7 +579,8 @@ class BaseHistorianAgent(Agent):
                                    custom_topics_list)
 
         self.stop_process_thread()
-
+        self.device_data_filter = config.get("device_data_filter")
+        _log.debug("Setup data filter: {}".format(self.data_filter))
         try:
             self.configure(config)
         except Exception as e:
@@ -645,7 +644,7 @@ class BaseHistorianAgent(Agent):
         if self.no_insert:
             raise RuntimeError("Insert not supported by this historian.")
 
-        rpc_peer = self.vip.rpc.context.vip_message.peer
+        rpc_peer = bytes(self.vip.rpc.context.vip_message.peer)
         _log.debug("insert called by {} with {} records".format(rpc_peer, len(records)))
 
         for r in records:
@@ -701,7 +700,7 @@ class BaseHistorianAgent(Agent):
         table_prefix = tables_def.get('table_prefix', None)
         table_prefix = table_prefix + "_" if table_prefix else ""
         if table_prefix:
-            for key, value in list(table_names.items()):
+            for key, value in table_names.items():
                 table_names[key] = table_prefix + table_names[key]
         table_names["agg_topics_table"] = table_prefix + \
             "aggregate_" + tables_def["topics_table"]
@@ -720,7 +719,7 @@ class BaseHistorianAgent(Agent):
         # Only if we have some topics to replace.
         if self._topic_replace_list:
             # if we have already cached the topic then return it.
-            if input_topic_lower in self._topic_replace_map:
+            if input_topic_lower in self._topic_replace_map.keys():
                 output_topic = self._topic_replace_map[input_topic_lower]
             else:
                 self._topic_replace_map[input_topic_lower] = input_topic
@@ -792,7 +791,7 @@ class BaseHistorianAgent(Agent):
         if self.gather_timing_data:
             add_timing_data_to_header(headers, self.core.agent_uuid or self.core.identity, "collected")
 
-        for point, item in data.items():
+        for point, item in data.iteritems():
             if 'Readings' not in item or 'Units' not in item:
                 _log.error("logging request for {topic} missing Readings "
                            "or Units".format(topic=topic))
@@ -839,8 +838,23 @@ class BaseHistorianAgent(Agent):
         # Because of the above if we know that all is in the topic so
         # we strip it off to get the base device
         parts = topic.split('/')
+        msg = [{},{}]
         device = '/'.join(parts[1:-1])
-        self._capture_data(peer, sender, bus, topic, headers, message, device)
+        try:
+            if self.device_data_filter:
+                for filter, point_list  in self.data_filter.items():
+                    if filter in device:
+                        for point in point_list:
+                            if point in message[0]:
+                                msg[0][point] = message[0][point]
+                                msg[1][point] = message[1][point]
+            else:
+                msg = message
+        except:
+            _log.debug("Error handling device_data_filter.")
+            msg = message
+        
+        self._capture_data(peer, sender, bus, topic, headers, msg, device)
 
     def _capture_analysis_data(self, peer, sender, bus, topic, headers,
                                message):
@@ -913,7 +927,7 @@ class BaseHistorianAgent(Agent):
         if self.gather_timing_data:
             add_timing_data_to_header(headers, self.core.agent_uuid or self.core.identity, "collected")
 
-        for key, value in values.items():
+        for key, value in values.iteritems():
             point_topic = device + '/' + key
             self._event_queue.put({'source': source,
                                    'topic': point_topic,
@@ -1021,7 +1035,7 @@ class BaseHistorianAgent(Agent):
         # is setting up connections that are shared for both query and write
         # operations
 
-        self._historian_setup()  # should be called even for readonly as this
+        self._historian_setup() # should be called even for readonly as this
         # might load the topic id name map
 
         if self._readonly:
@@ -1060,6 +1074,7 @@ class BaseHistorianAgent(Agent):
                         new_to_publish.append(self._event_queue.get_nowait())
                     except Empty:
                         break
+
 
             # We wake the thread after a configuration change by passing a None to the queue.
             # Backup anything new before checking for a stop.
@@ -1126,6 +1141,7 @@ class BaseHistorianAgent(Agent):
                         self._send_alert({STATUS_KEY_PUBLISHING: False}, "historian_not_publishing")
                         break
 
+
                     backupdb.remove_successfully_published(
                         self._successful_published, self._submit_size_limit)
 
@@ -1163,7 +1179,7 @@ class BaseHistorianAgent(Agent):
 
         try:
             self.historian_teardown()
-        except Exception:
+        except:
             _log.exception("Historian teardown failed!")
 
         _log.debug("Process loop stopped.")
@@ -1171,7 +1187,7 @@ class BaseHistorianAgent(Agent):
 
     def _historian_setup(self):
         try:
-            _log.info("Trying to setup historian")
+            _log.exception("Trying to setup historian")
             self.historian_setup()
             if not self._readonly:
                 # Record the names of data, topics, meta tables in a metadata table
@@ -1396,7 +1412,7 @@ class BackupDatabase:
                 self._backup_cache[topic] = topic_id
 
             meta_dict = self._meta_data[(source, topic_id)]
-            for name, value in meta.items():
+            for name, value in meta.iteritems():
                 current_meta_value = meta_dict.get(name)
                 if current_meta_value != value:
                     c.execute('''INSERT OR REPLACE INTO metadata
@@ -1417,63 +1433,33 @@ class BackupDatabase:
                     # In the case where we are upgrading an existing installed historian the
                     # unique constraint may still exist on the outstanding database.
                     # Ignore this case.
-                    _log.warning(f"sqlite3.Integrity error -- {e}")
                     pass
 
         cache_full = False
         if self._backup_storage_limit_gb is not None:
-            try:
-                def page_count():
-                    c.execute("PRAGMA page_count")
-                    return c.fetchone()[0]
 
-                def free_count():
-                    c.execute("PRAGMA freelist_count")
-                    return c.fetchone()[0]
+            def page_count():
+                c.execute("PRAGMA page_count")
+                return c.fetchone()[0]
 
-                p = page_count()
-                f = free_count()
+            while page_count() > self.max_pages:
+                c.execute(
+                    '''DELETE FROM outstanding
+                    WHERE ROWID IN
+                    (SELECT ROWID FROM outstanding
+                    ORDER BY ROWID ASC LIMIT 100)''')
+                if self._record_count < c.rowcount:
+                    self._record_count = 0
+                else:
+                    self._record_count -= c.rowcount
+                cache_full = True
 
-                # check if we are over the alert threshold.
-                if page_count() >= self.max_pages - int(self.max_pages * (1.0 - self._backup_storage_report)):
-                    cache_full = True
+            # Catch case where we are not adding fast enough to trigger the above
+            # every time we add more data.
+            if page_count() >= self.max_pages - int(self.max_pages*(1.0-self._backup_storage_report)):
+                cache_full = True
 
-                # Now check if we are above the limit, if so start deleting in batches of 100
-                # page count doesnt update even after deleting all records
-                # and record count becomes zero. If we have deleted all record
-                # exit.
-                _log.debug(f"record count before check is {self._record_count} page count is {p}"
-                           f" free count is {f}")
-                # max_pages  gets updated based on inserts but freelist_count doesn't
-                # enter delete loop based on page_count
-                min_free_pages = p - self.max_pages
-                while p > self.max_pages:
-                    cache_full = True
-                    c.execute(
-                        '''DELETE FROM outstanding
-                        WHERE ROWID IN
-                        (SELECT ROWID FROM outstanding
-                        ORDER BY ROWID ASC LIMIT 100)''')
-                    #self._connection.commit()
-                    if self._record_count < c.rowcount:
-                        self._record_count = 0
-                    else:
-                        self._record_count -= c.rowcount
-                    p = page_count()  #page count doesn't reflect delete without commit
-                    f = free_count() # freelist count does. So using that to break from loop
-                    if f >= min_free_pages:
-                        break
-                    _log.debug(f" Cleaning cache since we are over the limit. "
-                               f"After delete of 100 records from cache"
-                               f" record count is {self._record_count} page count is {p} freelist count is{f}")
-
-            except Exception as e:
-                _log.warning(f"Exception when check page count and deleting{e}")
-
-        try:
-            self._connection.commit()
-        except Exception as e:
-            _log.warning(f"Exception in committing after back db storage {e}")
+        self._connection.commit()
 
         return cache_full
 
@@ -1570,15 +1556,8 @@ class BackupDatabase:
         """ Creates a backup database for the historian if doesn't exist."""
 
         _log.debug("Setting up backup DB.")
-        if utils.is_secure_mode():
-            # we want to create it in the agent-data directory since agent will not have write access to any other
-            # directory in secure mode
-            backup_db = os.path.join(os.getcwd(), os.path.basename(os.getcwd()) + ".agent-data", 'backup.sqlite')
-        else:
-            backup_db = 'backup.sqlite'
-        _log.info(f"Creating  backup db at {backup_db}")
         self._connection = sqlite3.connect(
-            backup_db,
+            'backup.sqlite',
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
             check_same_thread=check_same_thread)
 
@@ -1589,7 +1568,6 @@ class BackupDatabase:
             page_size = c.fetchone()[0]
             max_storage_bytes = self._backup_storage_limit_gb * 1024 ** 3
             self.max_pages = max_storage_bytes / page_size
-            _log.debug(f"Max pages is {self.max_pages}")
 
         c.execute("SELECT name FROM sqlite_master WHERE type='table' "
                   "AND name='outstanding';")
@@ -1708,22 +1686,6 @@ class BaseQueryHistorianAgent(Agent):
     their data stores.
     """
 
-    def __init__(self, **kwargs):
-        _log.debug('Constructor of BaseQueryHistorianAgent thread: {}'.format(
-            threading.currentThread().getName()
-        ))
-        global time_parser
-        if time_parser is None:
-            if utils.is_secure_mode():
-                # find agent's data dir. we have write access only to that dir
-                for d in os.listdir(os.getcwd()):
-                    if d.endswith(".agent-data"):
-                        agent_data_dir = os.path.join(os.getcwd(), d)
-                time_parser = yacc.yacc(write_tables=0,
-                                        outputdir=agent_data_dir)
-            else:
-                time_parser = yacc.yacc(write_tables=0)
-        super(BaseQueryHistorianAgent, self).__init__(**kwargs)
     @RPC.export
     def get_version(self):
         """RPC call to get the version of the historian
@@ -1918,6 +1880,7 @@ class BaseQueryHistorianAgent(Agent):
                 start = time_parser.parse(start)
             if start and start.tzinfo is None:
                 start = start.replace(tzinfo=pytz.UTC)
+
         if end is not None:
             try:
                 end = parse_timestamp_string(end)
@@ -2193,3 +2156,6 @@ def p_reltime(t):
 def p_error(p):
     raise ValueError("Syntax Error in Query")
 
+
+# Build the parser
+time_parser = yacc.yacc(write_tables=0)


### PR DESCRIPTION
# Description
Addresses issue #2339.  The base_historian captures and stores all "device" data or a set of custom_topics.  All points in the "all" or custom_topic publish are then stored in the database.  For some applications it is desirable to have the ability to filter the data points in the "all" or custom_topic publish.  This helps limit the size of the database and is particularly useful for deployments that utilize local storage via the sqlite historian.  

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2339 
