### PR TITLE
modify return value of _get_unit

### DIFF
--- a/examples/DataPublisher/datapublisher/agent.py
+++ b/examples/DataPublisher/datapublisher/agent.py
@@ -247,7 +247,7 @@ class Publisher(Agent):
         for k, v in unittype_map.items():
             if re.match(k, point):
                 return v
-        return 'percent'
+        return {'type': 'float'}
 
     def _publish_point_all(self, topic, data, meta_data, headers):
         # makesure topic+point gives a true value.


### PR DESCRIPTION
Default unit is formatted incorrectly.
This caused an error related to meta data in historian agent.
So I modified the second return of the '_get_unit' function of datapublisher.