### PR TITLE
Agents heartbeat autostart

### DIFF
--- a/volttron/platform/vip/agent/__init__.py
+++ b/volttron/platform/vip/agent/__init__.py
@@ -78,7 +78,7 @@ class Agent(object):
 
     def __init__(self, identity=None, address=None, context=None,
                  publickey=None, secretkey=None, serverkey=None,
-                 heartbeat_autostart=False, heartbeat_period=60,
+                 heartbeat_autostart=True, heartbeat_period=30,
                  volttron_home=os.path.abspath(platform.get_home()),
                  agent_uuid=None, enable_store=True,
                  enable_web=False, enable_channel=False,

--- a/volttron/platform/vip/agent/__init__.py
+++ b/volttron/platform/vip/agent/__init__.py
@@ -78,14 +78,19 @@ class Agent(object):
 
     def __init__(self, identity=None, address=None, context=None,
                  publickey=None, secretkey=None, serverkey=None,
+                 # Since heartbeat is now 100% tied to status on the vctl change the defaults
+                 # to auto start the heartbeat.
                  heartbeat_autostart=True, heartbeat_period=30,
-                 volttron_home=os.path.abspath(platform.get_home()),
+                 volttron_home=None,
                  agent_uuid=None, enable_store=True,
                  enable_web=False, enable_channel=False,
                  reconnect_interval=None, version='0.1', enable_fncs=False,
                  instance_name=None, message_bus=None,
                  volttron_central_address=None, volttron_central_instance_name=None):
 
+        if volttron_home is None:
+            volttron_home = os.path.abspath(platform.get_home())
+            
         try:
             self._version = version
 

--- a/volttron/platform/vip/agent/__init__.py
+++ b/volttron/platform/vip/agent/__init__.py
@@ -80,7 +80,7 @@ class Agent(object):
                  publickey=None, secretkey=None, serverkey=None,
                  # Since heartbeat is now 100% tied to status on the vctl change the defaults
                  # to auto start the heartbeat.
-                 heartbeat_autostart=True, heartbeat_period=30,
+                 heartbeat_autostart=True, heartbeat_period=60,
                  volttron_home=None,
                  agent_uuid=None, enable_store=True,
                  enable_web=False, enable_channel=False,

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -631,7 +631,7 @@ class PlatformWrapper:
                     if identity == PLATFORM_WEB:
                         capabilities = dict(allow_auth_modifications=None)
                     else:
-                        capabilities = dict(edit_config_stor=dict(identity="/.*/"))
+                        capabilities = dict(edit_config_store=dict(identity="/.*/"))
 
                     ks = KeyStore(KeyStore.get_agent_keystore_path(identity))
                     entry = AuthEntry(credentials=encode_key(decode_key(ks.public)),
@@ -642,7 +642,7 @@ class PlatformWrapper:
 
                 # Control connection needs to be added so that vctl can connect easily
                 identity = CONTROL_CONNECTION
-                capabilities = dict(edit_config_stor=dict(identity="/.*/"))
+                capabilities = dict(edit_config_store=dict(identity="/.*/"))
                 ks = KeyStore(KeyStore.get_agent_keystore_path(identity))
                 entry = AuthEntry(credentials=encode_key(decode_key(ks.public)),
                                   user_id=identity,


### PR DESCRIPTION
# Description

Heartbeat is tied to status for vctl therefore it is necessary for this to have all installed agents get their status reported correctly.

Replaces: #2576 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
