### PR TITLE
Fix vctl install

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -2925,9 +2925,6 @@ def main(argv=sys.argv):
         _stderr.write("Invalid command: '{}' or command requires additional arguments\n".format(opts.command))
         parser.print_help()
         return 1
-    # except Exception as exc:
-    #     print_tb = traceback.print_exc
-    #     error = str(exc)
     finally:
         # make sure the connection to the server is closed when this scriopt is about to exit.
         if opts.connection:

--- a/volttron/platform/install_agents.py
+++ b/volttron/platform/install_agents.py
@@ -153,7 +153,7 @@ def install_agent_directory(opts):
 
     if opts.tag:
         cmds.extend(["--tag", opts.tag])
-    print(cmds)
+
     out = execute_command(cmds, env=env, logger=_log,
                           err_prefix="Error installing agent")
 

--- a/volttron/platform/install_agents.py
+++ b/volttron/platform/install_agents.py
@@ -85,7 +85,7 @@ def install_requirements(agent_source):
             sys.exit(1)
 
 
-def install_agent_directory(opts, package, agent_config):
+def install_agent_directory(opts):
     """
     The main installation method for installing the agent on the correct local
     platform instance.
@@ -120,6 +120,7 @@ def install_agent_directory(opts, package, agent_config):
             # Note we don't remove the agent here because if we do that will
             # not allow us to update without losing the keys.  The
             # install_agent method either installs or upgrades the agent.
+    agent_config = opts.agent_config
 
     if agent_config is None:
         agent_config = {}
@@ -144,6 +145,7 @@ def install_agent_directory(opts, package, agent_config):
     add_files_to_package(opts.package, {'config_file': config_file})
     env = os.environ.copy()
 
+
     if agent_exists:
         cmds = [volttron_control, "--json", "upgrade", opts.vip_identity, opts.package]
     else:
@@ -151,7 +153,7 @@ def install_agent_directory(opts, package, agent_config):
 
     if opts.tag:
         cmds.extend(["--tag", opts.tag])
-
+    print(cmds)
     out = execute_command(cmds, env=env, logger=_log,
                           err_prefix="Error installing agent")
 
@@ -244,9 +246,10 @@ def install_agent(opts, publickey=None, secretkey=None, callback=None):
         install_path = opts.wheel
 
     if os.path.isdir(install_path):
-        install_agent_directory(opts, opts, opts.agent_config)
-        return
-
+        install_agent_directory(opts)
+        if opts.connection is not None:
+            opts.connection.server.core.stop()
+        sys.exit(0)
     filename = install_path
     tag = opts.tag
     vip_identity = opts.vip_identity
@@ -320,10 +323,10 @@ def install_agent(opts, publickey=None, secretkey=None, callback=None):
     name = opts.connection.call('agent_name', agent_uuid)
     _stdout.write('Installed {} as {} {}\n'.format(filename, agent_uuid, name))
 
-    # Need to use a callback here rather than a return value.  I am not 100%
-    # sure why this is the reason for allowing our tests to pass.
-    if callback:
-        callback(agent_uuid)
+    opts.connection.server.core.stop()
+
+    # This is where we need to exit so the script doesn't continue after installation.
+    sys.exit(0)
 
 
 def add_install_agent_parser(add_parser_fn, has_restricted):

--- a/volttrontesting/platform/test_vctl_commands.py
+++ b/volttrontesting/platform/test_vctl_commands.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import tempfile
 
 import gevent
@@ -8,7 +9,51 @@ from gevent import subprocess
 from volttron.platform import get_examples
 import sys
 
+from volttron.platform import jsonapi
+from volttron.platform.agent.utils import execute_command
 from volttrontesting.utils.platformwrapper import with_os_environ
+
+
+@pytest.mark.control
+def test_install_agent_config_not_empty(volttron_instance):
+    listener_agent_dir = get_examples("ListenerAgent")
+    listener_agent_config = Path(listener_agent_dir).joinpath("config")
+    with with_os_environ(volttron_instance.env):
+        cmds = ["vctl", '--json', 'install', listener_agent_dir, '--agent-config',
+                listener_agent_config]
+        response = execute_command(cmds, volttron_instance.env)
+
+        json_response = jsonapi.loads(response)
+
+        agent_uuid = json_response['agent_uuid']
+        config_path = Path(volttron_instance.volttron_home).joinpath(
+            f'agents/{agent_uuid}/listeneragent-3.3/listeneragent-3.3.dist-info/config')
+        with open(config_path) as fp:
+            with open(listener_agent_config) as fp2:
+                assert fp2.read() == fp.read()
+
+        volttron_instance.remove_all_agents()
+
+
+@pytest.mark.control
+def test_install_agent_config_empty(volttron_instance):
+    listener_agent_dir = get_examples("ListenerAgent")
+
+    with with_os_environ(volttron_instance.env):
+        cmds = ["vctl", '--json', 'install', listener_agent_dir]
+
+        response = execute_command(cmds, volttron_instance.env)
+
+        json_response = jsonapi.loads(response)
+
+        agent_uuid = json_response['agent_uuid']
+        config_path = Path(volttron_instance.volttron_home).joinpath(
+            f'agents/{agent_uuid}/listeneragent-3.3/listeneragent-3.3.dist-info/config')
+        with open(config_path) as fp:
+            config_data = jsonapi.loads(fp.read())
+            assert {} == config_data
+
+        volttron_instance.remove_all_agents()
 
 
 @pytest.mark.control


### PR DESCRIPTION
# Description

Installing using vctl install --agent-config was not using the config file instead it was making an empty config in the agent directory.

Fixes # jira-356

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests to test the installation with an empty or non-existent config file as well as one with a listener config

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
