### PR TITLE
Fix install_agents.py to set filename to correct 'install_path'

### DIFF
--- a/volttron/platform/install_agents.py
+++ b/volttron/platform/install_agents.py
@@ -247,8 +247,7 @@ def install_agent(opts, publickey=None, secretkey=None, callback=None):
         install_agent_directory(opts, opts, opts.agent_config)
         return
 
-    aip = opts.aip
-    filename = opts.install_path
+    filename = install_path
     tag = opts.tag
     vip_identity = opts.vip_identity
     if opts.vip_address.startswith('ipc://'):


### PR DESCRIPTION
# Description

When installing agents using scripts/install_agent.py, the script will sometimes fail for certain agents (i.e. MasterDriver/PlatformDriver), because `filename` is set to opts.install_path, which sometimes can return None. More importantly, it appears that 'filename'  was intended to be set to another variable 'install_path' as inferred from this block of code: https://github.com/VOLTTRON/volttron/blob/develop/volttron/platform/install_agents.py#L241-L244

I also removed an unused variable, `aip`.

Fixes #2548  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Installed MasterDriver (which was the case that made scripts/install_agent.py fail) and observed successful installation. 

```
$ python scripts/install-agent.py -s services/core/MasterDriverAgent --vip-identity platform.driver --force -c services/core/MasterDriverAgent/master-driver.agent  --start
INFO:install-agent.py:Installing requirements for agent from services/core/MasterDriverAgent/requirements.txt.
{
    "agent_uuid": "3b0f794e-6362-4c69-ba5d-076dd34a1364",
    "starting": true,
    "started": true,
    "agent_pid": 30915
}

$ vctl status
  AGENT                  IDENTITY            TAG STATUS          HEALTH
c listeneragent-3.3      listeneragent-3.3_1     running [13494] GOOD
3 master_driveragent-4.0 platform.driver         running [30915] GOOD


```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code