### PR TITLE
Added proxy-id option to grab_multiple_configs for environments runni…

### DIFF
--- a/docs/source/driver-framework/bacnet/bacnet-auto-configuration.rst
+++ b/docs/source/driver-framework/bacnet/bacnet-auto-configuration.rst
@@ -188,6 +188,9 @@ Grab Multiple Configs Options
 
     - ``--out-directory OUT_DIRECTORY`` Specify the output directory.
     - ``--use-proxy`` Use `proxy_grab_bacnet_config.py` to gather configuration data.
+    - ``--proxy-id`` When using ``-use-proxy``, supply ``proxy-id`` with the VIP identity of a BACnet proxy agent.  This
+      is useful for deployments with multiple BACnet proxies, such as on segmented networks, or in deployments
+      communicating with multiple BACnet networks.
 
 
 BACnet Proxy Alternative Scripts

--- a/scripts/bacnet/grab_multiple_configs.py
+++ b/scripts/bacnet/grab_multiple_configs.py
@@ -58,6 +58,7 @@ arg_parser.add_argument("csv_file", type=argparse.FileType('r'),
                         help="Input CSV file")
 arg_parser.add_argument("--use-proxy", action="store_true",
                         help="Use proxy_grab_bacnet_config.py to grab configurations.")
+arg_parser.add_argument("--proxy-id", help="Use this VIP identity for the BACnet Proxy instance")
 arg_parser.add_argument("--out-directory",
                         help="Output directory.", default=".")
 arg_parser.add_argument("--ini", help="BACPypes.ini config file to use")
@@ -85,6 +86,8 @@ for device in device_list:
     if not args.use_proxy and address:
         prog_args.append("--address")
         prog_args.append(address)
+    if args.use_proxy and args.proxy_id:
+        prog_args += ['--proxy-id', args.proxy_id]
     prog_args.append("--registry-out-file")
     prog_args.append(join(registers_dir, str(device_id)+".csv"))
     prog_args.append("--driver-out-file")

--- a/scripts/bacnet/proxy_grab_bacnet_config.py
+++ b/scripts/bacnet/proxy_grab_bacnet_config.py
@@ -38,13 +38,13 @@
 
 import sys
 from csv import DictWriter
-
+from os.path import basename
 import logging
 import argparse
 import gevent
 from gevent.event import AsyncResult
 
-from volttron.platform import get_address, get_home
+from volttron.platform import get_address, get_home, jsonapi
 from volttron.platform.agent import utils
 from volttron.platform.agent.bacnet_proxy_reader import BACnetReader
 from volttron.platform.keystore import KeyStore
@@ -111,6 +111,17 @@ def main():
 
     _log.debug("initialization")
     _log.debug("    - args: %r", args)
+
+    config_file_name = basename(args.registry_out_file.name)
+
+    config = {
+        "driver_config": {"device_address": str(args.address),
+                          "device_id": args.device_id},
+        "driver_type": "bacnet",
+        "registry_config": "config://registry_configs/{}".format(config_file_name)
+    }
+
+    jsonapi.dump(config, args.driver_out_file, indent=4)
 
     key_store = KeyStore()
     config_writer = DictWriter(args.registry_out_file,


### PR DESCRIPTION
# Description

Fixes proxy_grab_bacnet_config.py not writing a driver configuration file for a device (grab_bacnet_config.py produces a driver config file when using the --driver-out-file option, this option exists for the proxy version of the script but was not used)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested using multiple configurations of BACnet Proxy agents with BACnet devices on the network.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
