### PR TITLE
Add regex pattern for checking command in secure_stop_agent.sh

### DIFF
--- a/scripts/secure_stop_agent.sh
+++ b/scripts/secure_stop_agent.sh
@@ -64,11 +64,15 @@ if [ $exit_code -ne 0 ]; then
 fi
 
 # if we find a command check the pattern
-# command should be of the pattern
+# command should be one of two patterns
+# Pattern 1:
 # sudo -E -u <username passed to this script> /<some path to volttron source>/env/bin/python -m <agent name>
+# Pattern 2: if the platform is created using an official volttron docker image, PYTHONPATH will be used in installing agents
+# sudo PTYHONPATH=<the pythonpath of the user> -E -u <username passed to this script> /<some path to volttron source>/env/bin/python -m <agent name>
 
 re="^sudo -E -u $user /.+/python.* -m .+"
-if [[ ! $command =~ $re ]]; then
+re2="^sudo PYTHONPATH=.* -E -u $user /.+/python.* -m .+"
+if [[ ! $command =~ $re && ! $command =~ $re2 ]]; then
     echo "Invalid process id. pid does not correspond to a volttron agent owned by user $user"
     echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
     exit 4


### PR DESCRIPTION
# Description

Creating the volttron platform in secure mode on a Docker container using the official volttron base images requires the explicit setting and use of PYTHONPATH when the volttron user runs any modules that requires volttron-related modules. As part of its workflow, the `secure_stop_agent.sh` must verify a command that uses such modules. However, `secure_stop_agent.sh` assumes that the volttron user never uses PYTHONPATH to make such commands. Consequently, the script will fail because it does not expect to see PYTHONPATH when verifying commands that use volttron-related modules. This PR fixes that issues and allows users to create volttron platforms in secure mode on a Docker container using volttron-official images.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the change by creating a Docker container and starting a volttron platform in secure mode and starting a listener agent. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
