### PR TITLE
Fixes issue#2110. 

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -121,9 +121,6 @@ extras_require = {
         # Allows us to compare nested dictionaries easily.
         'deepdiff'
     ],
-    'rabbitmq': [
-        'gevent-pika'
-    ],
     'web': [    # Web support for launching web based agents including ssl and json web tokens.
         'ws4py',
         'PyJWT',


### PR DESCRIPTION
#Description
Bootstrap was ignoring optional rabbitmq server install directory. Bootstrap now handles rabbitmq server installation separately so that non-default rabbitmq install path can be accepted.

Fixes #2110
