### PR TITLE
Add try/finally block to docker_wrapper

### DIFF
--- a/volttrontesting/fixtures/docker_wrapper.py
+++ b/volttrontesting/fixtures/docker_wrapper.py
@@ -36,11 +36,7 @@ if HAS_DOCKER:
             ::
                 # example port exposing mysql's known port.
                 {'3306/tcp': 3306}
-        :param env: environment variables to set inside the container, as a dictionary following the convention
-
-            ::
-                example environment variable for mysql's root password.
-                {'MYSQL_ROOT_PASSWORD': '12345'}
+        :param env: environment variables to set inside the container.
         :param command: string or list of commands to run during the startup of the container.
         :param startup_time_seconds: Allow this many seconds for the startup of the container before raising a
             runtime exception (Download of image and instantiation could take a while)
@@ -53,19 +49,13 @@ if HAS_DOCKER:
         client = docker.from_env()
 
         try:
-            repo = image_name
-            if ":" not in repo:
+            full_docker_image = image_name
+            if ":" not in full_docker_image:
                 # So all tags aren't pulled. According to docs https://docker-py.readthedocs.io/en/stable/images.html.
-                repo = repo + ":latest"
-            client.images.pull(repo)
-        except APIError as e:
-            raise RuntimeError(e)
-
-        try:
+                full_docker_image = full_docker_image + ":latest"
+            client.images.pull(full_docker_image)
             container = client.containers.run(image_name, ports=ports, environment=env, auto_remove=True, detach=True)
-        except ImageNotFound as e:
-            raise RuntimeError(e)
-        except APIError as e:
+        except (ImageNotFound, APIError, RuntimeError) as e:
             raise RuntimeError(e)
 
         if container is None:

--- a/volttrontesting/fixtures/docker_wrapper.py
+++ b/volttrontesting/fixtures/docker_wrapper.py
@@ -1,6 +1,6 @@
 try:
     import docker
-
+    from docker.errors import APIError, ImageNotFound
     HAS_DOCKER = True
 except ImportError:
     HAS_DOCKER = False
@@ -51,18 +51,39 @@ if HAS_DOCKER:
 
         # Create docker client (Uses localhost as agent connection.
         client = docker.from_env()
-        if ":" in image_name:
-            client.images.pull(image_name)
-        else:
-            # So all tags aren't pulled. According to docs https://docker-py.readthedocs.io/en/stable/images.html.
-            client.images.pull(image_name + ":latest")
-        container = client.containers.run(image_name, ports=ports, environment=env, auto_remove=True, detach=True)
+
+        try:
+            repo = image_name
+            if ":" not in repo:
+                # So all tags aren't pulled. According to docs https://docker-py.readthedocs.io/en/stable/images.html.
+                repo = repo + ":latest"
+            client.images.pull(repo)
+        except APIError as e:
+            raise RuntimeError(e)
+
+        try:
+            container = client.containers.run(image_name, ports=ports, environment=env, auto_remove=True, detach=True)
+        except ImageNotFound as e:
+            raise RuntimeError(e)
+        except APIError as e:
+            raise RuntimeError(e)
 
         if container is None:
             raise RuntimeError(f"Unable to run image {image_name}")
 
+        # wait for a certain amount of time to let container complete its build
+        try:
+            if _not_valid_container(container, startup_time_seconds):
+                yield None
+            else:
+                yield container
+        finally:
+            container.kill()
+
+    def _not_valid_container(container, startup_time_seconds):
         error_time = time.time() + startup_time_seconds
         invalid = False
+
         while container.status != 'running':
             if time.time() > error_time:
                 invalid = True
@@ -70,11 +91,4 @@ if HAS_DOCKER:
             time.sleep(0.1)
             container.reload()
 
-        try:
-            if invalid:
-                yield None
-            else:
-                yield container
-        finally:
-            container.kill()
-
+        return invalid

--- a/volttrontesting/fixtures/docker_wrapper.py
+++ b/volttrontesting/fixtures/docker_wrapper.py
@@ -31,12 +31,16 @@ if HAS_DOCKER:
 
         :param image_name: The image name (from dockerhub) that is to be instantiated
         :param ports:
-            a dictionary following the convention {'portincontainre/protocol': portonhost}
+            a dictionary following the convention {'portincontainer/protocol': portonhost}
 
             ::
                 # example port exposing mysql's known port.
                 {'3306/tcp': 3306}
-        :param env:
+        :param env: environment variables to set inside the container, as a dictionary following the convention
+
+            ::
+                example environment variable for mysql's root password.
+                {'MYSQL_ROOT_PASSWORD': '12345'}
         :param command: string or list of commands to run during the startup of the container.
         :param startup_time_seconds: Allow this many seconds for the startup of the container before raising a
             runtime exception (Download of image and instantiation could take a while)
@@ -66,10 +70,11 @@ if HAS_DOCKER:
             time.sleep(0.1)
             container.reload()
 
-        if invalid:
-            yield None
-        else:
-            yield container
-
-        container.kill()
+        try:
+            if invalid:
+                yield None
+            else:
+                yield container
+        finally:
+            container.kill()
 

--- a/volttrontesting/testutils/test_docker_wrapper.py
+++ b/volttrontesting/testutils/test_docker_wrapper.py
@@ -10,13 +10,6 @@ except ImportError:
 SKIP_REASON = "No docker available in api (install pip install docker) for availability"
 
 
-def test_web_setup_properly(volttron_instance_web):
-    instance = volttron_instance_web
-
-    assert instance.is_running()
-    assert instance.bind_web_address == instance.volttron_central_address
-
-
 @pytest.mark.skipif(SKIP_DOCKER, reason=SKIP_REASON)
 def test_docker_wrapper():
     with create_container("mysql", ports={"3306/tcp": 3306}, env={"MYSQL_ROOT_PASSWORD": "12345"}) as container:
@@ -44,7 +37,7 @@ def test_docker_wrapper_should_throw_runtime_error_on_false_image_when_pull():
 def test_docker_wrapper_should_throw_runtime_error_when_ports_clash():
     port = 4200
     with pytest.raises(RuntimeError) as execinfo:
-        with create_container("crate", ports={"4200/tcp": port}) as container1:
+        with create_container("crate", ports={"4200/tcp": port}):
             with create_container("crate", ports={"4200/tcp": port}) as container2:
                 assert container2.status == 'running'
 

--- a/volttrontesting/testutils/test_fixtures.py
+++ b/volttrontesting/testutils/test_fixtures.py
@@ -17,13 +17,14 @@ def test_web_setup_properly(volttron_instance_web):
 
 @pytest.mark.skipif(SKIP_DOCKER, reason="No docker available in api (install pip install docker) for availability")
 def test_docker_wrapper():
-    with create_container("mysql") as container:
-        print(container.status)
-        print(container.logs())
+    with create_container("mysql", ports={"3306/tcp": 3306}, env={"MYSQL_ROOT_PASSWORD": "12345"}) as container:
+        print(f"\nStatus: {container.status}")
+        print(f"\nLogs: {container.logs()}")
+        assert container.status == 'running'
 
 
 @pytest.mark.skipif(SKIP_DOCKER, reason="No docker available in api (install pip install docker) for availability")
 def test_docker_run_crate_latest():
-    with create_container("crate", {"4200/tcp": 4200}) as container:
+    with create_container("crate", ports={"4200/tcp": 4200}) as container:
         assert container.status == 'running'
 

--- a/volttrontesting/testutils/test_fixtures.py
+++ b/volttrontesting/testutils/test_fixtures.py
@@ -1,11 +1,13 @@
 import pytest
-from volttrontesting.fixtures.volttron_platform_fixtures import volttron_instance_web
+
 
 try:
     SKIP_DOCKER = False
     from volttrontesting.fixtures.docker_wrapper import create_container
 except ImportError:
     SKIP_DOCKER = True
+
+SKIP_REASON = "No docker available in api (install pip install docker) for availability"
 
 
 def test_web_setup_properly(volttron_instance_web):
@@ -15,7 +17,7 @@ def test_web_setup_properly(volttron_instance_web):
     assert instance.bind_web_address == instance.volttron_central_address
 
 
-@pytest.mark.skipif(SKIP_DOCKER, reason="No docker available in api (install pip install docker) for availability")
+@pytest.mark.skipif(SKIP_DOCKER, reason=SKIP_REASON)
 def test_docker_wrapper():
     with create_container("mysql", ports={"3306/tcp": 3306}, env={"MYSQL_ROOT_PASSWORD": "12345"}) as container:
         print(f"\nStatus: {container.status}")
@@ -23,8 +25,28 @@ def test_docker_wrapper():
         assert container.status == 'running'
 
 
-@pytest.mark.skipif(SKIP_DOCKER, reason="No docker available in api (install pip install docker) for availability")
+@pytest.mark.skipif(SKIP_DOCKER, reason=SKIP_REASON)
 def test_docker_run_crate_latest():
     with create_container("crate", ports={"4200/tcp": 4200}) as container:
         assert container.status == 'running'
+
+
+@pytest.mark.skipif(SKIP_DOCKER, reason=SKIP_REASON)
+def test_docker_wrapper_should_throw_runtime_error_on_false_image_when_pull():
+    with pytest.raises(RuntimeError) as execinfo:
+        with create_container("not_a_real_image", ports={"4200/tcp": 4200}) as container:
+            container.logs()
+
+    assert "404 Client Error: Not Found" in str(execinfo.value)
+
+
+@pytest.mark.skipif(SKIP_DOCKER, reason=SKIP_REASON)
+def test_docker_wrapper_should_throw_runtime_error_when_ports_clash():
+    port = 4200
+    with pytest.raises(RuntimeError) as execinfo:
+        with create_container("crate", ports={"4200/tcp": port}) as container1:
+            with create_container("crate", ports={"4200/tcp": port}) as container2:
+                assert container2.status == 'running'
+
+    assert "500 Server Error: Internal Server Error" in str(execinfo.value)
 


### PR DESCRIPTION
# Description

Currently, if a test used docker_wrapper and the test failed, the
container will not be killed and rather will remain up and running. Thus, every time a test that uses docker_wrapper fails, the container must manually be killed/resource released by running ```docker container stop $(docker ps -aq)```. 

Adding the try/finally block will ensure that container is killed automatically.
See https://docs.python.org/3/library/contextlib.html

Fixes #2387 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the docker wrapper tests. 

I also created a failing test, then checked to see if the container was still running. 
Then I added the fix, reran the failing test, and checked to see if the container was killed/released.

Before:
![Screen Shot 2020-06-22 at 10 18 02 AM](https://user-images.githubusercontent.com/6901848/85316470-aa519980-b471-11ea-8d5d-a1eab4668c1a.png)

After:
![Screen Shot 2020-06-22 at 10 27 05 AM](https://user-images.githubusercontent.com/6901848/85317457-43cd7b00-b473-11ea-951a-4f4f4e8bec0a.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

