### PR TITLE
Fixed timezone in metadata to save string to database in place of pytz object.

### DIFF
--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -815,7 +815,7 @@ class BaseHistorianAgent(Agent):
                 if tz:
                     meta['tz'] = tz
                 elif my_tz:
-                    meta['tz'] = my_tz
+                    meta['tz'] = my_tz.zone
 
             self._event_queue.put({'source': 'log',
                                    'topic': topic + '/' + point,


### PR DESCRIPTION
# Description
Fix saving of timezone metadata in base historian for datalogger topics where the timezone is not explicitly provided. 

Fixes # (issue)
#2351 

## Type of change
Write string representation of timezone to database rather than pytz.timezone object.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
Publish datalogger topic without specifying 'tz' key explicitly. This will raise an error without the change when the metadata is saved to the sqlite.backup file without the change.  Works with the change.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
