### PR TITLE
Modified opts.connection to only be set when volttron is running.

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -2899,7 +2899,10 @@ def main(argv=sys.argv):
 
     opts.aip = aipmod.AIPplatform(opts)
     opts.aip.setup()
-    opts.connection = ControlConnection(opts.vip_address)
+
+    opts.connection = None
+    if utils.is_volttron_running(volttron_home):
+        opts.connection = ControlConnection(opts.vip_address)
 
     try:
         with gevent.Timeout(opts.timeout):


### PR DESCRIPTION
Initialized opts.connection to None
Modified opts.connection to only be set when volttron is running.
