### PR TITLE
Fixes issue#2345. 

### DIFF
--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -139,7 +139,7 @@ class AuthService(Agent):
                 _log.debug("Sending auth updates to peers")
                 # Give it few seconds for platform to startup or for the
                 # router to detect agent install/remove action
-                gevent.sleep(5)
+                gevent.sleep(2)
                 self._send_update()
             except BaseException as e:
                 _log.error("Exception sending auth updates to peer. {}".format(e))

--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -137,6 +137,9 @@ class AuthService(Agent):
         if self._is_connected:
             try:
                 _log.debug("Sending auth updates to peers")
+                # Give it few seconds for platform to startup or for the
+                # router to detect agent install/remove action
+                gevent.sleep(5)
                 self._send_update()
             except BaseException as e:
                 _log.error("Exception sending auth updates to peer. {}".format(e))
@@ -176,6 +179,8 @@ class AuthService(Agent):
                 peers = self.vip.peerlist().get(timeout=0.5)
             except BaseException as e:
                 _log.warning("Attempt {} to get peerlist failed with exception {}".format(i, e))
+                peers = list(self.vip.peerlist.peers_list)
+                _log.warning("Get list of peers from subsystem directly".format(peers))
                 exception = e
 
         if not peers:

--- a/volttron/platform/vip/agent/subsystems/peerlist.py
+++ b/volttron/platform/vip/agent/subsystems/peerlist.py
@@ -157,8 +157,7 @@ class PeerList(SubsystemBase):
                 result = self._results.pop(message.id)
             except KeyError:
                 return
-            # The response will have frames, we convert to bytes and then from bytes
-            # we decode to strings for the final response.
+
             peers = [arg for arg in message.args[1:]]
             result.set(peers)
             self.peers_list = set(peers)


### PR DESCRIPTION
AuthService attempts to get peerlist to send the auth updates to all it's peers. The peerlist subsystem is able to get the list of peers from router, but is unable to set the result into asyn result object properly. As a workaround, peerlist subsystem now keeps track of list of peers to make it accessible to auth service

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2345 
