### PR TITLE
Update writing-tests docs

### DIFF
--- a/docs/source/devguides/agent_development/Testing-Agents.rst
+++ b/docs/source/devguides/agent_development/Testing-Agents.rst
@@ -1,35 +1,37 @@
 .. _Writing-Agent-Tests:
 
-*******************
+===================
 Writing Agent Tests
-*******************
+===================
 
-The VOLTTRON team strongly encourages developing agents with a set of unit and integration tests. Test-driven
+The VOLTTRON team strongly encourages developing agents with a set of unit and integration tests.  Test-driven
 development can save developers significant time and effort by clearly defining behavioral expectations for agent code.
-We recommend developing agent tests using Pytest. Agent code contributed to VOLTTRON is expected to include a set of
-tests using Pytest in the agent module directory. Following are instructions for setting up Pytest, structuring your
+We recommend developing agent tests using Pytest.  Agent code contributed to VOLTTRON is expected to include a set of
+tests using Pytest in the agent module directory.  Following are instructions for setting up Pytest, structuring your
 tests, how to write unit and integration tests (including some helpful tools using Pytest and Mock) and how to run your
 tests.
 
+
 Installation
-############
+============
 
 To get started with Pytest, install it in an activated environment:
 
-::
+.. code-block:: bash
 
     pip install pytest
 
-Or when running VOLTTRON's bootstrap process, specify the `--testing` optional argument.
+Or when running VOLTTRON's bootstrap process, specify the ``--testing`` optional argument.
 
-::
+.. code-block:: bash
 
     python bootstrap.py --testing
 
 `Pytest on PyPI <https://pypi.org/project/pytest/>`_
 
+
 Module Structure
-################
+================
 
 We suggest the following structure for your agent module:
 
@@ -50,12 +52,13 @@ We suggest the following structure for your agent module:
     │   └── setup.py
 
 The test suite should be in a `tests` directory in the root agent directory, and should contain one or more
-test code files (with the `test_<name of test>` convention). Conftest.py can be used to give all agent tests
-access to some portion of the VOLTTRON code -  in many cases agents use conftest to import VOLTTRON testing
+test code files (with the `test_<name of test>` convention). `conftest.py` can be used to give all agent tests
+access to some portion of the VOLTTRON code -  in many cases agents use `conftest.py` to import VOLTTRON testing
 fixtures for integration tests.
 
+
 Naming Conventions
-##################
+------------------
 
 Pytest tests are discovered and run using some conventions:
 
@@ -64,7 +67,7 @@ Pytest tests are discovered and run using some conventions:
     * Pytest will search in those directories for files called test_<name of test>.py or <name of test>_test.py
     * In those files, Pytest will test:
         * functions and methods prefixed by "test" outside of any class
-        * functions and methonds prefixed by "test" inside of any class prefixed by "test"
+        * functions and methods prefixed by "test" inside of any class prefixed by "test"
 
 ::
 
@@ -101,20 +104,31 @@ Pytest tests are discovered and run using some conventions:
         assert False
 
 In the above example, Pytest will run the tests `test_success` from the file test1.py and `test_success` and test_fail
-from test2.py. No tests will be run from file.txt, even though it contains test code, nor will it try to run
+from test2.py.  No tests will be run from file.txt, even though it contains test code, nor will it try to run
 `helper_method` from test1.py as a test.
 
+
 Writing Unit Tests
-##################
+==================
 
 These tests should test the various methods of the code base, checking for success and fail conditions. These tests
-should capture how the components of the system should function - tests should describe all the possible output
+should capture how the components of the system should function; and describe all the possible output
 conditions given the possible range of inputs including how they should fail if given improper input.
 
 `Pytest guide to Unit Testing <https://docs.python-guide.org/writing/tests/#unittest>`_
 
-VOLTTRON agents include code for many platform features, these features can be mocked to allow unit tests to test only
-the features of the agent, without having to account for the behaviors of the core platform:
+Mocking Dependencies
+--------------------
+
+VOLTTRON agents include code for many platform features; these features can be mocked to allow unit tests to test only
+the features of the agent without having to account for the behaviors of the core platform. While there are many tools
+that can mock dependencies of an agent, we recommend Volttron's AgentMock or Python's Mock testing library.
+
+AgentMock
+^^^^^^^^^
+`AgentMock <https://github.com/VOLTTRON/volttron/blob/master/volttrontesting/utils/utils.py#L182>`_  was specifically created to unit-test agents. AgentMock takes an Agent class and mocks the
+the attributes and methods of that Agent's dependencies. AgentMock also allows you to customize the behavior of
+dependencies within each individual test. Below is an example.
 
 .. code-block:: python
 
@@ -138,24 +152,75 @@ the features of the agent, without having to account for the behaviors of the co
         assert isinstance(result.get("test2"), str)
         # ...
 
+    def test_success_case_custom_mocks():
+        agent.some_dependency.some_method.return_value = "foobar"
+        agent.some_attribute = "custom, dummy value"
+        result = agent.do_function_that_relies_on_custom_mocks("valid input")
+        # ...
+
     def test_failure_case()
         # pytests.raises can be useful for testing exceptions, more information about usage below
         with pytest.raises(ValueError, match=r'Invalid input string for do_function')
             result = agent.do_function("invalid input")
 
+Mock
+^^^^
+
+Simliar to AgentMock, Python's Mock testing library allows a user to replace the behavior of dependencies with a user specified behavior.  This is useful for replacing
+VOLTTRON platform behavior, remote API behavior, modules, etc. where using them in unit or integration tests is
+impractical or impossible. Below is an example that uses the patch decorator to mock an Agent's web request.
+
+`Mock documentation <https://docs.python.org/3/library/unittest.mock.html#quick-guide>`_
+
+.. code-block:: python
+
+    class UserAgent()
+
+        def __init__():
+            # Code here
+
+        def get_remote_data()
+            response = self._get_data_from_remote()
+            return "Remote response: {}".format(response)
+
+        # it can be useful to create private functions for use with mock for things like making web requests
+        def _get_data_from_remote():
+            url = "test.com/test1"
+            headers = {}
+            return requests.get(url, headers)
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    import pytest
+    import mock
+
+    def get_mock_response():
+        return "test response"
+
+    # here we're mocking the UserAgent's _get_data_from_remote method and replacing it with our get_mock_response method
+    # to feed our test some fake remote data
+    @mock.patch.object(UserAgent, '_get_data_from_remote', get_mock_response)
+    def test_get_remote_data():
+           assert UserAgent.get_remote_Data() == "Remote response: test response"
+
+
+
+
+
 Pytest Tools
-************
+------------
 
 Pytest includes many helpful tools for developing your tests, here we'll highlight a few that have been useful for
-VOLTTRON core tests, but checkout `the Pytest documentation <https://docs.pytest.org/>`_ for additional information on each tool as well as
-tools not covered in this guide.
+VOLTTRON core tests, but checkout `the Pytest documentation <https://docs.pytest.org/>`_ for additional information on
+each tool as well as tools not covered in this guide.
+
 
 Pytest Fixtures
----------------
+^^^^^^^^^^^^^^^
 
 Pytest fixtures can be used to create reusable code for tests that can be accessed by every test in a module based on
-scope. There are several kinds of scopes, but commonly used are "module" (the fixture is run once per module for all
-the tests of that module) or "function" (the fixture is run once per test). For fixtures to be used by tests, they
+scope.  There are several kinds of scopes, but commonly used are "module" (the fixture is run once per module for all
+the tests of that module) or "function" (the fixture is run once per test).  For fixtures to be used by tests, they
 should be passed as parameters.
 
 `Pytest Fixture documentation <https://docs.pytest.org/en/latest/fixture.html>`_
@@ -192,21 +257,21 @@ Here is an example of a fixture, along with using it in a test:
         assert count == 1
 
 
-
 Pytest.mark
------------
+^^^^^^^^^^^
 
 Pytest marks are used to set metadata for test functions. Defining your own custom marks can allow you to run
-subsections of your tests. Parametrize can be used to pass a series of parameters to a test, so that it can be run
-many times to cover the space of potential inputs. Marks also exist to specify expected behavior for tests.
+subsections of your tests.  Parametrize can be used to pass a series of parameters to a test, so that it can be run
+many times to cover the space of potential inputs.  Marks also exist to specify expected behavior for tests.
 
 `Mark documentation <https://docs.pytest.org/en/latest/mark.html>`_
 
+
 Custom Marks
-~~~~~~~~~~~~
+""""""""""""
 
 To add a custom mark, add the name of the mark followed by a colon then a description string to the 'markers' section
-of Pytest.ini (an example of this exists in the core VOLTTRON repository). Then add the appropriate decorator:
+of Pytest.ini (an example of this exists in the core VOLTTRON repository).  Then add the appropriate decorator:
 
 .. code-block:: python
 
@@ -225,10 +290,11 @@ The VOLTTRON team also has a `dev` mark for running individual (or a few) one-of
         # TODO unit test here
         pass
 
-Parametrize
-~~~~~~~~~~~
 
-Parametrize will allow tests to be run with a variety of parameters. Add the parametrize decorator, and for parameters
+Parametrize
+"""""""""""
+
+Parametrize will allow tests to be run with a variety of parameters.  Add the parametrize decorator, and for parameters
 include a list of parameter names matching the test parameter names as a comma-delimited string followed by a list of
 tuples containing parameters for each test.
 
@@ -241,10 +307,11 @@ tuples containing parameters for each test.
         # TODO unit test here
         pass
 
-Skip, skipif, and xfail
-~~~~~~~~~~~~~~~~~~~~~~~
 
-The skip mark can be used to skip a test for any reason every time the test suite is run:
+Skip, skipif, and xfail
+"""""""""""""""""""""""
+
+The `skip` mark can be used to skip a test for any reason every time the test suite is run:
 
 .. code-block:: python
 
@@ -254,7 +321,7 @@ The skip mark can be used to skip a test for any reason every time the test suit
         # TODO unit test here
         pass
 
-The skipif mark can be used to skip a test based on some condition:
+The `skipif` mark can be used to skip a test based on some condition:
 
 .. code-block:: python
 
@@ -264,7 +331,7 @@ The skipif mark can be used to skip a test based on some condition:
         # TODO unit test here
         pass
 
-The xfail mark can be used to run a test, but to show that the test is currently expected to fail
+The `xfail` mark can be used to run a test, but to show that the test is currently expected to fail
 
 .. code-block:: python
 
@@ -276,58 +343,22 @@ The xfail mark can be used to run a test, but to show that the test is currently
 
 `Skip, skipif, and xfail docs <https://docs.pytest.org/en/documentation-restructure/how-to/skipping.html>`_
 
-Mock
-****
-
-Mock allows a user to replace the behavior of dependencies with a user specified behavior. This is useful for replacing
-VOLTTRON platform behavior, remote API behavior, modules, etc. where using them in unit or integration tests is
-impractical or impossible.
-
-`Mock documentation <https://docs.pytest.org/en/latest/monkeypatch.html>`_
-
-.. code-block:: python
-
-    class UserAgent()
-
-        def __init__():
-            # Code here
-
-        def get_remote_data()
-            response = self._get_data_from_remote()
-            return "Remote response: {}".format(response)
-
-        # it can be useful to create private functions for use with mock for things like making web requests
-        def _get_data_from_remote():
-            url = "test.com/test1"
-            headers = {}
-            return requests.get(url, headers)
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    import pytest
-    import mock
-
-    def get_mock_response():
-        return "test response"
-
-    # here we're mocking the UserAgent's _get_data_from_remote method and replacing it with our get_mock_response method
-    # to feed our test some fake remote data
-    @mock.patch.object(UserAgent, '_get_data_from_remote', get_mock_response)
-    def test_get_remote_data():
-           assert UserAgent.get_remote_Data() == "Remote response: test response"
 
 Writing Integration Tests
-#########################
+=========================
 
-Integration tests are useful for testing the faults that occur between integrated units. In the context of VOLTTRON
+Integration tests are useful for testing the faults that occur between integrated units.  In the context of VOLTTRON
 agents, integration tests should test the interactions between the agent, the platform, and other agents installed on
-the platform that would interface with the agent. It is typical for integration tests to test configuration, behavior
+the platform that would interface with the agent.  It is typical for integration tests to test configuration, behavior
 and content of RPC calls and agent Pub/Sub, the agent subsystems, etc.
 
 `Pytest best practices for Integration Testing <https://docs.pytest.org/en/latest/goodpractices.html>`_
 
-The Volttrontesting directory includes several helpful fixtures for your tests. Including the following line at the top
-of your tests, or in conftest.py, will allow you to utilize the platform wrapper fixtures, and more.
+Volttrontesting Directory
+-------------------------
+
+The `Volttrontesting` directory includes several helpful fixtures for your tests. Including the following line at the
+top of your tests, or in `conftest.py`, will allow you to utilize the platform wrapper fixtures, and more.
 
 .. code-block:: python
 
@@ -391,22 +422,45 @@ Here is an example success case integration test:
 For more integration test examples, it is recommended to take a look at some of the VOLTTRON core agents, such as
 historian agents and weather service agents.
 
+Using Docker for Limited-Integration Testing
+--------------------------------------------
+
+If you want to run limited-integration tests which do not require the setup of a volttron system, you can use Docker
+containers to mimic dependencies of an agent. The `volttrontesting/fixtures/docker_wrapper.py` module provides a
+convenient function to create docker containers for use in limited-integration tests. For example, suppose that you
+had an agent with a dependency on a MySQL database. If you want to test the connection between the Agent and the MySQL
+dependency, you can create a Docker container to act as a real MySQL database. Below is an example:
+
+.. code-block:: python
+
+    from volttrontesting.fixtures.docker_wrapper import create_container
+    from UserAgent import UserAgentClass
+
+    def test_docker_wrapper_example():
+        ports_config = {'3306/tcp': 3306}
+        with create_container("mysql:5.7", ports=ports_config) as container:
+            init_database(container)
+            agent = UserAgent(ports_config)
+
+            results = agent.some_method_that_talks_to_container()
+
+
 Running your Tests and Debugging
-################################
+================================
 
 Pytest can be run from the command line to run a test module.
 
-::
+.. code-block:: bash
 
     pytest <path to module to be tested>
 
-If using marks, you can add "-m <mark>" to specify your testing subset, and -s can be used to surpress standard output.
-For more information about optional arguments you can type `pytest --help` into your command line interface to see the
-full list of options.
+If using marks, you can add ``-m <mark>`` to specify your testing subset, and -s can be used to suppress standard
+output.  For more information about optional arguments you can type `pytest --help` into your command line interface to
+see the full list of options.
 
 Testing output should look something like this:
 
-::
+.. code-block:: console
 
     (volttron) <user>@<host>:~/volttron$ pytest services/core/SQLHistorian/
     ======================================================== test session starts =========================================================
@@ -453,12 +507,12 @@ Testing output should look something like this:
 
 
 Running Tests Via PyCharm
-*************************
+-------------------------
 
-To run our Pytests using PyCharm, we'll need to create a run configuration. To do so, select "edit configurations" from
+To run our Pytests using PyCharm, we'll need to create a run configuration.  To do so, select "edit configurations" from
 the "Run" menu (or if using the toolbar UI element you can click on the run configurations dropdown to select "edit
-configurations"). Use the plus symbol at the top right of the pop-up menu, scroll to "Python Tests" and expand this
-menu and select "pytest". This will create a run configuration, which will then need to be filled out. We recommend the
+configurations").  Use the plus symbol at the top right of the pop-up menu, scroll to "Python Tests" and expand this
+menu and select "pytest".  This will create a run configuration, which will then need to be filled out. We recommend the
 following in general:
 
     * Set the "Script Path" radio and fill the form with the path to your module. Pytest will run any tests in that


### PR DESCRIPTION
# Description

I've updated the Writing Tests documentation to highlight the use of AgentMock and the DockerWrapper container for limited-integration testing.

Note: the rst file is based off of the docs in @jklarson's PR #2446 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

I've generated the docs using Sphinx and viewed the output on my browser. Some screenshots attached. Commands below on how to render and navigate the docs on your own machine:

```bash
# must be in the docs directory
pip install -r requirements.txt
mkdir build
sphinx-build -b html source build
open -a "Google Chrome" build/index.html
```
<details>
<summary> Screenshots of updated docs </summary>
<img src=https://user-images.githubusercontent.com/6901848/91621959-00e3c400-e94a-11ea-86ea-a34f0d7834cb.png /img>

<img src=https://user-images.githubusercontent.com/6901848/91621964-02ad8780-e94a-11ea-93cd-c3657df3d92c.png /img>

</details>