### PR TITLE
WIP: Add automatic approval of CSR's to platform configuration

### DIFF
--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -1055,6 +1055,12 @@ def start_volttron_process(opts):
                     opts.web_ssl_key = certs.private_key_file(base_webserver_name)
                     opts.web_ssl_cert = certs.cert_file(base_webserver_name)
 
+            try:
+                if opts.auto_allow_csr == 'True':
+                    opts.auto_allow_csr = True
+            except AttributeError:
+                opts.auto_allow_csr = None
+
             _log.info("Starting master web service")
             services.append(MasterWebService(
                 serverkey=publickey, identity=MASTER_WEB,
@@ -1066,7 +1072,8 @@ def start_volttron_process(opts):
                 volttron_central_rmq_address=opts.volttron_central_rmq_address,
                 web_ssl_key=opts.web_ssl_key,
                 web_ssl_cert=opts.web_ssl_cert,
-                web_secret_key=opts.web_secret_key
+                web_secret_key=opts.web_secret_key,
+                auto_allow_csr=opts.auto_allow_csr
             ))
 
         ks_masterweb = KeyStore(KeyStore.get_agent_keystore_path(MASTER_WEB))
@@ -1197,6 +1204,12 @@ def main(argv=sys.argv):
     parser.add_argument(
         '--show-config', action='store_true',
         help=argparse.SUPPRESS)
+    parser.add_argument(
+        '--message-bus', action='store', default='zmq', dest='message_bus',
+        help='set message to be used. valid values are zmq and rmq')
+    parser.add_argument(
+        '--auto-allow-csr', action='store_true', dest='auto_allow_csr',
+        help='Set auto approval of CSR requests')
     parser.add_help_argument()
     parser.add_version_argument(version='%(prog)s ' + __version__)
 
@@ -1255,9 +1268,6 @@ def main(argv=sys.argv):
     agents.add_argument(
         '--setup-mode', action='store_true',
         help='Setup mode flag for setting up authorization of external platforms.')
-    parser.add_argument(
-        '--message-bus', action='store', default='zmq', dest='message_bus',
-        help='set message to be used. valid values are zmq and rmq')
     agents.add_argument(
         '--volttron-central-rmq-address', default=None,
         help='The AMQP address of a volttron central install instance')

--- a/volttron/platform/web/master_web_service.py
+++ b/volttron/platform/web/master_web_service.py
@@ -115,7 +115,7 @@ class MasterWebService(Agent):
 
     def __init__(self, serverkey, identity, address, bind_web_address,
                  volttron_central_address=None, volttron_central_rmq_address=None,
-                 web_ssl_key=None, web_ssl_cert=None, web_secret_key=None, **kwargs):
+                 web_ssl_key=None, web_ssl_cert=None, web_secret_key=None, auto_allow_csr=False, **kwargs):
         """
         Initialize the configuration of the base web service integration within the platform.
 
@@ -137,6 +137,7 @@ class MasterWebService(Agent):
         self.web_ssl_key = web_ssl_key
         self.web_ssl_cert = web_ssl_cert
         self._web_secret_key = web_secret_key
+        self._auto_allow_csr = auto_allow_csr
 
         # Maps from endpoint to peer.
         self.endpoints = {}
@@ -782,6 +783,9 @@ class MasterWebService(Agent):
             # We need reference to the object so we can change the behavior of
             # whether or not to have auto certs be created or not.
             self._csr_endpoints = CSREndpoints(self.core)
+            if self._auto_allow_csr:
+                _log.info("MasterWebService has enabled auto approval of CSR's")
+                self._csr_endpoints.auto_allow_csr = self._auto_allow_csr
             for rt in self._csr_endpoints.get_routes():
                 self.registeredroutes.append(rt)
 


### PR DESCRIPTION
# Description

Adds a new platform configuration `auto_allow_csr` to enable the automatic approval of CSR's using a platform config file, thus allowing a user to initialize a Volttron instance with this capability in addition to the current capability of enabling auto approval after the creation of an instance. 

Adds _auto_allow_csr as new attribute of MasterWebServce. 
 
NOTE: Although manually tested, I still need to create tests, update the Docs, and perhaps include a step in the platform wizard. Putting this PR out there now for feedback and questions.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested by creating two Volttron instances in which one has the auto_allow_csr configuration and then I created a VCP agent on the other Volttron instance. I checked the Web UI and saw that the CSR's were automatically approved.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
