### PR TITLE
Fixed CSVHistorian opening file in bytes mode

### DIFF
--- a/examples/CSVHistorian/csv_historian/historian.py
+++ b/examples/CSVHistorian/csv_historian/historian.py
@@ -36,6 +36,7 @@
 # under Contract DE-AC05-76RL01830
 # }}}
 
+import os
 import sys
 import logging
 
@@ -72,13 +73,13 @@ def historian(config_path, **kwargs):
 class CSVHistorian(BaseHistorian):
     """
     Historian that stores the data into crate tables.
-
     """
 
     def __init__(self, output_path="", **kwargs):
         self.output_path = output_path
         self.csv_dict = None
         self.csv_file = None
+        self.default_dir = "./data"
         super(CSVHistorian, self).__init__(**kwargs)
 
     def version(self):
@@ -99,7 +100,16 @@ class CSVHistorian(BaseHistorian):
         self.csv_file.flush()
 
     def historian_setup(self):
+        # if the current file doesn't exist, or the path provided doesn't include a directory, use the default dir
+        # in <agent dir>/data
+        if not (os.path.isfile(self.output_path) or os.path.dirname(self.output_path)):
+            if not os.path.isdir(self.default_dir):
+                os.mkdir(self.default_dir)
+            self.output_path = os.path.join(self.default_dir, self.output_path)
+
         self.csv_file = open(self.output_path, "w")
+
+
         self.csv_dict = csv.DictWriter(self.csv_file, fieldnames=["timestamp", "source", "topic", "value"])
         self.csv_dict.writeheader()
         self.csv_file.flush()

--- a/examples/CSVHistorian/csv_historian/historian.py
+++ b/examples/CSVHistorian/csv_historian/historian.py
@@ -36,7 +36,6 @@
 # under Contract DE-AC05-76RL01830
 # }}}
 
-
 import sys
 import logging
 
@@ -53,12 +52,10 @@ __version__ = '1.0.1'
 
 def historian(config_path, **kwargs):
     """
-    This method is called by the :py:func:`crate_historian.historian.main` to parse
+    This method is called by the main method to parse
     the passed config file or configuration dictionary object, validate the
-    configuration entries, and create an instance of CSVHistorian
-
-    :param config_path: could be a path to a configuration file or can be a
-                        dictionary object
+    configuration entries, and create an instance of the CSVHistorian class
+    :param config_path: could be a path to a configuration file or can be a dictionary object
     :param kwargs: additional keyword arguments if any
     :return: an instance of :py:class:`CSVHistorian`
     """
@@ -69,7 +66,7 @@ def historian(config_path, **kwargs):
 
     output_path = config_dict.get("output", "historian_output.csv")
 
-    return CSVHistorian(output_path = output_path, **kwargs)
+    return CSVHistorian(output_path=output_path, **kwargs)
 
 
 class CSVHistorian(BaseHistorian):
@@ -81,12 +78,15 @@ class CSVHistorian(BaseHistorian):
     def __init__(self, output_path="", **kwargs):
         self.output_path = output_path
         self.csv_dict = None
+        self.csv_file = None
         super(CSVHistorian, self).__init__(**kwargs)
 
+    def version(self):
+        return __version__
 
     def publish_to_historian(self, to_publish_list):
         for record in to_publish_list:
-            row = {}
+            row = dict()
             row["timestamp"] = record["timestamp"]
 
             row["source"] = record["source"]
@@ -96,13 +96,13 @@ class CSVHistorian(BaseHistorian):
             self.csv_dict.writerow(row)
 
         self.report_all_handled()
-        self.f.flush()
+        self.csv_file.flush()
 
     def historian_setup(self):
-        self.f = open(self.output_path, "wb")
-        self.csv_dict = csv.DictWriter(self.f, ["timestamp", "source", "topic", "value"])
+        self.csv_file = open(self.output_path, "w")
+        self.csv_dict = csv.DictWriter(self.csv_file, fieldnames=["timestamp", "source", "topic", "value"])
         self.csv_dict.writeheader()
-        self.f.flush()
+        self.csv_file.flush()
 
 
 def main(argv=sys.argv):


### PR DESCRIPTION
# Description

Fixed CSVHistorian failing to start and showing bad health as a result of opening a file in bytes mode and then using the Python3 CSV DictWriter to write headers as strings.

Fixes #2356

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Installed and started CSVHistorian, configured master driver with fake driver, fake driver collected data points, confirmed contents of CSVHistorian's "database" (currently no unit tests exist for this example agent). 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
