### PR TITLE
Issue2447

### DIFF
--- a/volttron/platform/vip/agent/results.py
+++ b/volttron/platform/vip/agent/results.py
@@ -42,18 +42,20 @@ import random
 import weakref
 
 from gevent.event import AsyncResult
-
+import sys
+import time
+from datetime import datetime
 
 __all__ = ['counter', 'ResultsDictionary']
 
 
 def counter(start=None, minimum=0, maximum=2**64-1):
-    count = random.randint(minimum, maximum) if start is None else start
+    count = time.time() if start is None else start
     while True:
         yield count
         count += 1
         if count >= maximum:
-            count = minimum
+            count = time.time() #int(datetime.now().timestamp())
 
 
 class ResultsDictionary(weakref.WeakValueDictionary):

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -463,7 +463,7 @@ class PubSubService(object):
                 subscribers |= subscription
 
         if subscribers:
-            self._logger.debug("PUBSUBSERVICE: found subscribers: {}".format(subscribers))
+            #self._logger.debug("PUBSUBSERVICE: found subscribers: {}".format(subscribers))
             for subscriber in subscribers:
                 frames[0] = zmq.Frame(subscriber)
                 try:

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -449,21 +449,16 @@ class PubSubService(object):
             pass
 
         subs.update(subscriptions)
-        self._logger.debug("PUBSUBSERVICE: all_subscriptions: {}".format(all_subscriptions))
         subs.update(all_subscriptions)
-        self._logger.debug("PUBSUBSERVICE: subs1: {}".format(subs))
         for prefix, subscribers in all_subscriptions.items():
             if prefix in subs.keys():
                 subs[prefix] = subs[prefix]|subscribers
-                self._logger.debug("PUBSUBSERVICE: subs: {}".format(subs[prefix]))
             else:
                 subs[prefix] = subscribers
 
-        self._logger.debug("PUBSUBSERVICE: subs2: {}".format(subs))
         subscribers = set()
         # Check for local subscribers
         for prefix, subscription in subs.iteritems():
-            self._logger.debug("PUBSUBSERVICE: prefix: {}, subscription: {}".format(prefix, subscription))
             if subscription and topic.startswith(prefix):
                 subscribers |= subscription
 

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -193,7 +193,7 @@ class PubSubService(object):
         if len(frames) < 8:
             return False
         else:
-            # self._logger.debug("Subscribe before: {}".format(self._peer_subscriptions))
+            self._logger.debug("Subscribe before: {}".format(self._peer_subscriptions))
             if isinstance(frames[7], str):
                 data = bytes(frames[7])
             else:
@@ -228,7 +228,7 @@ class PubSubService(object):
             for prefix in prefix if isinstance(prefix, list) else [prefix]:
                 self._add_peer_subscription(peer, bus, prefix, platform)
 
-            # self._logger.debug("Subscribe after: {}".format(self._peer_subscriptions))
+            self._logger.debug("Subscribe after: {}".format(self._peer_subscriptions))
             if is_all and self._ext_router is not None:
                 # Send subscription message to all connected platforms
                 external_platforms = self._ext_router.get_connected_platforms()
@@ -448,16 +448,27 @@ class PubSubService(object):
         except KeyError:
             pass
 
-        subs.update(all_subscriptions)
         subs.update(subscriptions)
+        self._logger.debug("PUBSUBSERVICE: all_subscriptions: {}".format(all_subscriptions))
+        subs.update(all_subscriptions)
+        self._logger.debug("PUBSUBSERVICE: subs1: {}".format(subs))
+        for prefix, subscribers in all_subscriptions.items():
+            if prefix in subs.keys():
+                subs[prefix] = subs[prefix]|subscribers
+                self._logger.debug("PUBSUBSERVICE: subs: {}".format(subs[prefix]))
+            else:
+                subs[prefix] = subscribers
+
+        self._logger.debug("PUBSUBSERVICE: subs2: {}".format(subs))
         subscribers = set()
         # Check for local subscribers
         for prefix, subscription in subs.iteritems():
+            self._logger.debug("PUBSUBSERVICE: prefix: {}, subscription: {}".format(prefix, subscription))
             if subscription and topic.startswith(prefix):
                 subscribers |= subscription
 
         if subscribers:
-            # self._logger.debug("PUBSUBSERVICE: found subscribers: {}".format(subscribers))
+            self._logger.debug("PUBSUBSERVICE: found subscribers: {}".format(subscribers))
             for subscriber in subscribers:
                 frames[0] = zmq.Frame(subscriber)
                 try:

--- a/volttron/platform/vip/pubsubservice.py
+++ b/volttron/platform/vip/pubsubservice.py
@@ -193,7 +193,7 @@ class PubSubService(object):
         if len(frames) < 8:
             return False
         else:
-            self._logger.debug("Subscribe before: {}".format(self._peer_subscriptions))
+            #self._logger.debug("Subscribe before: {}".format(self._peer_subscriptions))
             if isinstance(frames[7], str):
                 data = bytes(frames[7])
             else:
@@ -228,7 +228,7 @@ class PubSubService(object):
             for prefix in prefix if isinstance(prefix, list) else [prefix]:
                 self._add_peer_subscription(peer, bus, prefix, platform)
 
-            self._logger.debug("Subscribe after: {}".format(self._peer_subscriptions))
+            #self._logger.debug("Subscribe after: {}".format(self._peer_subscriptions))
             if is_all and self._ext_router is not None:
                 # Send subscription message to all connected platforms
                 external_platforms = self._ext_router.get_connected_platforms()


### PR DESCRIPTION
# Description
The forwarder agent on VOLTTRON6 was shutting down due to gevent timeout when trying to publish data to VOLTTRON7. It was found that async result identity was not found. Modified the ResultDictionary counter maximum to a very high value. This seems to retain the async result object. Further, one combination of multiplatform publish (from V6 to V7) was failing when there was multiple subscriptions, handled that as well.

# Fixes #2447 

# How Has This Been Tested?
Tested following combinations:
Forwarder agent publishing data from V6 to V7 and from V7 to V6
Datapuller agent moving data from V6 to V7 and from V7 to V6
Multiplatform comination sending data from V6 to V7 and from V7 to v6
