### PR TITLE
Fix Documentation for RabbitMQ installation steps 

### DIFF
--- a/docs/source/introduction/platform-install.rst
+++ b/docs/source/introduction/platform-install.rst
@@ -181,8 +181,15 @@ Proceed to step 4.
 Steps for RabbitMQ
 ------------------
 
+Step 1 - Install Required Packages and Activate the Virtual Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Step 1 - Install Erlang packages
+Setting up RabbmitMQ requires additional steps; but before running those steps we still need to install the required
+packages and activate the virtual environment just as we did in the Steps for ZeroMQ. To do so, see :ref:`ZeroMQ-Install`.
+Once finished, proceed to the next step.
+
+
+Step 2 - Install Erlang packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For RabbitMQ based VOLTTRON, some of the RabbitMQ specific software packages have to be installed.
@@ -215,9 +222,9 @@ Example command:
 Alternatively
 """""""""""""
 
-You can download and install Erlang from [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html).
+You can download and install Erlang from `Erlang Solutions <https://www.erlang-solutions.com/resources/download.html>`_.
 Please include OTP/components - ssl, public_key, asn1, and crypto.
-Also lock your version of Erlang using the [yum-plugin-versionlock](https://access.redhat.com/solutions/98873)
+Also lock your version of Erlang using the `yum-plugin-versionlock <https://access.redhat.com/solutions/98873>`_.
 
 .. note::
     Currently VOLTTRON only officially supports specific versions of Erlang for each operating system:
@@ -227,11 +234,11 @@ Also lock your version of Erlang using the [yum-plugin-versionlock](https://acce
             `here <https://dl.bintray.com/rabbitmq-erlang/rpm/erlang>`_
 
 
-Step 2 - Configure hostname
+Step 3 - Configure hostname
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Make sure that your hostname is correctly configured in /etc/hosts.
-See (<https://stackoverflow.com/questions/24797947/os-x-and-rabbitmq-error-epmd-error-for-host-xxx-address-cannot-connect-to-ho>).
+See this `StackOverflow post <https://stackoverflow.com/questions/24797947/os-x-and-rabbitmq-error-epmd-error-for-host-xxx-address-cannot-connect-to-ho>`_.
 If you are testing with VMs make please make sure to provide unique host names for each of the VMs you are using.
 
 The hostname should be resolvable to a valid IP when running on bridged mode. RabbitMQ checks for this during initial
@@ -244,7 +251,7 @@ to connect to empd (port 4369) on <hostname>."
     (/var/log/rabbitmq/rabbitmq@hostname.log)
 
 
-Step 3 - Bootstrap the environment
+Step 4 - Bootstrap the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
@@ -262,11 +269,12 @@ documentation refers to the directory `<install dir>/rabbitmq_server-3.7.7` as `
    There are many additional :ref:`options for bootstrap.py <Bootstrap-Process>` for including dependencies, altering
    the environment, etc.
 
-You can check if the RabbitMQ server is installed by checking its status:
+By bootstrapping the environment for RabbitMQ, an environmental variable $RABBITMQ_HOME is created for your convenience.
+Thus, you can use $RABBITMQ_HOME to see if the RabbitMQ server is installed by checking its status:
 
 .. code-block:: bash
 
-    service rabbitmq status
+    $RABBITMQ_HOME/sbin/rabbitmqctl status
 
 .. note::
 
@@ -280,18 +288,6 @@ You can check if the RabbitMQ server is installed by checking its status:
     $RABBITMQ_HOME/sbin/rabbitmqctl status
 
 
-Step 4 - Activate the environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-    source env/bin/activate
-
-.. note::
-
-    You can deactivate the environment at any time by running :bash:`deactivate`.
-
-
 Step 5 - Configure RabbitMQ setup for VOLTTRON
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -299,9 +295,8 @@ Step 5 - Configure RabbitMQ setup for VOLTTRON
 
     vcfg --rabbitmq single [optional path to rabbitmq_config.yml]
 
-Refer to [examples/configurations/rabbitmq/rabbitmq_config.yml](examples/configurations/rabbitmq/rabbitmq_config.yml)
-for a sample configuration file.  At a minimum you will need to provide the host name and a unique common-name
-(under certificate-data) in the configuration file.
+A sample configuration file can be found in the VOLTTRON repository in **examples/configurations/rabbitmq/rabbitmq_config.yml**.
+At a minimum you will need to provide the host name and a unique common-name (under certificate-data) in the configuration file.
 
 .. note::
 


### PR DESCRIPTION
# Description

Updates docs for installing RMQ. 
* Fixes hyperlinks to use RST syntax instead of Markdown
* Updates how to check RMQ status by using the RABBIT_MQ env variable, which is given by running bootstrap.py --rabbmitq
* Reemphasizes need to initially bootstrap and activate the virtual environment
* Removes unnecessary step of activating the environment since it was already done in Step 1 
* Removes illegal (Markdown) hyperlink to examples directory 

## Type of change
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran make html and checked output on Browser. See screenshots:

![Screen Shot 2021-01-26 at 12 32 37 PM](https://user-images.githubusercontent.com/6901848/105901689-94d9ba80-5fd2-11eb-891c-68cf1c0c1617.png)
![Screen Shot 2021-01-26 at 12 33 00 PM](https://user-images.githubusercontent.com/6901848/105901727-a1f6a980-5fd2-11eb-98f9-96c642a181ee.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
