### PR TITLE
Modify rabbit_dependencies.sh so that tests will run in Travis CI

### DIFF
--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -73,10 +73,10 @@ function install_on_debian {
     ${prefix} apt-get install apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git
     ${prefix} apt-get purge -yf erlang*
     # Add the signing key
-    wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | sudo apt-key add -
+    wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
 
     if [[ ! -f "/etc/apt/sources.list.d/erlang.solutions.list" ]]; then
-        echo "deb https://packages.erlang-solutions.com/ubuntu $DIST contrib" | sudo tee /etc/apt/sources.list.d/erlang.solutions.list
+        echo "deb https://packages.erlang-solutions.com/ubuntu $DIST contrib" | tee /etc/apt/sources.list.d/erlang.solutions.list
     fi
 
     version=${erlang_package_version}

--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -73,10 +73,10 @@ function install_on_debian {
     ${prefix} apt-get install apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git
     ${prefix} apt-get purge -yf erlang*
     # Add the signing key
-    wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
+    wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | ${prefix} apt-key add -
 
     if [[ ! -f "/etc/apt/sources.list.d/erlang.solutions.list" ]]; then
-        echo "deb https://packages.erlang-solutions.com/ubuntu $DIST contrib" | tee /etc/apt/sources.list.d/erlang.solutions.list
+        echo "deb https://packages.erlang-solutions.com/ubuntu $DIST contrib" | ${prefix} tee /etc/apt/sources.list.d/erlang.solutions.list
     fi
 
     version=${erlang_package_version}


### PR DESCRIPTION
# Description

The latest commit for develop fails to build on Travis CI not because tests have failed but because one of the build scripts, `rabbit_dependencies.sh` fails to install rabbit dependencies, e.g. erlang, which is needed later in the build. One of the last lines in Travis logs shows that a rabbit dependency did fail to build (i.e. erlang):

```bash
/sbin/rabbitmq-plugins: 360: exec: erl: not found
```

Earlier in the Travis CI logs, it points to two lines in that script that are failing:
```bash
./scripts/rabbit_dependencies.sh: line 76: sudo: command not found

....
./scripts/rabbit_dependencies.sh: line 79: sudo: command not found
```

Because of this, rabbit dependencies such as erlang are not installed. Travis CI logs confirm this:
<details>
<summary> Click to see the logs</summary>

```bash
./scripts/rabbit_dependencies.sh: line 79: sudo: command not found
Get:1 http://deb.debian.org/debian buster InRelease [121 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 Packages [7905 kB]
Get:5 http://security.debian.org/debian-security buster/updates/main amd64 Packages [208 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [7868 B]
Fetched 8360 kB in 2s (4760 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
0 upgraded, 0 newly installed, 0 to remove and 104 not upgraded.
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '1:22.1.8.1-1' for 'erlang-asn1' was not found
E: Version '1:22.1.8.1-1' for 'erlang-base' was not found
E: Version '1:22.1.8.1-1' for 'erlang-crypto' was not found
E: Version '1:22.1.8.1-1' for 'erlang-diameter' was not found
E: Version '1:22.1.8.1-1' for 'erlang-edoc' was not found
E: Version '1:22.1.8.1-1' for 'erlang-eldap' was not found
E: Version '1:22.1.8.1-1' for 'erlang-erl-docgen' was not found
E: Version '1:22.1.8.1-1' for 'erlang-eunit' was not found
E: Unable to locate package erlang-ic
E: Version '1:22.1.8.1-1' for 'erlang-inets' was not found
E: Unable to locate package erlang-inviso
E: Version '1:22.1.8.1-1' for 'erlang-mnesia' was not found
E: Version '1:22.1.8.1-1' for 'erlang-odbc' was not found
E: Version '1:22.1.8.1-1' for 'erlang-os-mon' was not found
E: Version '1:22.1.8.1-1' for 'erlang-parsetools' was not found
E: Unable to locate package erlang-percept
E: Version '1:22.1.8.1-1' for 'erlang-public-key' was not found
E: Version '1:22.1.8.1-1' for 'erlang-runtime-tools' was not found
E: Version '1:22.1.8.1-1' for 'erlang-snmp' was not found
E: Version '1:22.1.8.1-1' for 'erlang-ssh' was not found
E: Version '1:22.1.8.1-1' for 'erlang-ssl' was not found
E: Version '1:22.1.8.1-1' for 'erlang-syntax-tools' was not found
E: Version '1:22.1.8.1-1' for 'erlang-tools' was not found
E: Version '1:22.1.8.1-1' for 'erlang-xmerl' was not found
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '1:22.1.8.1-1' for 'erlang-nox' was not found
Finished installing dependencies for rabbitmq
```
</details>

This PR removes `sudo` and replaces it with `${prefix}`, ensuring that the dependencies are built and that the build continues to tests and that it fails on Travis CI because the tests failed and not because a script failed. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this change on my own Travis CI account and checked that `rabbit_dependencies.sh` did complete and build the required dependencies and actually run a test. Note, those tests still failed but now the Travis CI build fails because the tests failed and *not* because the rabbit deps build script failed. The build on my Travis CI account can be viewed at https://travis-ci.org/github/bonicim/volttron/builds/707036312. 

For a snippet of the logs, see below:

<details>
<summary>Click to see logs confirming installation of rabbit dependencies</summary>

```bash
The following additional packages will be installed:
  libodbc1
Suggested packages:
  erlang erlang-manpages erlang-doc xsltproc fop erlang-ic-java libmyodbc
  odbc-postgresql tdsodbc unixodbc-bin
The following NEW packages will be installed:
  erlang-asn1 erlang-base erlang-crypto erlang-diameter erlang-edoc
  erlang-eldap erlang-erl-docgen erlang-eunit erlang-ic erlang-inets
  erlang-inviso erlang-mnesia erlang-odbc erlang-os-mon erlang-parsetools
  erlang-percept erlang-public-key erlang-runtime-tools erlang-snmp erlang-ssh
  erlang-ssl erlang-syntax-tools erlang-tools erlang-xmerl libodbc1
0 upgraded, 25 newly installed, 0 to remove and 104 not upgraded.
Need to get 18.5 MB of archives.
After this operation, 31.5 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main amd64 libodbc1 amd64 2.3.6-0.1 [223 kB]
Get:2 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-base amd64 1:22.1.8.1-1 [8075 kB]
Get:3 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-syntax-tools amd64 1:22.1.8.1-1 [375 kB]
Get:4 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-asn1 amd64 1:22.1.8.1-1 [743 kB]
Get:5 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-crypto amd64 1:22.1.8.1-1 [167 kB]
Get:6 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-mnesia amd64 1:22.1.8.1-1 [747 kB]
Get:7 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-runtime-tools amd64 1:22.1.8.1-1 [213 kB]
Get:8 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-public-key amd64 1:22.1.8.1-1 [598 kB]
Get:9 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-ssl amd64 1:22.1.8.1-1 [1098 kB]
Get:10 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-diameter amd64 1:22.1.8.1-1 [680 kB]
Get:11 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-inets amd64 1:22.1.8.1-1 [606 kB]
Get:12 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-xmerl amd64 1:22.1.8.1-1 [981 kB]
Get:13 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-edoc amd64 1:22.1.8.1-1 [312 kB]
Get:14 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-eldap amd64 1:22.1.8.1-1 [131 kB]
Get:15 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-erl-docgen amd64 1:22.1.8.1-1 [154 kB]
Get:16 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-eunit amd64 1:22.1.8.1-1 [165 kB]
Get:17 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-ic amd64 1:22.1.8.1-1 [37.1 kB]
Get:18 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-inviso amd64 1:22.1.8.1-1 [37.1 kB]
Get:19 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-odbc amd64 1:22.1.8.1-1 [79.7 kB]
Get:20 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-snmp amd64 1:22.1.8.1-1 [1561 kB]
Get:21 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-os-mon amd64 1:22.1.8.1-1 [112 kB]
Get:22 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-parsetools amd64 1:22.1.8.1-1 [182 kB]
Get:23 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-percept amd64 1:22.1.8.1-1 [37.2 kB]
Get:24 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-ssh amd64 1:22.1.8.1-1 [669 kB]
Get:25 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-tools amd64 1:22.1.8.1-1 [527 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 18.5 MB in 0s (41.2 MB/s)
Selecting previously unselected package erlang-base.
(Reading database ... 26788 files and directories currently installed.)
Preparing to unpack .../00-erlang-base_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-base (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-syntax-tools.
Preparing to unpack .../01-erlang-syntax-tools_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-syntax-tools (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-asn1.
Preparing to unpack .../02-erlang-asn1_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-asn1 (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-crypto.
Preparing to unpack .../03-erlang-crypto_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-crypto (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-mnesia.
Preparing to unpack .../04-erlang-mnesia_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-mnesia (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-runtime-tools.
Preparing to unpack .../05-erlang-runtime-tools_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-runtime-tools (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-public-key.
Preparing to unpack .../06-erlang-public-key_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-public-key (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-ssl.
Preparing to unpack .../07-erlang-ssl_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-ssl (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-diameter.
Preparing to unpack .../08-erlang-diameter_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-diameter (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-inets.
Preparing to unpack .../09-erlang-inets_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-inets (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-xmerl.
Preparing to unpack .../10-erlang-xmerl_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-xmerl (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-edoc.
Preparing to unpack .../11-erlang-edoc_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-edoc (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-eldap.
Preparing to unpack .../12-erlang-eldap_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-eldap (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-erl-docgen.
Preparing to unpack .../13-erlang-erl-docgen_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-erl-docgen (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-eunit.
Preparing to unpack .../14-erlang-eunit_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-eunit (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-ic.
Preparing to unpack .../15-erlang-ic_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-ic (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-inviso.
Preparing to unpack .../16-erlang-inviso_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-inviso (1:22.1.8.1-1) ...
Selecting previously unselected package libodbc1:amd64.
Preparing to unpack .../17-libodbc1_2.3.6-0.1_amd64.deb ...
Unpacking libodbc1:amd64 (2.3.6-0.1) ...
Selecting previously unselected package erlang-odbc.
Preparing to unpack .../18-erlang-odbc_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-odbc (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-snmp.
Preparing to unpack .../19-erlang-snmp_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-snmp (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-os-mon.
Preparing to unpack .../20-erlang-os-mon_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-os-mon (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-parsetools.
Preparing to unpack .../21-erlang-parsetools_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-parsetools (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-percept.
Preparing to unpack .../22-erlang-percept_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-percept (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-ssh.
Preparing to unpack .../23-erlang-ssh_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-ssh (1:22.1.8.1-1) ...
Selecting previously unselected package erlang-tools.
Preparing to unpack .../24-erlang-tools_1%3a22.1.8.1-1_amd64.deb ...
Unpacking erlang-tools (1:22.1.8.1-1) ...
Setting up erlang-base (1:22.1.8.1-1) ...
Searching for services which depend on erlang and should be started...none found.
Setting up erlang-xmerl (1:22.1.8.1-1) ...
Setting up erlang-syntax-tools (1:22.1.8.1-1) ...
Setting up erlang-eunit (1:22.1.8.1-1) ...
Setting up erlang-parsetools (1:22.1.8.1-1) ...
Setting up libodbc1:amd64 (2.3.6-0.1) ...
Setting up erlang-asn1 (1:22.1.8.1-1) ...
Setting up erlang-mnesia (1:22.1.8.1-1) ...
Setting up erlang-crypto (1:22.1.8.1-1) ...
Setting up erlang-ic (1:22.1.8.1-1) ...
Setting up erlang-runtime-tools (1:22.1.8.1-1) ...
Setting up erlang-odbc (1:22.1.8.1-1) ...
Setting up erlang-inviso (1:22.1.8.1-1) ...
Setting up erlang-snmp (1:22.1.8.1-1) ...
Setting up erlang-public-key (1:22.1.8.1-1) ...
Setting up erlang-ssh (1:22.1.8.1-1) ...
Setting up erlang-ssl (1:22.1.8.1-1) ...
Setting up erlang-diameter (1:22.1.8.1-1) ...
Setting up erlang-os-mon (1:22.1.8.1-1) ...
Setting up erlang-inets (1:22.1.8.1-1) ...
Setting up erlang-percept (1:22.1.8.1-1) ...
Setting up erlang-eldap (1:22.1.8.1-1) ...
Setting up erlang-edoc (1:22.1.8.1-1) ...
Setting up erlang-erl-docgen (1:22.1.8.1-1) ...
Setting up erlang-tools (1:22.1.8.1-1) ...
Processing triggers for libc-bin (2.28-10) ...
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  erlang erlang-manpages erlang-doc
The following NEW packages will be installed:
  erlang-nox
0 upgraded, 1 newly installed, 0 to remove and 128 not upgraded.
Need to get 37.1 kB of archives.
After this operation, 59.4 kB of additional disk space will be used.
Get:1 https://packages.erlang-solutions.com/ubuntu buster/contrib amd64 erlang-nox all 1:22.1.8.1-1 [37.1 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 37.1 kB in 0s (441 kB/s)
Selecting previously unselected package erlang-nox.
(Reading database ... 28136 files and directories currently installed.)
Preparing to unpack .../erlang-nox_1%3a22.1.8.1-1_all.deb ...
Unpacking erlang-nox (1:22.1.8.1-1) ...
Setting up erlang-nox (1:22.1.8.1-1) ...
Finished installing dependencies for rabbitmq
```
</details>

More importantly, we can now see that the build gets to run the tests:

<details>
<summary>Click below to see the logs confirming tests were run and did fail </summary>

```bash
There are 113 test modules to run
Running test module services/ops/AgentWatcher/tests/test_agent_watcher.py
Running test module services/ops/FailoverAgent/tests/test_simple_failover.py
Running test module services/ops/FailoverAgent/tests/test_failover.py
Running test module services/ops/ThresholdDetectionAgent/tests/test_threshold_agent.py
Running test module services/ops/ThresholdDetectionAgent/tests/test_threshold_detection.py
Running test module services/ops/MessageDebuggerAgent/tests/test_message_debugging.py
Running test module services/ops/SysMonAgent/tests/test_sysmonagent.py
Running test module services/ops/TopicWatcher/tests/test_remote_topic_watcher.py
Running test module services/ops/TopicWatcher/tests/test_topic_watcher.py
Running test module services/contrib/FactsServiceAgent/tests/test_agent.py
module test_agent_watcher.py FAILED
now Executing pytest services/ops/AgentWatcher/tests/test_agent_watcher.py
Traceback (most recent call last):
  File "/home/volttron/.local/lib/python3.7/site-packages/_pytest/config/__init__.py", line 372, in _getconftestmodules
    return self._path2confmods[path]
KeyError: local('/code/volttron/services/ops/AgentWatcher/tests/test_agent_watcher.py')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/volttron/.local/lib/python3.7/site-packages/_pytest/config/__init__.py", line 372, in _getconftestmodules
    return self._path2confmods[path]
KeyError: local('/code/volttron/services/ops/AgentWatcher/tests')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/volttron/.local/lib/python3.7/site-packages/_pytest/config/__init__.py", line 403, in _importconftest
    return self._conftestpath2mod[conftestpath]
KeyError: local('/code/volttron/services/ops/AgentWatcher/conftest.py')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/volttron/.local/lib/python3.7/site-packages/_pytest/config/__init__.py", line 409, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/volttron/.local/lib/python3.7/site-packages/py/_path/local.py", line 704, in pyimport
    __import__(modname)
  File "/home/volttron/.local/lib/python3.7/site-packages/_pytest/assertion/rewrite.py", line 226, in load_module
    py.builtin.exec_(co, mod.__dict__)
  File "/code/volttron/services/ops/AgentWatcher/conftest.py", line 3, in <module>
    from volttrontesting.fixtures.volttron_platform_fixtures import *
ModuleNotFoundError: No module named 'volttrontesting'
ERROR: could not load /code/volttron/services/ops/AgentWatcher/conftest.py
Exiting cleanly now!
Cleaning up test containers before exiting!
test_agent_watcher.py
test_agent_watcher.py
test_simple_failover.py
test_simple_failover.py
test_failover.py
test_failover.py
test_threshold_agent.py
test_threshold_agent.py
test_threshold_detection.py
test_threshold_detection.py
test_message_debugging.py
test_message_debugging.py
test_sysmonagent.py
test_sysmonagent.py
test_remote_topic_watcher.py
test_remote_topic_watcher.py
test_topic_watcher.py
test_topic_watcher.py
test_agent.py
test_agent.py
Total reclaimed space: 0B
The command "ci-integration/run-test-docker.sh" exited with 1.
```
</details>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code