### PR TITLE
Fix bacnet_scan.py in python3

### DIFF
--- a/scripts/bacnet/bacnet_scan.py
+++ b/scripts/bacnet/bacnet_scan.py
@@ -55,8 +55,8 @@ from bacpypes.apdu import WhoIsRequest, IAmRequest
 from bacpypes.basetypes import ServicesSupported
 from bacpypes.errors import DecodingError
 
-import threading, time, sys
-
+import threading
+import time
 import csv
 
 # some debugging
@@ -193,7 +193,8 @@ args = arg_parser.parse_args()
 f = None
 
 if args.csv_out is not None:
-    f = open(args.csv_out, "wb")
+    mode = 'wb' if sys.version_info.major == 2 else 'w'
+    f = open(args.csv_out, mode)
     field_names = ["address",
                    "device_id",
                    "max_apdu_length",


### PR DESCRIPTION
# Description

This updates the file write mode so that the `csv.DictWriter` usage works in Python 3. I wasn't sure if Python 2 support is deprecated or not so I left the existing code path intact with a version switch.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the `scan_bacnet.py` script locally with python `2.7.17` and `3.6.9`

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
