### PR TITLE
Add PYTHONPATH in SecureExecutionEnvironment

### DIFF
--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -242,8 +242,15 @@ class SecureExecutionEnvironment(object):
             stdout, stderr = process.communicate()
             _log.info("stopping agent: stdout {} stderr: {}".format(stdout, stderr))
             if process.returncode != 0:
-                _log.error("Exception stopping agent: stdout {} stderr: {}".format(stdout, stderr))
-                raise RuntimeError("Exception stopping agent: stdout {} stderr: {}".format(stdout, stderr))
+                # executing this script in a docker container requires a different path to the script
+                cmd2 = ["sudo", "/code/volttron/scripts/secure_stop_agent.sh", self.agent_user, str(self.process.pid)]
+                _log.debug("Initial request to stopping agent failed, trying different command {}".format(cmd2))
+                process2 = subprocess.Popen(cmd2, stdout=PIPE, stderr=PIPE)
+                stdout, stderr = process2.communicate()
+                _log.info("stopping agent: stdout {} stderr: {}".format(stdout, stderr))
+                if process2.returncode != 0:
+                    _log.error("Exception stopping agent: stdout {} stderr: {}".format(stdout, stderr))
+                    raise RuntimeError("Exception stopping agent: stdout {} stderr: {}".format(stdout, stderr))
         return self.process.poll()
 
     def __call__(self, *args, **kwargs):

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -224,7 +224,8 @@ class SecureExecutionEnvironment(object):
     def execute(self, *args, **kwargs):
         try:
             self.env = kwargs.get('env', None)
-            run_as_user = ['sudo', '-E', '-u', self.agent_user]
+            pythonpath = ':'.join(x for x in sys.path if x)
+            run_as_user = ['sudo', f"PYTHONPATH={pythonpath}", '-E', '-u', self.agent_user]
             run_as_user.extend(*args)
             _log.debug(run_as_user)
             self.process = subprocess.Popen(run_as_user, universal_newlines=True, **kwargs)


### PR DESCRIPTION
# Description

When installing agents on a platform in a non-virtual environment, the volttron user does not have visibility of volttron-related modules which it needs to execute Python modules that depend on volttron modules. This change allows the volttron user visibility of the correct PYTHONPATH.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the change by creating a volttron platform on a Docker container without using the virtual environment. I saw that the agent was successfully created and installed. Note that I have not tested this change on a virtual environment in secure mode. I will update this PR later with the results of that testing. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
