### PR TITLE
Fix setup of default aggregate historian tables

### DIFF
--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -164,17 +164,17 @@ class PostgreSqlFuncts(DbDriver):
             SQL('SELECT table_id, table_name FROM {}').format(
                 Identifier(meta_table_name))))
         prefix = tables.pop('', '')
-        tables['agg_topics_table'] = 'aggregate_' + tables['topics_table']
-        tables['agg_meta_table'] = 'aggregate_' + tables['meta_table']
+        tables['agg_topics_table'] = 'aggregate_' + tables.get('topics_table', 'topics')
+        tables['agg_meta_table'] = 'aggregate_' + tables.get('meta_table', 'meta')
         if prefix:
             tables = {key: prefix + '_' + name for key, name in tables.items()}
         return tables
 
     def setup_aggregate_historian_tables(self, meta_table_name):
         table_names = self.read_tablenames_from_db(meta_table_name)
-        self.data_table = table_names['data_table']
-        self.topics_table = table_names['topics_table']
-        self.meta_table = table_names['meta_table']
+        self.data_table = table_names.get('data_table', 'data')
+        self.topics_table = table_names.get('topics_table', 'topics')
+        self.meta_table = table_names.get('meta_table', 'meta')
         self.agg_topics_table = table_names['agg_topics_table']
         self.agg_meta_table = table_names['agg_meta_table']
         self.execute_stmt(SQL(


### PR DESCRIPTION
# Description

Changes setup of aggregate historian tables so that all tables are properly set. Updates the associated tests. 

Detailed explanation below:

`setup_aggregate_aggregate_historian_tables` and `read_tablenames_from_db` both rely that the metadata table have the following values for the field 'table_name': data_table, topics_table, and meta_table. If those fields are not present or correctly spelled, then the aggregate tables will not be created and the table attributes of the `postgresfuncts` instance will be set to None instead of some name. In other words, `postgresfuncts` assumes that the metadata table exists and is properly initialized. In other words, this change ensures that some default value is given instead of None when a key is missing from a dictionary; see https://docs.python.org/3/library/stdtypes.html#dict.get

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have updated the current level one integration tests by adding two extra cases: 1) metadata table is empty 2) metadata table does not have the correct/expected values for the the table_name field.

I was able to successfully run the tests locally using Pytest command. All other existing, untouched tests also passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
