### PR TITLE
Make RTD headings more concise and less redundant

### DIFF
--- a/docs/source/agent-framework/agents-overview.rst
+++ b/docs/source/agent-framework/agents-overview.rst
@@ -1,8 +1,8 @@
 .. _Agent-Framework:
 
-===============
-Agent Framework
-===============
+========================
+Agent Framework Overview
+========================
 
 Agents in VOLTTRON can be loosely defined as software modules communicating on the platform which perform some function
 on behalf of the user.  Agents may perform a huge variety of tasks, but common use cases involve data collection,

--- a/docs/source/agent-framework/core-service-agents/openadr-ven/ven-agent.rst
+++ b/docs/source/agent-framework/core-service-agents/openadr-ven/ven-agent.rst
@@ -1,8 +1,8 @@
 .. _OpenADR-VEN-Agent:
 
-===============================================
-VEN Agent: OpenADR 2.0b Interface Specification
-===============================================
+======================
+OpenADR 2.0b VEN Agent
+======================
 
 OpenADR (Automated Demand Response) is a standard for alerting and responding to the need to adjust electric power
 consumption in response to fluctuations in grid demand.

--- a/docs/source/agent-framework/example-agents/index.rst
+++ b/docs/source/agent-framework/example-agents/index.rst
@@ -1,8 +1,8 @@
 .. _Example-Agents:
 
-=======================
-Example Agents Overview
-=======================
+==============
+Example Agents
+==============
 
 Some example agents are included with the platform to help explore its features.  These agents represent concrete
 implementations of important agent sub-types such as Historians or Weather Agents, or demonstrate a development pattern

--- a/docs/source/agent-framework/historian-agents/historian-framework.rst
+++ b/docs/source/agent-framework/historian-agents/historian-framework.rst
@@ -1,8 +1,8 @@
 .. _Historian-Framework:
 
-============================
-VOLTTRON Historian Framework
-============================
+===================
+Historian Framework
+===================
 
 Historian Agents are the way by which `device`, `actuator`, `datalogger`, and `analysis` topics are automatically
 captured and stored in some sort of data store.  Historians exist for the following storage options:

--- a/docs/source/agent-framework/web-framework.rst
+++ b/docs/source/agent-framework/web-framework.rst
@@ -1,14 +1,15 @@
 .. _Web-Framework:
 
-VOLTTRON Web Framework
-======================
+=============
+Web Framework
+=============
 
 This document describes the interaction between web enabled agents and the Master Web Service agent.
 
 The web framework enables agent developers to expose JSON, static, and websocket endpoints.
 
 Web SubSystem
-+++++++++++++
+=============
 
 Enabling
 --------
@@ -78,5 +79,3 @@ Websocket endpoints allow bi-directional communication between the client and th
     @Core.receiver('onstart')
     def onstart(self, sender, **kwargs):
         self.vip.web.register_websocket(r'/vc/ws', self.open_authenticate_ws_endpoint, self._ws_closed, self._ws_received)
-
-

--- a/docs/source/deploying-volttron/platform-hardening.rst
+++ b/docs/source/deploying-volttron/platform-hardening.rst
@@ -1,6 +1,6 @@
 .. _Platform-Hardening:
 
-==================sssss
+==================
 Platform Hardening
 ==================
 

--- a/docs/source/deploying-volttron/platform-hardening.rst
+++ b/docs/source/deploying-volttron/platform-hardening.rst
@@ -1,7 +1,8 @@
 .. _Platform-Hardening:
 
-Platform Hardening for VOLTTRON
-===============================
+==================sssss
+Platform Hardening
+==================
 
 Rev. 0 \| 1/29/2015 \| Initial Document Development
 

--- a/docs/source/driver-framework/bacnet/bacnet-auto-configuration.rst
+++ b/docs/source/driver-framework/bacnet/bacnet-auto-configuration.rst
@@ -1,8 +1,8 @@
 .. _BACnet-Auto-Configuration:
 
-===================================================
-Automatically Generating BACnet Configuration Files
-===================================================
+=========================
+BACnet Auto-Configuration
+=========================
 
 Included with the platform are two scripts for finding and configuring BACnet devices.  These scripts are located in
 `scripts/bacnet`.  `bacnet_scan.py` will scan the network for devices.  `grab_bacnet_config.py` creates a CSV file

--- a/docs/source/driver-framework/drivers-overview.rst
+++ b/docs/source/driver-framework/drivers-overview.rst
@@ -1,7 +1,7 @@
 .. _Driver-Framework:
 
 =========================
-VOLTTRON Driver Framework
+Driver Framework Overview
 =========================
 
 VOLTTRON drivers act as an interface between agents on the platform and a device.  While running on the platform,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,7 +115,6 @@ at our bi-weekly office-hours and on Slack. To be invited to office-hours or sla
    platform-features/control/index
    platform-features/config-store/configuration-store
    platform-features/security/volttron-security
-   platform-features/web-framework/web-framework-overview
 
 
 .. toctree::

--- a/docs/source/platform-features/config-store/commandline-interface.rst
+++ b/docs/source/platform-features/config-store/commandline-interface.rst
@@ -1,8 +1,8 @@
 .. _Commandline-Interface:
 
-======================================
-Configuration Store Command Line Tools
-======================================
+===============================
+Config Store Command Line Tools
+===============================
 
 Command line management of the Configuration Store is done with the `vctl config` sub-commands.
 

--- a/docs/source/platform-features/config-store/configuration-store.rst
+++ b/docs/source/platform-features/config-store/configuration-store.rst
@@ -1,8 +1,8 @@
 .. _Configuration-Store:
 
-============================
-VOLTTRON Configuration Store
-============================
+===================
+Configuration Store
+===================
 
 The Platform Configuration Store is a mechanism provided by the platform to facilitate the dynamic configuration
 of agents.  The Platform Configuration Store works by informing agents of changes to their configuration store and

--- a/docs/source/platform-features/control/authentication-commands.rst
+++ b/docs/source/platform-features/control/authentication-commands.rst
@@ -70,7 +70,6 @@ For more details on how to create authentication record, please see section
 
 .. _Agent-Authentication:
 
-==================================================================
 How to authenticate an agent to communicate with VOLTTRON platform
 ==================================================================
 

--- a/docs/source/platform-features/message-bus/index.rst
+++ b/docs/source/platform-features/message-bus/index.rst
@@ -1,8 +1,8 @@
 .. _Message-Bus:
 
-====================
-VOLTTRON Message Bus
-====================
+===========
+Message Bus
+===========
 
 The VOLTTRON message bus is the mechanism responsible for enabling communication between agents, drivers, and platform
 instances.  The message bus supports communication using the :ref:`Publish/Subscribe Paradigm <VIP-Overview>` and

--- a/docs/source/platform-features/message-bus/vip/vip-overview.rst
+++ b/docs/source/platform-features/message-bus/vip/vip-overview.rst
@@ -1,8 +1,8 @@
 .. _VIP-Overview:
 
-=====================================
-VIP - VOLTTRON™ Interconnect Protocol
-=====================================
+===============================
+VOLTTRON™ Interconnect Protocol
+===============================
 
 This document specifies VIP, the VOLTTRON™ Interconnect Protocol. The use case for VIP is to provide communications
 between *agents*, *controllers*, *services*, and the supervisory *platform* in an abstract fashion so that additional

--- a/docs/source/platform-features/security/volttron-security.rst
+++ b/docs/source/platform-features/security/volttron-security.rst
@@ -1,7 +1,7 @@
 .. _VOLTTRON-Security:
 
 =================
-VOLTTRON Security
+Platform Security
 =================
 
 There are various security-related topics throughout VOLTTRON's documentation.  This is a quick roadmap for finding

--- a/docs/source/platform-features/web-framework/web-framework-overview.rst
+++ b/docs/source/platform-features/web-framework/web-framework-overview.rst
@@ -1,7 +1,0 @@
-.. _Web-Framework-Overview:
-
-=============
-Web Framework
-=============
-
-Documentation Coming Soon!


### PR DESCRIPTION
# Description

Updates the title of some Readthedocs articles to be more concise for the topic, less redundant, and remove excessive references to VOLTTRON.  

# How Has This Been Tested?

Tested with Sphinx build in docs dir.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings