### PR TITLE
Add unit marker to pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -56,3 +56,4 @@ markers =
         mysqlfuncts: level one integration tests for mysqlfuncts
         postgresqlfuncts: level one integration tests for postgresqlfuncts
         dbutils: test all the level one integrations tests for dbfuncts classes
+        unit: Run all unit/level one integration tests

--- a/services/core/ActuatorAgent/tests/test_actuator_pubsub_unit.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_pubsub_unit.py
@@ -49,6 +49,7 @@ from services.core.ActuatorAgent.tests.actuator_fixtures import MockedAsyncResul
 from volttrontesting.utils.utils import AgentMock
 from volttron.platform.vip.agent import Agent
 
+pytestmark = [pytest.mark.actuator_unit, pytest.mark.unit]
 
 PEER = "peer-1"
 SENDER = "sender-1"
@@ -65,7 +66,6 @@ agent._log = logging.getLogger("test_logger")
 ActuatorAgent.__bases__ = (AgentMock.imitate(Agent, Agent()),)
 
 
-@pytest.mark.actuator_unit
 def test_handle_get_should_succeed():
     with get_actuator_agent() as actuator_agent:
         actuator_agent.handle_get(PEER, SENDER, BUS, GET_TOPIC, HEADERS, MESSAGE)
@@ -74,7 +74,6 @@ def test_handle_get_should_succeed():
         actuator_agent.vip.pubsub.publish.assert_called_once()
 
 
-@pytest.mark.actuator_unit
 def test_handle_get_should_handle_standard_error(caplog):
     with get_actuator_agent(vip_identity=None) as actuator_agent:
         actuator_agent.handle_get(PEER, SENDER, BUS, GET_TOPIC, HEADERS, MESSAGE)
@@ -88,7 +87,6 @@ def test_handle_get_should_handle_standard_error(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "sender, device_state",
     [
@@ -111,7 +109,6 @@ def test_handle_set_should_succeed(sender, device_state):
         actuator_agent.vip.pubsub.publish.assert_called()
 
 
-@pytest.mark.actuator_unit
 def test_handle_set_should_return_none_on_none_message(caplog):
     with get_actuator_agent(vip_identity=None) as actuator_agent:
         result = actuator_agent.handle_set(PEER, SENDER, BUS, SET_TOPIC, HEADERS, None)
@@ -125,7 +122,6 @@ def test_handle_set_should_return_none_on_none_message(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 def test_handle_set_should_handle_type_error_on_invalid_sender(caplog):
     with get_actuator_agent(vip_identity=None) as actuator_agent:
         actuator_agent.handle_set(PEER, None, BUS, SET_TOPIC, HEADERS, MESSAGE)
@@ -138,7 +134,6 @@ def test_handle_set_should_handle_type_error_on_invalid_sender(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 def test_handle_set_should_handle_lock_error(caplog):
     with get_actuator_agent(vip_identity=None) as actuator_agent:
         actuator_agent.handle_set(PEER, SENDER, BUS, SET_TOPIC, HEADERS, MESSAGE)
@@ -151,7 +146,6 @@ def test_handle_set_should_handle_lock_error(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 def test_handle_revert_point_should_succeed():
     device_state = {
         "actuators/revert/point/somedevicepath": DeviceState(
@@ -168,7 +162,6 @@ def test_handle_revert_point_should_succeed():
         actuator_agent.vip.pubsub.publish.assert_called_once()
 
 
-@pytest.mark.actuator_unit
 def test_handle_revert_point_should_handle_lock_error(caplog):
     with get_actuator_agent(vip_identity=None) as actuator_agent:
         actuator_agent.handle_revert_point(
@@ -183,7 +176,6 @@ def test_handle_revert_point_should_handle_lock_error(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 def test_handle_revert_device_should_succeed():
     device_state = {
         "somedevicepath": DeviceState("sender-1", "task-id-1", "anytime")
@@ -199,7 +191,6 @@ def test_handle_revert_device_should_succeed():
         actuator_agent.vip.pubsub.publish.assert_called_once()
 
 
-@pytest.mark.actuator_unit
 def test_handle_revert_device_should_handle_lock_error(caplog):
    with get_actuator_agent(vip_identity=None) as actuator_agent:
         actuator_agent.handle_revert_device(
@@ -214,7 +205,6 @@ def test_handle_revert_device_should_handle_lock_error(caplog):
         )
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "priority, success",
     [
@@ -244,7 +234,6 @@ def test_handle_schedule_request_should_succeed_on_new_schedule_request_type(
         actuator_agent.vip.pubsub.publish.assert_called()
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("success", [True, False])
 def test_handle_schedule_request_should_succeed_on_cancel_schedule_request_type(success):
     headers = {"type": "CANCEL_SCHEDULE", "requesterID": "id-123", "taskID": "12345"}
@@ -257,7 +246,6 @@ def test_handle_schedule_request_should_succeed_on_cancel_schedule_request_type(
         actuator_agent.vip.pubsub.publish.assert_called()
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("invalid_request_type", ["bad request type", None])
 def test_handle_schedule_request_should_log_invalid_request_type(
     invalid_request_type, caplog

--- a/services/core/ActuatorAgent/tests/test_actuator_rpc_unit.py
+++ b/services/core/ActuatorAgent/tests/test_actuator_rpc_unit.py
@@ -52,6 +52,7 @@ from services.core.ActuatorAgent.tests.actuator_fixtures import MockedAsyncResul
 from volttrontesting.utils.utils import AgentMock
 from volttron.platform.vip.agent import Agent
 
+pytestmark = [pytest.mark.actuator_unit, pytest.mark.unit]
 
 PRIORITY_LOW = "LOW"
 SUCCESS = "SUCCESS"
@@ -66,7 +67,6 @@ agent._log = logging.getLogger("test_logger")
 ActuatorAgent.__bases__ = (AgentMock.imitate(Agent, Agent()),)
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("topic, point", [("path/topic", None), ("another/path/to/topic", 42)])
 def test_get_point_should_succeed(topic, point):
     with get_actuator_agent(vip_rpc_call_res=MockedAsyncResult(10.0)) as actuator_agent:
@@ -76,7 +76,6 @@ def test_get_point_should_succeed(topic, point):
         assert result is not None
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "point, device_state",
     [
@@ -101,7 +100,6 @@ def test_set_point_should_succeed(point, device_state):
         assert result is not None
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("rpc_peer", [None, 42, []])
 def test_set_point_should_raise_type_error(rpc_peer):
     with pytest.raises(TypeError, match="Agent id must be a nonempty string"):
@@ -114,7 +112,6 @@ def test_set_point_should_raise_type_error(rpc_peer):
             actuator_agent.set_point(requester_id, topic, value, point=point)
 
 
-@pytest.mark.actuator_unit
 def test_set_point_should_raise_lock_error_on_non_matching_device():
     with pytest.raises(LockError):
         requester_id = "requester-id-1"
@@ -125,7 +122,6 @@ def test_set_point_should_raise_lock_error_on_non_matching_device():
             actuator_agent.set_point(requester_id, topic, value)
 
 
-@pytest.mark.actuator_unit
 def test_scrape_all_should_succeed():
     with get_actuator_agent(vip_rpc_call_res=MockedAsyncResult({})) as actuator_agent:
         topic = "whan/that/aprille"
@@ -136,7 +132,6 @@ def test_scrape_all_should_succeed():
 
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "topics",
     [
@@ -156,7 +151,6 @@ def test_get_multiple_points_should_succeed(topics):
         assert len(errors) == 0
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("invalid_topics", [[(123,)], [(None)], [[123]], [[None]]])
 def test_get_multiple_points_should_return_errors(invalid_topics):
     with get_actuator_agent() as actuator_agent:
@@ -168,7 +162,6 @@ def test_get_multiple_points_should_return_errors(invalid_topics):
         assert len(errors) == 1
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "topic_values, device_state",
     [
@@ -186,7 +179,6 @@ def test_get_multiple_points_should_return_errors(invalid_topics):
         ),
     ],
 )
-@pytest.mark.actuator_unit
 def test_set_multiple_points_should_succeed(topic_values, device_state):
     requester_id = "requester-id-1"
     mocked_rpc_call_res = MockedAsyncResult(({}))
@@ -197,7 +189,6 @@ def test_set_multiple_points_should_succeed(topic_values, device_state):
         assert result == {}
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("invalid_topic_values", [[(None,)], [(1234,)]])
 def test_set_multiple_points_should_raise_value_error(invalid_topic_values):
     with pytest.raises(ValueError):
@@ -207,7 +198,6 @@ def test_set_multiple_points_should_raise_value_error(invalid_topic_values):
             actuator_agent.set_multiple_points("request-id-1", invalid_topic_values)
 
 
-@pytest.mark.actuator_unit
 def test_set_multiple_points_should_raise_lock_error_on_empty_devices():
     with pytest.raises(LockError):
         requester_id = "requester-id-1"
@@ -217,7 +207,6 @@ def test_set_multiple_points_should_raise_lock_error_on_empty_devices():
             actuator_agent.set_multiple_points("request-id-1", topic_values)
 
 
-@pytest.mark.actuator_unit
 def test_set_multiple_points_should_raise_lock_error_on_non_matching_requester():
     with pytest.raises(LockError):
         requester_id = "wrong-requester"
@@ -231,7 +220,6 @@ def test_set_multiple_points_should_raise_lock_error_on_non_matching_requester()
             actuator_agent.set_multiple_points("request-id-1", topic_values)
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("point", [None, "foobarpoint"])
 def test_revert_point_should_raise_lock_error_on_empty_devices(point):
     with pytest.raises(LockError):
@@ -242,7 +230,6 @@ def test_revert_point_should_raise_lock_error_on_empty_devices(point):
             actuator_agent.revert_point(requester_id, topic, point=point)
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize("point", [None, "foobarpoint"])
 def test_revert_point_should_raise_lock_error_on_non_matching_requester(point):
     with pytest.raises(LockError):
@@ -257,7 +244,6 @@ def test_revert_point_should_raise_lock_error_on_non_matching_requester(point):
             actuator_agent.revert_point(requester_id, topic, point=point)
 
 
-@pytest.mark.actuator_unit
 def test_revert_device_should_raise_lock_error_on_empty_devices():
     with pytest.raises(LockError):
         requester_id = "request-id-1"
@@ -267,7 +253,6 @@ def test_revert_device_should_raise_lock_error_on_empty_devices():
             actuator_agent.revert_device(requester_id, topic)
 
 
-@pytest.mark.actuator_unit
 def test_revert_device_should_raise_lock_error_on_non_matching_requester():
     with pytest.raises(LockError):
         device_state = {
@@ -281,7 +266,6 @@ def test_revert_device_should_raise_lock_error_on_non_matching_requester():
             actuator_agent.revert_device(requester_id, topic)
 
 
-@pytest.mark.actuator_unit
 def test_request_new_schedule_should_succeed():
     with get_actuator_agent() as actuator_agent:
         result = actuator_agent.request_new_schedule(REQUESTER_ID, TASK_ID,
@@ -290,7 +274,6 @@ def test_request_new_schedule_should_succeed():
         assert result["result"] == SUCCESS
 
 
-@pytest.mark.actuator_unit
 def test_request_new_schedule_should_succeed_when_stop_start_times_overlap():
     start = str(datetime.now())
     end = str(datetime.now() + timedelta(seconds=1))
@@ -304,7 +287,6 @@ def test_request_new_schedule_should_succeed_when_stop_start_times_overlap():
         assert result["result"] == SUCCESS
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "task_id, expected_info",
     [
@@ -325,7 +307,6 @@ def test_request_new_schedule_should_fail_on_invalid_taskid(task_id, expected_in
         assert result["info"] == expected_info
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "invalid_priority, expected_info",
     [("LOW2", "INVALID_PRIORITY"), (None, "MISSING_PRIORITY")],
@@ -341,7 +322,6 @@ def test_request_new_schedule_should_fail_on_invalid_priority(invalid_priority, 
         assert result["info"] == expected_info
 
 
-@pytest.mark.actuator_unit
 @pytest.mark.parametrize(
     "time_slot_request, expected_info",
     [
@@ -372,7 +352,6 @@ def test_request_new_schedule_should_fail_invalid_time_slot_requests(time_slot_r
         assert result["info"] == expected_info
 
 
-@pytest.mark.actuator_unit
 def test_request_cancel_schedule_should_succeed_happy_path():
     true_request_result = RequestResult(
         True, {}, ""
@@ -384,7 +363,6 @@ def test_request_cancel_schedule_should_succeed_happy_path():
         assert result["result"] == SUCCESS
 
 
-@pytest.mark.actuator_unit
 def test_request_cancel_schedule_should_fail_on_invalid_task_id():
     false_request_result = RequestResult(
         False, {}, "TASK_ID_DOES_NOT_EXIST"

--- a/volttrontesting/platform/dbutils/test_mysqlfuncts.py
+++ b/volttrontesting/platform/dbutils/test_mysqlfuncts.py
@@ -9,11 +9,14 @@ from volttron.platform.dbutils.mysqlfuncts import MySqlFuncts
 from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
+pytestmark = [pytest.mark.mysqlfuncts, pytest.mark.dbutils, pytest.mark.unit]
 
 # mysqlfuncts was written for MYSQL 5.7; however, the latest version is 8.0
 # these tests cannot use latest or anything 8.0 and above and will fail if the latest image/8.0 is used
 # for example, latest/8.0 will throw a "specified key was too long; max key length is 3072 bytes" error
-IMAGES = ["mysql:5.7", ]  # To test more images, add them here
+IMAGES = [
+    "mysql:5.7",
+]  # To test more images, add them here
 TEST_DATABASE = "test_historian"
 ROOT_PASSWORD = "12345"
 ENV_MYSQL = {"MYSQL_ROOT_PASSWORD": ROOT_PASSWORD, "MYSQL_DATABASE": TEST_DATABASE}
@@ -25,7 +28,6 @@ AGG_TOPICS_TABLE = "p_aggregate_topics"
 AGG_META_TABLE = "p_aggregate_meta"
 
 
-@pytest.mark.mysqlfuncts
 def test_setup_historian_tables_should_create_tables(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -39,12 +41,11 @@ def test_setup_historian_tables_should_create_tables(get_container_func, ports_c
             mysqlfuncts.setup_historian_tables()
 
             tables = get_tables(port_on_host)
-            assert 'data' in tables
-            assert 'topics' in tables
-            assert 'meta' in tables
+            assert "data" in tables
+            assert "topics" in tables
+            assert "meta" in tables
 
 
-@pytest.mark.mysqlfuncts
 def test_record_table_definitions_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -52,14 +53,18 @@ def test_record_table_definitions_should_succeed(get_container_func, ports_confi
 
         port_on_host = ports_config["port_on_host"]
         with get_mysqlfuncts(port_on_host) as mysqlfuncts:
-            tables_def = {'table_prefix': "prefix",
-                          'data_table': "data",
-                          'topics_table': "topics",
-                          'meta_table': "meta"}
-            meta_table_name = 'meta_other'
-            expected_data = {('data_table', "data", "prefix"),
-                             ('topics_table', "topics", "prefix"),
-                             ('meta_table', "meta", "prefix")}
+            tables_def = {
+                "table_prefix": "prefix",
+                "data_table": "data",
+                "topics_table": "topics",
+                "meta_table": "meta",
+            }
+            meta_table_name = "meta_other"
+            expected_data = {
+                ("data_table", "data", "prefix"),
+                ("topics_table", "topics", "prefix"),
+                ("meta_table", "meta", "prefix"),
+            }
 
             tables = get_tables(port_on_host)
             assert meta_table_name not in tables
@@ -74,8 +79,9 @@ def test_record_table_definitions_should_succeed(get_container_func, ports_confi
                 assert val in expected_data
 
 
-@pytest.mark.mysqlfuncts
-def test_setup_aggregate_historian_tables_should_succeed(get_container_func, ports_config):
+def test_setup_aggregate_historian_tables_should_succeed(
+    get_container_func, ports_config
+):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
         wait_for_connection(container)
@@ -88,18 +94,27 @@ def test_setup_aggregate_historian_tables_should_succeed(get_container_func, por
             assert AGG_TOPICS_TABLE not in tables
             assert AGG_META_TABLE not in tables
 
-            mysqlfuncts.setup_aggregate_historian_tables('metadata')
+            mysqlfuncts.setup_aggregate_historian_tables("metadata")
 
             tables = get_tables(port_on_host)
             assert AGG_TOPICS_TABLE in tables
             assert AGG_META_TABLE in tables
 
 
-@pytest.mark.mysqlfuncts
-@pytest.mark.parametrize("topic_ids, id_name_map, expected_values",
-                         [([42], {42: "topic42"}, {"topic42": []}),
-                          ([43], {43: "topic43"}, {"topic43": [('2020-06-01T12:30:59.000000+00:00', [2,3])]})])
-def test_query_should_return_data(get_container_func, ports_config, topic_ids, id_name_map, expected_values):
+@pytest.mark.parametrize(
+    "topic_ids, id_name_map, expected_values",
+    [
+        ([42], {42: "topic42"}, {"topic42": []}),
+        (
+            [43],
+            {43: "topic43"},
+            {"topic43": [("2020-06-01T12:30:59.000000+00:00", [2, 3])]},
+        ),
+    ],
+)
+def test_query_should_return_data(
+    get_container_func, ports_config, topic_ids, id_name_map, expected_values
+):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
         wait_for_connection(container)
@@ -122,7 +137,6 @@ def test_query_should_return_data(get_container_func, ports_config, topic_ids, i
             assert actual_values == expected_values
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_meta_query_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -138,10 +152,9 @@ def test_insert_meta_query_should_succeed(get_container_func, ports_config):
             res = mysqlfuncts.insert_meta(topic_id, metadata)
 
             assert res is True
-            assert get_data_in_table(port_on_host, 'meta')[0] == expected_data
+            assert get_data_in_table(port_on_host, "meta")[0] == expected_data
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_data_query_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -150,7 +163,7 @@ def test_insert_data_query_should_succeed(get_container_func, ports_config):
 
         port_on_host = ports_config["port_on_host"]
         with get_mysqlfuncts(port_on_host) as mysqlfuncts:
-            ts = '2001-09-11 08:46:00'
+            ts = "2001-09-11 08:46:00"
             topic_id = "11"
             data = "1wtc"
             expected_data = [(datetime.datetime(2001, 9, 11, 8, 46), 11, '"1wtc"')]
@@ -158,10 +171,9 @@ def test_insert_data_query_should_succeed(get_container_func, ports_config):
             res = mysqlfuncts.insert_data(ts, topic_id, data)
 
             assert res is True
-            assert get_data_in_table(port_on_host, 'data') == expected_data
+            assert get_data_in_table(port_on_host, "data") == expected_data
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_topic_query_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -175,10 +187,11 @@ def test_insert_topic_query_should_succeed(get_container_func, ports_config):
             actual_id = mysqlfuncts.insert_topic(topic)
 
             assert isinstance(actual_id, int)
-            assert (actual_id, 'football') == get_data_in_table(port_on_host, 'topics')[0]
+            assert (actual_id, "football") == get_data_in_table(port_on_host, "topics")[
+                0
+            ]
 
 
-@pytest.mark.mysqlfuncts
 def test_update_topic_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -196,10 +209,9 @@ def test_update_topic_should_succeed(get_container_func, ports_config):
             result = mysqlfuncts.update_topic("soccer", actual_id)
 
             assert result is True
-            assert (actual_id, 'soccer') == get_data_in_table(port_on_host, 'topics')[0]
+            assert (actual_id, "soccer") == get_data_in_table(port_on_host, "topics")[0]
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_agg_topic_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -211,7 +223,7 @@ def test_insert_agg_topic_should_succeed(get_container_func, ports_config):
             topic = "some_agg_topic"
             agg_type = "AVG"
             agg_time_period = "2019"
-            expected_data = (1, 'some_agg_topic', 'AVG', '2019')
+            expected_data = (1, "some_agg_topic", "AVG", "2019")
 
             actual_id = mysqlfuncts.insert_agg_topic(topic, agg_type, agg_time_period)
 
@@ -219,7 +231,6 @@ def test_insert_agg_topic_should_succeed(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-@pytest.mark.mysqlfuncts
 def test_update_agg_topic_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -231,7 +242,7 @@ def test_update_agg_topic_should_succeed(get_container_func, ports_config):
             topic = "cars"
             agg_type = "SUM"
             agg_time_period = "2100ZULU"
-            expected_data = (1, 'cars', 'SUM', '2100ZULU')
+            expected_data = (1, "cars", "SUM", "2100ZULU")
 
             actual_id = mysqlfuncts.insert_agg_topic(topic, agg_type, agg_time_period)
 
@@ -239,7 +250,7 @@ def test_update_agg_topic_should_succeed(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
             new_agg_topic_name = "boats"
-            expected_data = (1, 'boats', 'SUM', '2100ZULU')
+            expected_data = (1, "boats", "SUM", "2100ZULU")
 
             result = mysqlfuncts.update_agg_topic(actual_id, new_agg_topic_name)
 
@@ -247,7 +258,6 @@ def test_update_agg_topic_should_succeed(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_agg_meta_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -258,7 +268,7 @@ def test_insert_agg_meta_should_succeed(get_container_func, ports_config):
         with get_mysqlfuncts(port_on_host) as mysqlfuncts:
 
             topic_id = 42
-            metadata = 'meaning of life'
+            metadata = "meaning of life"
             expected_data = (42, '"meaning of life"')
 
             result = mysqlfuncts.insert_agg_meta(topic_id, metadata)
@@ -267,7 +277,6 @@ def test_insert_agg_meta_should_succeed(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_META_TABLE)[0] == expected_data
 
 
-@pytest.mark.mysqlfuncts
 def test_get_topic_map_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -283,14 +292,16 @@ def test_get_topic_map_should_succeed(get_container_func, ports_config):
                        VALUES ('baseball');                     
                     """
             seed_database(container, query)
-            expected = ({'baseball': 2, 'football': 1}, {'baseball': 'baseball', 'football': 'football'})
+            expected = (
+                {"baseball": 2, "football": 1},
+                {"baseball": "baseball", "football": "football"},
+            )
 
             actual = mysqlfuncts.get_topic_map()
 
             assert actual == expected
 
 
-@pytest.mark.mysqlfuncts
 def test_get_agg_topic_map_should_return_dict(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -305,14 +316,13 @@ def test_get_agg_topic_map_should_return_dict(get_container_func, ports_config):
                         VALUES ('topic_name', 'AVG', '2001');
                      """
             seed_database(container, query)
-            expected = {('topic_name', 'AVG', '2001'): 1}
+            expected = {("topic_name", "AVG", "2001"): 1}
 
             actual = mysqlfuncts.get_agg_topic_map()
 
             assert actual == expected
 
 
-@pytest.mark.mysqlfuncts
 def test_query_topics_by_pattern_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -330,7 +340,7 @@ def test_query_topics_by_pattern_should_succeed(get_container_func, ports_config
                        VALUES ('xyzzzzzzzz');                     
                     """
             seed_database(container, query)
-            expected = {'football': 1, 'foobar': 2}
+            expected = {"football": 1, "foobar": 2}
             topic_pattern = "foo"
 
             actual = mysqlfuncts.query_topics_by_pattern(topic_pattern)
@@ -338,7 +348,6 @@ def test_query_topics_by_pattern_should_succeed(get_container_func, ports_config
             assert actual == expected
 
 
-@pytest.mark.mysqlfuncts
 def test_create_aggregate_store_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -350,16 +359,18 @@ def test_create_aggregate_store_should_succeed(get_container_func, ports_config)
             agg_type = "AVG"
             agg_time_period = "1984"
             expected_aggregate_table = "AVG_1984"
-            expected_fields = {'value_string', 'topics_list', 'topic_id', 'ts'}
+            expected_fields = {"value_string", "topics_list", "topic_id", "ts"}
 
             result = mysqlfuncts.create_aggregate_store(agg_type, agg_time_period)
 
             assert result is not None
             assert expected_aggregate_table in get_tables(port_on_host)
-            assert describe_table(port_on_host, expected_aggregate_table) == expected_fields
+            assert (
+                describe_table(port_on_host, expected_aggregate_table)
+                == expected_fields
+            )
 
 
-@pytest.mark.mysqlfuncts
 def test_insert_aggregate_stmt_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -382,16 +393,24 @@ def test_insert_aggregate_stmt_should_succeed(get_container_func, ports_config):
             ts = "2020-06-01 12:30:59"
             data = "some_data"
             topic_ids = [12, 54, 65]
-            expected_data = (datetime.datetime(2020, 6, 1, 12, 30, 59), 42, '"some_data"', '[12, 54, 65]')
+            expected_data = (
+                datetime.datetime(2020, 6, 1, 12, 30, 59),
+                42,
+                '"some_data"',
+                "[12, 54, 65]",
+            )
 
-            res = mysqlfuncts.insert_aggregate(agg_topic_id, agg_type, period, ts, data, topic_ids)
+            res = mysqlfuncts.insert_aggregate(
+                agg_topic_id, agg_type, period, ts, data, topic_ids
+            )
 
             assert res is True
             assert get_data_in_table(port_on_host, "AVG_1776")[0] == expected_data
 
 
-@pytest.mark.mysqlfuncts
-def test_collect_aggregate_should_return_aggregate_result(get_container_func, ports_config):
+def test_collect_aggregate_should_return_aggregate_result(
+    get_container_func, ports_config
+):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
         wait_for_connection(container)
@@ -416,7 +435,6 @@ def test_collect_aggregate_should_return_aggregate_result(get_container_func, po
             assert actual_aggregate == expected_aggregate
 
 
-@pytest.mark.mysqlfuncts
 def test_collect_aggregate_should_raise_value_error(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(image, ports=ports_config["ports"], env=ENV_MYSQL) as container:
@@ -429,17 +447,21 @@ def test_collect_aggregate_should_raise_value_error(get_container_func, ports_co
 
 @contextlib.contextmanager
 def get_mysqlfuncts(port):
-    connect_params = {"host": 'localhost',
-                      "port": port,
-                      "database": TEST_DATABASE,
-                      "user": "root",
-                      "passwd": ROOT_PASSWORD}
+    connect_params = {
+        "host": "localhost",
+        "port": port,
+        "database": TEST_DATABASE,
+        "user": "root",
+        "passwd": ROOT_PASSWORD,
+    }
 
-    table_names = {"data_table": DATA_TABLE,
-                   "topics_table": TOPICS_TABLE,
-                   "meta_table": META_TABLE,
-                   "agg_topics_table": AGG_TOPICS_TABLE,
-                   "agg_meta_table": AGG_META_TABLE}
+    table_names = {
+        "data_table": DATA_TABLE,
+        "topics_table": TOPICS_TABLE,
+        "meta_table": META_TABLE,
+        "agg_topics_table": AGG_TOPICS_TABLE,
+        "agg_meta_table": AGG_META_TABLE,
+    }
 
     mysqlfuncts = MySqlFuncts(connect_params, table_names)
 
@@ -454,8 +476,7 @@ def get_container_func(request):
 @pytest.fixture()
 def ports_config():
     port_on_host = get_rand_port(ip="3306")
-    return {"port_on_host": port_on_host,
-            "ports": {"3306/tcp": port_on_host}}
+    return {"port_on_host": port_on_host, "ports": {"3306/tcp": port_on_host}}
 
 
 def wait_for_connection(container):
@@ -463,7 +484,7 @@ def wait_for_connection(container):
     response = None
     while time() - start_time < ALLOW_CONNECTION_TIME:
         command = (
-            f"mysqlshow --user=\"root\" --password=\"{ROOT_PASSWORD}\" {TEST_DATABASE}"
+            f'mysqlshow --user="root" --password="{ROOT_PASSWORD}" {TEST_DATABASE}'
         )
         response = container.exec_run(command, tty=True)
         exit_code, output = response
@@ -474,7 +495,6 @@ def wait_for_connection(container):
             return
 
     raise RuntimeError(f"Failed to make connection within allowed time {response}")
-
 
 
 def create_historian_tables(container):
@@ -494,7 +514,7 @@ def create_historian_tables(container):
                metadata TEXT NOT NULL,
                PRIMARY KEY(topic_id));
             """
-    command = f"mysql --user=\"root\" --password=\"{ROOT_PASSWORD}\" {TEST_DATABASE} --execute=\"{query}\""
+    command = f'mysql --user="root" --password="{ROOT_PASSWORD}" {TEST_DATABASE} --execute="{query}"'
     container.exec_run(cmd=command, tty=True)
     return
 
@@ -512,7 +532,7 @@ def create_metadata_table(container):
                REPLACE INTO metadata
                VALUES ('meta_table', 'meta', 'p');
             """
-    command = f"mysql --user=\"root\" --password=\"{ROOT_PASSWORD}\" {TEST_DATABASE} --execute=\"{query}\""
+    command = f'mysql --user="root" --password="{ROOT_PASSWORD}" {TEST_DATABASE} --execute="{query}"'
     container.exec_run(cmd=command, tty=True)
     return
 
@@ -531,7 +551,7 @@ def create_aggregate_tables(container):
                 metadata TEXT NOT NULL,
                 PRIMARY KEY(agg_topic_id));
             """
-    command = f"mysql --user=\"root\" --password=\"{ROOT_PASSWORD}\" {TEST_DATABASE} --execute=\"{query}\""
+    command = f'mysql --user="root" --password="{ROOT_PASSWORD}" {TEST_DATABASE} --execute="{query}"'
     container.exec_run(cmd=command, tty=True)
     return
 
@@ -544,7 +564,7 @@ def create_all_tables(container):
 
 
 def seed_database(container, query):
-    command = f"mysql --user=\"root\" --password=\"{ROOT_PASSWORD}\" {TEST_DATABASE} --execute=\"{query}\""
+    command = f'mysql --user="root" --password="{ROOT_PASSWORD}" {TEST_DATABASE} --execute="{query}"'
     container.exec_run(cmd=command, tty=True)
     return
 
@@ -602,12 +622,13 @@ def get_data_in_table(port, table):
 
 
 def get_cnx_cursor(port):
-    connect_params = {"host": 'localhost',
-                      "port": port,
-                      "database": TEST_DATABASE,
-                      "user": "root",
-                      "passwd": ROOT_PASSWORD}
+    connect_params = {
+        "host": "localhost",
+        "port": port,
+        "database": TEST_DATABASE,
+        "user": "root",
+        "passwd": ROOT_PASSWORD,
+    }
     cnx = mysql.connector.connect(**connect_params)
     cursor = cnx.cursor()
     return cnx, cursor
-

--- a/volttrontesting/platform/dbutils/test_postgresqlfuncts.py
+++ b/volttrontesting/platform/dbutils/test_postgresqlfuncts.py
@@ -22,6 +22,8 @@ from volttron.platform.dbutils.postgresqlfuncts import PostgreSqlFuncts
 from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
+pytestmark = [pytest.mark.postgresqlfuncts, pytest.mark.dbutils, pytest.mark.unit]
+
 # Current documentation claims that we have tested Historian on Postgres 10
 # See https://volttron.readthedocs.io/en/develop/core_services/historians/SQL-Historian.html#postgresql-and-redshift
 IMAGES = ["postgres:9.6.18", "postgres:10.13"]
@@ -57,8 +59,6 @@ AGG_META_TABLE = "aggregate_meta"
 METADATA_TABLE = "metadata"
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_setup_historian_tables_should_create_tables(get_container_func, ports_config):
     get_container, image = get_container_func
     with get_container(
@@ -79,8 +79,6 @@ def test_setup_historian_tables_should_create_tables(get_container_func, ports_c
             assert actual_tables == expected_tables
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_record_table_definitions_should_create_meta_table(
     get_container_func, ports_config
 ):
@@ -108,8 +106,6 @@ def test_record_table_definitions_should_create_meta_table(
             assert describe_table(port_on_host, METADATA_TABLE) == expected_table_defs
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_read_tablenames_from_db_should_return_table_names(
     get_container_func, ports_config
 ):
@@ -135,8 +131,6 @@ def test_read_tablenames_from_db_should_return_table_names(
             assert actual_tables == expected_tables
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_setup_aggregate_historian_tables_should_create_aggregate_tables(
     get_container_func, ports_config
 ):
@@ -190,8 +184,6 @@ def test_setup_aggregate_historian_tables_should_create_aggregate_tables(
         ),
     ],
 )
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_query_should_return_data(
     get_container_func, ports_config, topic_ids, id_name_map, expected_values
 ):
@@ -214,8 +206,6 @@ def test_query_should_return_data(
             assert actual_values == expected_values
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_topic_should_return_topic_id(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -236,8 +226,6 @@ def test_insert_topic_should_return_topic_id(get_container_func, ports_config):
             assert actual_topic_id == expected_topic_id
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_agg_topic_should_return_agg_topic_id(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -263,8 +251,6 @@ def test_insert_agg_topic_should_return_agg_topic_id(get_container_func, ports_c
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_meta_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -286,8 +272,6 @@ def test_insert_meta_should_return_true(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, "meta")[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_data_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -310,8 +294,6 @@ def test_insert_data_should_return_true(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, "data") == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_update_topic_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -335,8 +317,6 @@ def test_update_topic_should_return_true(get_container_func, ports_config):
             assert (actual_id, "soccer") == get_data_in_table(port_on_host, "topics")[0]
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_get_aggregation_list_should_return_list(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -369,8 +349,6 @@ def test_get_aggregation_list_should_return_list(get_container_func, ports_confi
             assert postgresqlfuncts.get_aggregation_list() == expected_list
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_agg_topic_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -395,8 +373,6 @@ def test_insert_agg_topic_should_return_true(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_update_agg_topic_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -429,8 +405,6 @@ def test_update_agg_topic_should_return_true(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_agg_meta_should_return_true(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -453,8 +427,6 @@ def test_insert_agg_meta_should_return_true(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, AGG_META_TABLE)[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_get_topic_map_should_return_maps(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -483,8 +455,6 @@ def test_get_topic_map_should_return_maps(get_container_func, ports_config):
             assert actual == expected
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_get_agg_topics_should_return_list(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -511,8 +481,6 @@ def test_get_agg_topics_should_return_list(get_container_func, ports_config):
             assert actual_list == expected_list
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_get_agg_topic_map_should_return_dict(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -537,8 +505,6 @@ def test_get_agg_topic_map_should_return_dict(get_container_func, ports_config):
             assert actual == expected
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_query_topics_by_pattern_should_return_matching_results(
     get_container_func, ports_config
 ):
@@ -569,8 +535,6 @@ def test_query_topics_by_pattern_should_return_matching_results(
             assert actual == expected
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_create_aggregate_store_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -596,8 +560,6 @@ def test_create_aggregate_store_should_succeed(get_container_func, ports_config)
             )
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_insert_aggregate_stmt_should_succeed(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -650,8 +612,6 @@ def test_insert_aggregate_stmt_should_succeed(get_container_func, ports_config):
             assert get_data_in_table(port_on_host, "avg_1776")[0] == expected_data
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_collect_aggregate_stmt_should_return_rows(get_container_func, ports_config):
     get_container, image = get_container_func
 
@@ -680,8 +640,6 @@ def test_collect_aggregate_stmt_should_return_rows(get_container_func, ports_con
             assert actual_aggregate == expected_aggregate
 
 
-@pytest.mark.postgresqlfuncts
-@pytest.mark.dbutils
 def test_collect_aggregate_stmt_should_raise_value_error(
     get_container_func, ports_config
 ):


### PR DESCRIPTION
# Description

Add a 'unit' test marker in order to run all unit/level one integ tests from the command line using Pytest.

Use 'pytestmark' to mark a whole module with a custom marker. See https://docs.pytest.org/en/stable/reference.html#globalvar-pytestmark

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run the following on the command line; navigate to a certain directory to run all the tests under that directory

```bash
# in this example, we will run all the unit/level 1 integ tests of the Actuator agent
$ pytest -m unit services/core/AcutatorAgent

# in this example, run all the unit/level 1 integ tests of the dbutils folder
$ pytest -m unit volttrontesting/platform/dbutils 
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

