### PR TITLE
Fixes #2466. 

### DIFF
--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -49,6 +49,7 @@ import signal
 import sys
 import uuid
 
+import requests
 import gevent
 import gevent.event
 from gevent import subprocess
@@ -681,7 +682,10 @@ class AIPplatform(object):
             # Delete RabbitMQ user for the agent
             instance_name = self.instance_name
             rmq_user = instance_name + '.' + identity
-            self.rmq_mgmt.delete_user(rmq_user)
+            try:
+                self.rmq_mgmt.delete_user(rmq_user)
+            except requests.exceptions.HTTPError as e:
+                _log.error(f"RabbitMQ user {rmq_user} is not available to delete. Going ahead and removing agent directory")
         self.agents.pop(agent_uuid, None)
         agent_directory = os.path.join(self.install_dir, agent_uuid)
         volttron_agent_user = None

--- a/volttron/utils/rmq_mgmt.py
+++ b/volttron/utils/rmq_mgmt.py
@@ -296,7 +296,7 @@ class RabbitMQMgmt(object):
         try:
             response = self._http_delete_request(url, ssl_auth)
         except requests.exceptions.HTTPError as e:
-            if not e.message.startswith("404 Client Error"):
+            if e.response.status_code == 404:
                 raise
 
     def delete_users_in_bulk(self, users, ssl_auth=None):
@@ -329,7 +329,7 @@ class RabbitMQMgmt(object):
             response = self._http_get_request(url, ssl_auth)
             return response
         except requests.exceptions.HTTPError as e:
-            if e.message.startswith("404 Client Error"):
+            if e.response.status_code == 404:
                 # No permissions are set for this user yet. Return none
                 # so caller can try to set permissions
                 return None


### PR DESCRIPTION
# Description

HTTPError exception does not contain 'message' attribute. Replaced that with 'status_code'. Catching the raised exception in caller method (remove_agent)

Fixes #2466 


