### PR TITLE
Add clarification on comments for 'database' parameter in sqlite historian config

### DIFF
--- a/docs/source/agent-framework/historian-agents/sql-historian/sql-historian.rst
+++ b/docs/source/agent-framework/historian-agents/sql-historian/sql-historian.rst
@@ -71,10 +71,14 @@ or
 Sqlite3 Specifics
 -----------------
 
-An Sqlite Historian provides a convenient solution for under powered
-systems. The database is parameter is a location on the file system. By
-default it is relative to the agents installation directory, however it
-will respect a rooted or relative path to the database.
+An Sqlite Historian provides a convenient solution for under powered systems. The database is a parameter to a location on the file system; 'database' should be a non-empty string.
+By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
+
+If 'database' does not have a rooted or relative path, the location of the database depends on whether the volttron platform is in secure mode. For more information on secure mode, see :ref:`Running-Agents-as-Unix-User`.
+In secure mode, the location will be under <install_dir>/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
+In regular mode, the location will be under <install_dir>/data for backward compatibility.
+
+The following is a minimal configuration file that uses a relative path to the database.
 
 ::
 

--- a/services/core/SQLHistorian/README.rst
+++ b/services/core/SQLHistorian/README.rst
@@ -91,10 +91,18 @@ YML format
 SQLite3
 ~~~~~~~
 
-An Sqlite historian provides a convenient solution for under powered
-systems. The database parameter is a location on the file system. By
-default it is relative to the agents installation directory, however it
-will respect a rooted or relative path to the database.
+An Sqlite Historian provides a convenient solution for under powered
+systems. The database is a parameter to a location on the file system; 'database' should be a non-empty string.
+By default, the location is relative to the agent's installation directory,
+however it will respect a rooted or relative path to the database.
+
+If 'database' does not have a rooted or relative path, the location of the database depends on whether the volttron
+platform is in secure mode.
+In secure mode, the location will be under <install_dir>/<agent name>.agent-data directory because this will be
+the only directory in which the agent will have write-access.
+In regular mode, the location will be under <install_dir>/data for backward compatibility.
+
+The following is a minimal configuration file that uses a relative path to the database.
 
 Configuration
 -------------

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -2,6 +2,9 @@
     "connection": {
         "type": "sqlite",
         "params": {
+            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
+            # in secure mode as this will be only directory in which agent will have write access
+            # In regular mode it will be under install_dir/data for backward compatibility
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -2,9 +2,19 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
-            # in secure mode as this will be only directory in which agent will have write access
-            # In regular mode it will be under install_dir/data for backward compatibility
+            # 'database' should be a non-empty string, which represents a location on the filesystem
+            # By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
+            # The following are two examples:
+
+            # Example 1 includes a path to the database:
+            # "my_data/historian_test.sqlite"
+
+            # Example 2 does not include a directory:
+            # "historian_test.sqlite"
+            # NOTE: In this example, the location of the database depends on whether the volttron platform is in secure mode.
+            # In secure mode, the location will be under install_dir/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
+            # In regular mode, the location will be under install_dir/data for backward compatibility.
+
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -2,19 +2,6 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # 'database' should be a non-empty string, which represents a location on the filesystem
-            # By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
-            # The following are two examples:
-
-            # Example 1 includes a path to the database:
-            # "my_data/historian_test.sqlite"
-
-            # Example 2 does not include a directory:
-            # "historian_test.sqlite"
-            # NOTE: In this example, the location of the database depends on whether the volttron platform is in secure mode.
-            # In secure mode, the location will be under install_dir/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
-            # In regular mode, the location will be under install_dir/data for backward compatibility.
-
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config.sqlite
+++ b/services/core/SQLHistorian/config.sqlite
@@ -2,9 +2,6 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
-            # in secure mode as this will be only directory in which agent will have write access
-            # In regular mode it will be under install_dir/data for backward compatibility
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -2,6 +2,9 @@
     "connection": {
         "type": "sqlite",
         "params": {
+            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
+            # in secure mode as this will be only directory in which agent will have write access
+            # In regular mode it will be under install_dir/data for backward compatibility
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -2,9 +2,19 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
-            # in secure mode as this will be only directory in which agent will have write access
-            # In regular mode it will be under install_dir/data for backward compatibility
+            # 'database' should be a non-empty string, which represents a location on the filesystem
+            # By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
+            # The following are two examples:
+
+            # Example 1 includes a path to the database:
+            # "my_data/historian_test.sqlite"
+
+            # Example 2 does not include a directory:
+            # "historian_test.sqlite"
+            # NOTE: In this example, the location of the database depends on whether the volttron platform is in secure mode.
+            # In secure mode, the location will be under install_dir/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
+            # In regular mode, the location will be under install_dir/data for backward compatibility.
+
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -2,19 +2,6 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # 'database' should be a non-empty string, which represents a location on the filesystem
-            # By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
-            # The following are two examples:
-
-            # Example 1 includes a path to the database:
-            # "my_data/historian_test.sqlite"
-
-            # Example 2 does not include a directory:
-            # "historian_test.sqlite"
-            # NOTE: In this example, the location of the database depends on whether the volttron platform is in secure mode.
-            # In secure mode, the location will be under install_dir/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
-            # In regular mode, the location will be under install_dir/data for backward compatibility.
-
             "database": "historian_test.sqlite"
         }
     },

--- a/services/core/SQLHistorian/config_device_data_filter.sqlite
+++ b/services/core/SQLHistorian/config_device_data_filter.sqlite
@@ -2,9 +2,6 @@
     "connection": {
         "type": "sqlite",
         "params": {
-            # if no directory is given, location will be under install_dir/<agent name>.agent-data directory
-            # in secure mode as this will be only directory in which agent will have write access
-            # In regular mode it will be under install_dir/data for backward compatibility
             "database": "historian_test.sqlite"
         }
     },


### PR DESCRIPTION
# Description

Fixes #2526 

Adds clarification on 'database' parameter that it should be a non-empty string, gives two examples, and revises the statements regarding the location of the database in secure vs regular mode. 

I tested creating a sqlite historian with an empty string for 'database' parameter and verified that no connection could be made since a location was not given:

```
# Configuration given to sqlite
{
    "connection": {
      "type": "sqlite",
      "params": {
        "database": ""
      }
    }
}

# Logs
20-12-04 22:09:46,842 (sqlhistorianagent-3.7.0 109) volttron.platform.dbutils.basedb DEBUG: kwargs for connect is {'database': '/home/volttron/.volttron/agents/6272c40a-5e5a-40c4-910d-5423772a2f73/sqlhistorianagent-3.7.0/sqlhistorianagent-3.7.0.agent-data/', 'detect_types': 3, 'timeout': 10}
2020-12-04 22:09:46,842 (sqlhistorianagent-3.7.0 109) volttron.platform.agent.base_historian DEBUG:

2020-12-04 22:09:46,871 (sqlhistorianagent-3.7.0 109) volttron.platform.dbutils.basedb ERROR: Could not connect to database. Raise ConnectionError
2020-12-04 22:09:46,871 (sqlhistorianagent-3.7.0 109) volttron.platform.agent.base_historian ERROR: Failed to setup historian!
Traceback (most recent call last):
  File "/code/volttron/volttron/platform/dbutils/basedb.py", line 121, in cursor
    self.__connection = self.__connect()
  File "/code/volttron/volttron/platform/dbutils/basedb.py", line 95, in <lambda>
    connect = lambda: dbapimodule.connect(**kwargs)
sqlite3.OperationalError: unable to open database file

```

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
