### PR TITLE
Fix/2480 hypertable

### DIFF
--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -118,7 +118,7 @@ class PostgreSqlFuncts(DbDriver):
         if self.timescale_dialect:
             _log.debug("trying to create hypertable")
             self.execute_stmt(SQL(
-                "SELECT create_hypertable({}, 'ts')").format(
+                "SELECT create_hypertable({}, 'ts', if_not_exists => true)").format(
                 Literal(self.data_table)))
             self.execute_stmt(SQL(
                 'CREATE INDEX ON {} (topic_id, ts)').format(


### PR DESCRIPTION
# Description

Updated create_hypertable statement to not error out when it already exists.

Fixes #2480 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested internally on production macahine.
