### PR TITLE
Add mysql to requirements_test for testing in Docker

### DIFF
--- a/ci-integration/virtualization/requirements_test.txt
+++ b/ci-integration/virtualization/requirements_test.txt
@@ -5,3 +5,4 @@ mock
 websocket-client
 numpy>1.13<2
 pandas
+mysql-connector-python-rf


### PR DESCRIPTION
# Description

Add mysql to requirements_test.txt to run level one integ tests for Mysql as part of CI. This change will allow `run-test-docker.sh` to run the MySQL level one integration tests in Travis CI.


## Type of change

Please delete options that are not relevant.

- [x] Config change

# How Has This Been Tested?

I have ran `run-test-docker.sh` both locally and on Travis CI but the tests were not able to run due to a permissions error. I believe the issue lies in the container having root privileges to run docker commands within a container. However, that is an issue with running docker commands within a container that is not a root user, which is out of the scope of this PR. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

