### PR TITLE
Update output messages and web interface address in VCentral Demo docs

### DIFF
--- a/docs/source/deploying-volttron/volttron-central.rst
+++ b/docs/source/deploying-volttron/volttron-central.rst
@@ -91,6 +91,7 @@ and localhost is volttron-pc.
         Installing volttron central.
         Should the agent autostart? [N]: y
         VC admin and password are set up using the admin web interface.
+        After starting VOLTTRON, please go to https://volttron-pc:8443/admin/login.html to complete the setup.
         Will this instance be controlled by volttron central? [Y]: y
         Configuring /home/user/volttron/services/core/VolttronCentralPlatform.
         What is the name of this instance? [volttron1]: 

--- a/docs/source/deploying-volttron/volttron-central.rst
+++ b/docs/source/deploying-volttron/volttron-central.rst
@@ -88,11 +88,9 @@ and localhost is volttron-pc.
         Creating new web server certificate.
         Is this an instance of volttron central? [N]: y
         Configuring /home/user/volttron/services/core/VolttronCentral.
-        Enter volttron central admin user name: <your volttron central admin username here>
-        Enter volttron central admin password: <your volttron central admin password here>
-        Retype password: <retype your volttron central admin password here>
         Installing volttron central.
         Should the agent autostart? [N]: y
+        VC admin and password are set up using the admin web interface.
         Will this instance be controlled by volttron central? [Y]: y
         Configuring /home/user/volttron/services/core/VolttronCentralPlatform.
         What is the name of this instance? [volttron1]: 
@@ -156,11 +154,10 @@ different.
          What type of message bus (rmq/zmq)? [zmq]: 
          What is the vip address? [tcp://127.0.0.1]: tcp://127.0.0.2
          What is the port for the vip address? [22916]: 
-         Is this instance web enabled? [N]: 
-         Is this an instance of volttron central? [N]: 
-         Will this instance be controlled by volttron central? [Y]: y
+         Is this instance web enabled? [N]:
+         Will this instance be controlled by volttron central? [Y]:
          Configuring /home/user/volttron/services/core/VolttronCentralPlatform.
-         What is the name of this instance? [volttron1]: 
+         What is the name of this instance? [volttron1]:
          What is the hostname for volttron central? [https://volttron-pc]: 
          What is the port for volttron central? [8443]: 
          Should the agent autostart? [N]: y
@@ -182,9 +179,17 @@ different.
 Starting the Demo
 -----------------
 
-Start each Volttron instance after configuration. The "-l" option in the
-following command tells volttron to log to a file. The file name
-should be different for each instance.
+Start each Volttron instance after configuration. You have two options.
+
+Option 1: The following command starts the volttron process in the background. The "-l" option tells volttron to log
+to a file. The file name should be different for each instance.
+
+.. code-block:: console
+
+    $ volttron -vv -l volttron.log&
+
+Option 2: Use the utility script start-volttron.
+
 
 .. code-block:: console
 
@@ -218,14 +223,17 @@ or
         In each of the above examples one could use * suffix to match more 
         than one agent.
 
-Open your browser to `localhost:8443/vc/index.hmtl` and and log in with the
-credentials you provided. The platform agents should be automatically register
-with VOLTTRON central.
+Open your browser to the web address that you specified for the VOLTTRON Central agent that you configured for the
+first instance. The web address is the admin web interface to Volttron; it is defined in the configuration of the
+first instance. In the above examples, the configuration file would be located at `~/.volttron1/config` and the
+admin web interface would be defined in the "volttron-central-address" field. The address takes the pattern:
+`https://<localhost>:8443/index.html`, where localhost is the local host of your machine.
+In the above examples, our localhost is `volttron-pc`; thus our admin web interface would be `https://volttron-pc:8443/index.html`.
 
-.. note::
-
-        localhost is the local host of your machine. In the above examples,
-        this was volttron-pc.
+When you open the page for the first time, Volttron will prompt you to create a new user and password. Recall when you
+ran `vcfg` in the first shell to configure the VOLTTRON Central agent, the script displayed
+the message "VC admin and password are set up using the admin web interface." This is where you setup you admin name
+and password.
 
 
 Stopping the Demo
@@ -247,7 +255,10 @@ details on how to configure the agent for your specific use case.
 Log In
 ------
 
-To log in to VOLTTRON Central, navigate in a browser to localhost:8443/vc/index.html, and enter the user name and password on the login screen.
+To log in to VOLTTRON Central, open a browser and login to the Volttron web interface, which takes the form
+`https://localhost:8443/vc/index.html` where localhost is the local host of your machine. In the above example, we open the
+following URL in which our localhost is "volttron-pc": https://volttron-pc:8443/vc/index.html and enter the user name
+and password on the login screen.
 
 |Login Screen|
 

--- a/docs/source/deploying-volttron/volttron-central.rst
+++ b/docs/source/deploying-volttron/volttron-central.rst
@@ -136,12 +136,12 @@ Remote Platform Configuration
 
 The next step is to configure the instances that will connect to VOLTTRON
 Central. In the second and third terminal windows run `vcfg`. Like
-the VOLTTRON\_HOME variable, these instances need to have unique vip addresses and unique instance names.
+the VOLTTRON\_HOME variable, these instances need to have unique VIP addresses and unique instance names.
 
 Install a platform agent and a historian as before. Since we used the default
 options when configuring VOLTTRON Central, we can use the default options when
 configuring these platform agents as well. The configuration will be a little
-different. The example below is for the second volttron instance. Note the unique vip address and instance name.
+different. The example below is for the second volttron instance. Note the unique VIP address and instance name.
 
 
  .. code-block:: console

--- a/docs/source/deploying-volttron/volttron-central.rst
+++ b/docs/source/deploying-volttron/volttron-central.rst
@@ -136,12 +136,12 @@ Remote Platform Configuration
 
 The next step is to configure the instances that will connect to VOLTTRON
 Central. In the second and third terminal windows run `vcfg`. Like
-the VOLTTRON\_HOME variable, these instances need to have unique addresses.
+the VOLTTRON\_HOME variable, these instances need to have unique vip addresses and unique instance names.
 
 Install a platform agent and a historian as before. Since we used the default
 options when configuring VOLTTRON Central, we can use the default options when
 configuring these platform agents as well. The configuration will be a little
-different.
+different. The example below is for the second volttron instance. Note the unique vip address and instance name.
 
 
  .. code-block:: console
@@ -157,7 +157,7 @@ different.
          Is this instance web enabled? [N]:
          Will this instance be controlled by volttron central? [Y]:
          Configuring /home/user/volttron/services/core/VolttronCentralPlatform.
-         What is the name of this instance? [volttron1]:
+         What is the name of this instance? [volttron1]: volttron2
          What is the hostname for volttron central? [https://volttron-pc]: 
          What is the port for volttron central? [8443]: 
          Should the agent autostart? [N]: y

--- a/docs/source/introduction/how-does-it-work.rst
+++ b/docs/source/introduction/how-does-it-work.rst
@@ -19,7 +19,7 @@ The platform comprises several components that allow agents to operate and conne
   variety of topics or directed communication using :ref:`Remote Procedure Calls <Remote-Procedure-Calls>`.
 
 * :ref:`Agents <Agent-Framework>` on the platform extend the base agent which provides a VIP connection to the message
-  bus as well as an agent lifecycle. Agents subscribe to topics which allow it to read The agent lifecycle is controlled
+  bus and an agent lifecycle. Agents subscribe to topics which allow it to read. The agent lifecycle is controlled
   by the :ref:`Agent Instantiation and Packaging <Agent-Instantiation-and-Packaging>` (AIP) component which launches
   agents in an agent execution environment.
 

--- a/docs/source/platform-features/security/running-agent-as-user.rst
+++ b/docs/source/platform-features/security/running-agent-as-user.rst
@@ -12,9 +12,9 @@ to run the agent process.
 
     The Unix user starting the VOLTTRON platform will be given limited sudo access to create and delete agent users.
 
-Since this feature require system level changes (sudo access, user creation, file permission changes) the initial step
-needs to be run as root or user with `sudo` access.  This can be a user other than Unix user used to run the VOLTTRON
-platform.
+Since this feature requires system level changes (e.g. sudo access, user creation, file permission changes), the initial
+step needs to be run as root or user with `sudo` access.  This can be a user other than Unix user used to run the
+VOLTTRON platform.
 
 All files and folder created by the VOLTTRON process in this mode would not have any access to others by default.
 Permission for Unix group others would be provided to specific files and folder based on VOLTTRON process requirement.


### PR DESCRIPTION
# Description

After following the Volttron Central Demo on the docs, I noticed some inconsistencies on what was on the docs and what I actually saw when I went through the Central Demo docs. I also added some clarity on the web interface address to give users more idea of what it is and also to match the experience I had when first opening the web interface.

Note: I used Ubuntu 20.04 to run the Volttron Central Demo instructions.

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

# How Has This Been Tested?

I built the docs using the following commands and opened the docs on my local machine. Screenshots attached of the updated areas. Click the dropdown button below. 
<details>
<summary>Screenshots click here </summary>
<img src=https://user-images.githubusercontent.com/6901848/92023218-51c03780-ed11-11ea-9465-4b7c67b83973.png /img>
<img src=https://user-images.githubusercontent.com/6901848/92023227-54bb2800-ed11-11ea-918b-e644f1193aec.png /img>
<img src=https://user-images.githubusercontent.com/6901848/92023235-571d8200-ed11-11ea-903b-6b31015e10ba.png /img>
</details>

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
