### PR TITLE
Update Forward Historian guide in Multi-Platform Connection section

### DIFF
--- a/docs/source/deploying-volttron/multi-platform/forward-historian-deployment.rst
+++ b/docs/source/deploying-volttron/multi-platform/forward-historian-deployment.rst
@@ -4,83 +4,58 @@
 Forward Historian
 =================
 
-This guide describes a simple setup where one VOLTTRON instance collects data from a fake devices and sends to another
-instance .  Lets consider the following example.
+This guide describes a simple setup where one VOLTTRON instance collects data from a fake device and sends to another
+instance. Consider the following scenario:
 
-We are going to create two VOLTTRON instances and send data from one VOLTTRON instance running a fake driver(subscribing
-values from a fake device) and sending the values to the second VOLTTRON instance.
+We have two VOLTTRON instances that are configured with ZMQ, have no agents installed, and are currently running. One VOLTTRON instance will be known as the "source" instance; the other will be known as the "destination" instance.
+The "source" instance will run a fake driver that subscribes to values from a fake device; the source instance will then sends those values to the destination instance.
 
 
-VOLTTRON instance 1 forwards data to VOLTTRON instance 2
+VOLTTRON source instance configuration
 --------------------------------------------------------
 
+We will install the ForwardHistorian on the source instance, which will create the connection from the source instance to the destination instance.
+The Forward Historian can be found in the *services/core* directory.
+The default configuration file is services/core/ForwardHistorian/config.
+We will use this configuration file to create the ForwardHistorian agent. However, we need to modify the following fields:
 
-VOLTTRON instance 1 
-^^^^^^^^^^^^^^^^^^^
-
--  ``vctl shutdown –platform`` (if the platform is already working)
--  ``vcfg`` (this helps in configuring the volttron instance
-   http://volttron.readthedocs.io/en/releases-4.1/core_services/control/VOLTTRON-Config.html
-
-   -  Specify the IP of the machine: ``tcp://130.20.*.*:22916``
-   -  Specify the port you want to use
-   -  Specify if you want to run VC(Volttron Central) here or this this instance would be controlled 
-      by a VC and the IP and port of the VC
-
-      - Then install agents like Master Driver Agent with a fake driver for the instance.
-      - Install a listener agent so see the topics that are coming from the diver agent
-      - Then run the volttron instance by using the following command: ``./start-volttron``
-
-- Volttron authentication: We need to add the IP of the instance 2 in the `auth.config` file of the VOLTTRON agent.
-  This is done as follows:
-
-   -  ``vctl auth-add``
-   -  We specify the IP of the instance 2 and the credentials of the agent (read
-      :ref:`Agent Authentication <Agent-Authentication>`
-   -  For specifying authentication for all the agents , we specify ``/.*/``
-   -  This should enable authentication for all the volttron-instance based on the IP you specify here
-
-
-For this documentation, the topics from the driver agent will be send to the instance 2
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
--  We use the existing agent called the Forward Historian for this purpose which is available in service/core in the
-   VOLTTRON directory.
--  In the config file under the Forward Historian directory, we modify the following fields:
-
-   - Destination-vip: the IP of the volttron instance to which we have to forward the data to along with the port
+   - 'destination-vip': this should be the IP address and port of the destination instance which will receive data from the ForwardHistorian.
      number.  Example : ``tcp://130.20.*.*:22916``
-   - Destination-serverkey: The server key of the VOLTTRON instance to which we need to forward the data to.
-     This can be obtained at the VOLTTRON instance by typing ``vctl auth serverkey``
+   - 'destination-serverkey': The server key of the destination instance. The server key can be retrieved in two ways:
 
--  Service_topic_list: specify the topics you want to forward specifically instead of all the values.
--  Once the above values are set, your forwarder is all set .
--  You can create a script file for the same and execute the agent.
+       - On the destination instance, run the following command: ``vctl auth serverkey``
+       - If web is enabled on the destination instance, open a browser and open the url at 'http(s)://hostaddress:port/discovery/'. For example: ``https://172.28.5.1:8443/discovery/``
 
+With the configuration of ForwardHistorian set, install the ForwardHistorian agent by running the following command:
 
-VOLTTRON instance 2
-^^^^^^^^^^^^^^^^^^^
+.. code-block:: bash
 
--  ``vctl shutdown –platform`` (if the platform is already working)
--  ``volttron-cfg`` (this helps in configuring the volttron instance)
-   http://volttron.readthedocs.io/en/releases-4.1/core_services/control/VOLTTRON-Config.html
-
-   -  Specify the IP of the machine : ``tcp://130.20.*.*:22916``
-   -  Specify the port you want to use.
-   -  Install the listener agent (this will show the connection from instance 1 if its successful 
-      and then show all the topics from instance 1.
-
--  Volttron authentication: We need to add the IP of the instance 1 in the auth.config file of the VOLTTRON agent . This
-   is done as follows:
-
-   -  ``vctl auth-add``
-   -  We specify the IP of the instance 1 and the credentials of the agent
-   -  For specifying authentication for all the agents , we specify ``/.*/``
-   -  This should enable authentication for all the volttron-instance based on the IP you specify here 
+    python3 ./scripts/install-agent.py \
+    -s ~/<path to volttron code>/services/core/ForwardHistorian \
+    -c ~/<path to volttron code>/services/core/ForwardHistorian/config \
+    --start
 
 
-Listener Agent
-^^^^^^^^^^^^^^
+VOLTTRON destination instance configuration
+--------------------------------------------------------
 
-Run the listener agent on this instance to see the values being forwarded from instance 1.  Once the above setup is
-done, you should be able to see the values from instance 1 on the listener agent of instance 2.
+The destination instance needs to authenticate the source instance so that it can receive data from the source instance. To authenticate the source instance, we need an add an authentication record
+for the source instance by running the following command on the destination instance: ``vctl auth add``. This will open an interactive session that will prompt for input.
+Accept the defaults for all fields except for two:
+
+  - 'credentials': this should be the credentials key of the forward historian agent on the source instance; you can get the credentials key by running ``vctl auth list`` on the source instance and looking for the 'credentials' key under the forward historian agent index
+  - 'address': this should be the IP address of the source instance
+
+To verify that the source instance authentication was setup, run ``vctl auth list`` on the destination instance to view the authentication record that you just added.
+
+
+Sending messages from source to destination instance
+------------------------------------------------------------
+
+
+Now that we have setup the ForwardHistorian and thereby establishing connection between the source and destination instances, we can now send data
+from the source instance to the destination instance. By default, the Forward Historian will send all messages from the 'devices' topic on the source instance to the destination instance.
+In order to setup the 'devices' topic on the source instance, install the Master Driver Agent with a fake driver.
+
+To verify that the destination instance is receiving messages, install a Listener agent on the destination instance. Once installed,
+check the logs of the destination instance for data from the source instance's Forward Historian agent.

--- a/docs/source/developing-volttron/contributing-documentation.rst
+++ b/docs/source/developing-volttron/contributing-documentation.rst
@@ -33,7 +33,7 @@ Then, open your browser to the created local files:
 
 .. code-block:: bash
 
-   file:///home/<USER>/git/volttron/docs/build/html/overview/index.html
+   file:///home/<USER>/git/volttron/docs/build/html/index.html
 
 
 When complete, changes can be contributed back using the same process as code :ref:`contributions <Contributing-Code>`


### PR DESCRIPTION
# Description

After going through the current forward historian guide at https://volttron.readthedocs.io/en/develop/deploying-volttron/multi-platform/forward-historian-deployment.html#forward-historian-deployment, I found the guide hard to follow. Instead, I've changed the narrative of the guide to focus on only two things: 1) configuring a new Forward Historian Agent 2) setting up supporting Agents to verify that the Forward Historian is working. I've created two separate sections in the guide to emphasize this. 

Also, I've updated the local file path when building the docs locally through `make html`. It appears that the 'overview' directory is not created by `make html`. If the current path is entered on a browser, readthedocs does not render because the 'overview' directory does not exists. Removing that non-existent directory in the path will render the documentation on a browser.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Checked the output on my local machine by running ```make html``` on the docs directory. 
Screenshot of updated docs pages attached:

![Screen Shot 2021-01-11 at 3 16 23 PM](https://user-images.githubusercontent.com/6901848/104249281-f8cf8100-541f-11eb-9320-165621685f95.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
