### PR TITLE
Updated references to Slack signup to use volttron mailing list

### DIFF
--- a/docs/source/community_resources/index.rst
+++ b/docs/source/community_resources/index.rst
@@ -12,19 +12,19 @@ Slack Channel
 ^^^^^^^^^^^^^
 
 volttron-community.slack.com is where the |VOLTTRON| community at large can ask questions and meet with others
-using |VOLTTRON| Signup via https://volttron-community.signup.team/
+using |VOLTTRON|.  To be added to Slack please email the VOLTTRON team at
+`volttron@pnnl.gov <mailto:volttron@pnnl.gov?subject=Subscribe%20To%20List>`__.
 
 Mailing List
 ^^^^^^^^^^^^
 
-Join the mailing list by emailing
-`volttron@pnnl.gov <mailto:volttron@pnnl.gov?subject=Subscribe%20To%20List>`__.
+Join the mailing list by emailing `volttron@pnnl.gov <mailto:volttron@pnnl.gov?subject=Subscribe%20To%20List>`__.
 
 Stack Overflow
 ^^^^^^^^^^^^^^
 
 The VOLTTRON community supports questions being asked and answered through Stack Overflow.  The questions tagged with
-the volttron tag can be found at http://stackoverflow.com/questions/tagged/volttron.
+the `volttron` tag can be found at http://stackoverflow.com/questions/tagged/volttron.
 
 Office Hours
 ^^^^^^^^^^^^


### PR DESCRIPTION
# Description

Removes link to volttron slack signup page which threw a 404, replaces with email link.

Fixes # 2254

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested against local Sphinx build for this branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
