### PR TITLE
Remove duplicate try/except in docker_wrapper

### DIFF
--- a/volttrontesting/fixtures/docker_wrapper.py
+++ b/volttrontesting/fixtures/docker_wrapper.py
@@ -63,14 +63,14 @@ if HAS_DOCKER:
 
         # wait for a certain amount of time to let container complete its build
         try:
-            if _not_valid_container(container, startup_time_seconds):
+            if _is_not_valid_container(container, startup_time_seconds):
                 yield None
             else:
                 yield container
         finally:
             container.kill()
 
-    def _not_valid_container(container, startup_time_seconds):
+    def _is_not_valid_container(container, startup_time_seconds):
         error_time = time.time() + startup_time_seconds
         invalid = False
 
@@ -80,10 +80,5 @@ if HAS_DOCKER:
                 break
             time.sleep(0.1)
             container.reload()
-        try:
-            if invalid:
-                yield None
-            else:
-                yield container
-        finally:
-            container.kill()
+
+        return invalid


### PR DESCRIPTION
# Description

Remove duplicate try/except block so that the wrapper works as expected. Currently, the wrapper tests return None instead of a container, leading to failing tests.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the current unit tests for the docker wrapper. See below:

```bash
$ pytest test_docker_wrapper.py

# output

test_docker_wrapper.py::test_docker_wrapper PASSED                                                                                                               [25%]
test_docker_wrapper.py::test_docker_run_crate_latest PASSED                                                                                                  [50%]
test_docker_wrapper.py::test_docker_wrapper_should_throw_runtime_error_on_false_image_when_pull PASSED                  [75%]                                            
test_docker_wrapper.py::test_docker_wrapper_should_throw_runtime_error_when_ports_clash PASSED                             [100%]                                                               

==== 4 passed in 12.53s =====

```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

