### PR TITLE
Update writing agent tests; add other reqs for documentation requirem…

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -85,7 +85,11 @@ extras_require = {
         'pymongo',
         'Sphinx',
         'recommonmark',
-        'sphinx-rtd-theme'
+        'sphinx-rtd-theme',
+        'werkzeug'
+        'pint',
+        'jwt',
+        'passlib'
     ],
     'drivers': [
         'pymodbus',


### PR DESCRIPTION
# Description

I've updated the Writing Tests documentation to highlight the use of AgentMock and the DockerWrapper container for limited-integration testing. Made some grammatical and stylistic changes. Also, I've added some requirements to the 'documentation' option when running `python bootstrap.py --documentation`, resolving some warnings when running 'make html'.


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

I've generated the docs using Sphinx and viewed the output on my browser. Some screenshots attached. To build the docs on your local machine, run the following:

```bash
# at root directory
$ python bootstrap.py --documentation

# navigate to docs: ~/volttron/docs
$ make html

# open in docs in Chrome
$ open -a "Google Chrome" build/html/index.html
```
<details>
<summary> Screenshots of updated docs </summary>
<img src=https://user-images.githubusercontent.com/6901848/91759837-2c9fbd80-eb87-11ea-8cdc-9799e6088545.png /img>
<img src=https://user-images.githubusercontent.com/6901848/91759844-30cbdb00-eb87-11ea-9f94-765dfa883ee1.png /img>
</details>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code