### PR TITLE
Fixes issue#2324 #2323 #2322

### DIFF
--- a/volttron/platform/vip/agent/results.py
+++ b/volttron/platform/vip/agent/results.py
@@ -87,6 +87,6 @@ class ResultsDictionary(WeakValueDictionary):
 
     def __next__(self):
         result = AsyncResult()
-        result.ident = ident = '%s.%s' % (next(self._counter), hash(result))
+        result.ident = ident = '%f.%f' % (next(self._counter), hash(result))
         self[ident] = result
         return result


### PR DESCRIPTION
# Description
Incorrect Frame de-serialization of message identifier frame in fedora and ubuntu 19.10 systems was causing some of the features in VOLTTRON to break, namely
1. "vctl status" command 
2. "vctl auth serverkey" command
3. Database was not getting created at startup of historians

Changing the format of message identifier seems to have fixed the problem

Fixes #2324 #2323 #2322 

