### PR TITLE
fix grab_multiple_configs.py in python3, add optional --ini cli flag

### DIFF
--- a/ci-integration/run-test-docker.sh
+++ b/ci-integration/run-test-docker.sh
@@ -19,7 +19,7 @@ fi
 
 export FAST_FAIL=${FAST_FAIL:-true}
 
-pip list
+python3 -m pip list
 echo "RUNNING $NUM_PROCESSES PARALLEL PROCESSESS AT A TIME"
 echo "FAST_FAIL IS $FAST_FAIL"
 

--- a/ci-integration/virtualization/requirements_test.txt
+++ b/ci-integration/virtualization/requirements_test.txt
@@ -11,8 +11,6 @@ cryptography==2.3
 docker
 psycopg2
 mysql-connector-python-rf
-watchdog
-watchdog-gevent
 docker
 cryptography
 pymongo

--- a/ci-integration/virtualization/requirements_test.txt
+++ b/ci-integration/virtualization/requirements_test.txt
@@ -12,6 +12,5 @@ docker
 psycopg2
 mysql-connector-python-rf
 docker
-cryptography
 pymongo
 influxdb

--- a/scripts/bacnet/grab_multiple_configs.py
+++ b/scripts/bacnet/grab_multiple_configs.py
@@ -54,12 +54,13 @@ def makedirs(path):
             raise
 
 arg_parser = argparse.ArgumentParser()
-arg_parser.add_argument("csv_file", type=argparse.FileType('rb'),
+arg_parser.add_argument("csv_file", type=argparse.FileType('r'),
                         help="Input CSV file")
 arg_parser.add_argument("--use-proxy", action="store_true",
                         help="Use proxy_grab_bacnet_config.py to grab configurations.")
 arg_parser.add_argument("--out-directory",
                         help="Output directory.", default=".")
+arg_parser.add_argument("--ini", help="BACPypes.ini config file to use")
 
 args = arg_parser.parse_args()
 
@@ -79,20 +80,19 @@ for device in device_list:
     address = device["address"]
     device_id = device["device_id"]
 
-    prog_args = ["python", program_path]
+    prog_args = ["python3", program_path]
     prog_args.append(device_id)
-    if not args.use_proxy:
+    if not args.use_proxy and address:
         prog_args.append("--address")
         prog_args.append(address)
     prog_args.append("--registry-out-file")
     prog_args.append(join(registers_dir, str(device_id)+".csv"))
     prog_args.append("--driver-out-file")
     prog_args.append(join(devices_dir, str(device_id)))
+    if args.ini is not None:
+        prog_args.append("--ini")
+        prog_args.append(args.ini)
 
     print("executing command:", " ".join(prog_args))
 
     subprocess.call(prog_args)
-
-
-
-

--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -72,6 +72,7 @@ function install_on_debian {
     fi
 
     echo "installing ERLANG"
+    ${prefix} apt-get update
     ${prefix} apt-get install -y apt-transport-https libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1  build-essential python-dev openssl libssl-dev libevent-dev git
     set +e
     ${prefix} apt-get purge -yf erlang*


### PR DESCRIPTION
# Description

This PR fixes `scripts/bacnet/grab_multiple_configs.py` in Python 3 and also adds an optional `--ini` flag which is passed through to the other bacnet scripts. 

I also helped the travis build to get further - the tests now run (before failing at an `apt-get` step) but still aren't passing. Figure that's a step in the right direction at least

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran this locally with `Python 3.6.9` and was able to grab sensor metadata from devices successfully

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
