### PR TITLE
Pin greenlet to older version; fix rabbit_dep script

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -46,6 +46,7 @@ option_requirements = [
 
 install_requires = [
     'gevent==20.6.1',
+    'greenlet==0.4.16',
     'grequests',
     'requests==2.23.0',
     'ply',

--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -72,7 +72,7 @@ function install_on_debian {
     fi
 
     echo "installing ERLANG"
-    ${prefix} apt-get install apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git
+    ${prefix} apt-get install apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git -y
     set +e
     ${prefix} apt-get purge -yf erlang*
     set -e


### PR DESCRIPTION
# Description

As part of getting volttron-docker to successfully create a container, `greenlet` needs to be pinned to an old version due to bug in gevent (see https://github.com/phovea/phovea_server/issues/130). 

Also, the rabbit script needs a `-y` for it to complete the building of the docker image. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By building the image in the Dockerfile in volttron-docker, I was able to execute the script and the rest of the Docker layers. I also was able to start volttron in `bootstart.sh`. Before this change, the container, running Python 3.7, failed to start volttron because of this greenlet issue.
 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
