### PR TITLE
Updated Command Line Cert Handling in Demo Documentation

### DIFF
--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -207,7 +207,8 @@ Go back to the terminal and check the status of Volttron Central Platform agent.
 
 You can also check the status of pending CSRs via the command line.
 
-After starting the Volttron Central Platform agent, use the auth remote subparser to list the current pending certs.
+After starting the Volttron Central Platform agent,
+use the auth remote sub-command's ``list`` to display the current pending certs.
 
 .. code-block:: console
 
@@ -226,7 +227,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.central.platform.agent
 
-Run the list command again, and see that the CSR has been approved.
+Run the ``list`` command again, and see that the CSR has been approved.
 
 .. code-block:: console
 
@@ -330,7 +331,7 @@ Approve the pending ZMQ credential using the ``approve`` command.
 
     vctl auth remote approve 68ef33c4-97bc-4e1b-b5f6-2a6049993b65
 
-Run the list command again, and see that the credential has been approved.
+Run the ``list`` command again, and see that the credential has been approved.
 
 .. code-block:: console
 
@@ -371,6 +372,7 @@ Pending Authorization header.
 
 Accept this credential in the same method as before.
 
+
 To accept via the command line:
 
 .. code-block:: console
@@ -392,7 +394,7 @@ Approve the pending ZMQ credential using the ``approve`` command.
 
     vctl auth remote approve fb30249d-b267-4bdd-b29a-d9112e6a6082
 
-Run the list command again, and see that the credential has been approved.
+Run the ``list`` command again, and see that the credential has been approved.
 
 .. code-block:: console
 
@@ -538,7 +540,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.collector2.forwarderagent-5.1_1
 
-Run the list command again, and see that the CSR has been approved.
+Run the ``list`` command again, and see that the CSR has been approved.
 
 .. code-block:: console
 
@@ -597,7 +599,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.collector2.forwarderagent-5.1_1
 
-Run the list command again, and see that the CSR has been approved.
+Run the ``list`` command again, and see that the CSR has been approved.
 
 .. code-block:: console
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -205,6 +205,33 @@ Approve the CSR request to allow authenticated SSL based connection to the "cent
 
 Go back to the terminal and check the status of Volttron Central Platform agent. It should be set to "GOOD".
 
+You can also check the status of pending CSRs via the command line.
+
+After starting the Volttron Central Platform agent, use the auth remote subparser to list the current pending certs.
+
+.. code-block:: console
+
+    vctl auth remote list
+
+You will see the pending CSR appear in the list.
+
+.. code-block:: console
+
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 PENDING
+
+Approve the pending CSR using the ``approve`` command.
+
+.. code-block:: console
+
+    vctl auth remote approve central.central.platform.agent
+
+Run the list command again, and see that the CSR has been approved.
+
+.. code-block:: console
+
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 APPROVED
 
 Node-ZMQ Instance Setup
 -----------------------
@@ -283,17 +310,33 @@ Accept the credential in the same method as a CSR.
 
 Using the command line:
 
-On the "node-zmq" box execute this command and grab the public key of the VCP agent.
+As with the pending CSR, list the current pending certs and credentials.
 
 .. code-block:: console
 
-  vctl auth publickey
+    vctl auth remote list
 
-Add auth entry corresponding to VCP agent on "central" instance using the below command. Replace the user id value and credentials value appropriately before running
+You will see the pending ZMQ credential has been added to the list.
 
 .. code-block:: console
 
-  vctl auth add --user_id <any unique user id. for example zmq_node_vcp> --credentials <public key of vcp on zmq node>
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65 127.0.0.1      PENDING
+
+Approve the pending ZMQ credential using the ``approve`` command.
+
+.. code-block:: console
+
+    vctl auth remote approve 68ef33c4-97bc-4e1b-b5f6-2a6049993b65
+
+Run the list command again, and see that the credential has been approved.
+
+.. code-block:: console
+
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65 127.0.0.1      APPROVED
 
 
 Complete similar steps to start a forwarder agent that connects to "central" instance. Modify the configuration in
@@ -328,21 +371,35 @@ Pending Authorization header.
 
 Accept this credential in the same method as before.
 
-
-To accept the credential using the command line:
-
-Grab the public key of the forwarder agent.
+To accept via the command line:
 
 .. code-block:: console
 
-  vctl auth publickey
+    vctl auth remote list
 
-
-Add auth entry corresponding to VCP agent on **central** instance.
+You will see the pending ZMQ credential has been added to the list.
 
 .. code-block:: console
 
-  vctl auth add --user_id <any unique user id. for example zmq_node_forwarder> --credentials <public key of forwarder on zmq node>
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65 127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082 127.0.0.1      PENDING
+
+Approve the pending ZMQ credential using the ``approve`` command.
+
+.. code-block:: console
+
+    vctl auth remote approve fb30249d-b267-4bdd-b29a-d9112e6a6082
+
+Run the list command again, and see that the credential has been approved.
+
+.. code-block:: console
+
+    USER_ID                              ADDRESS        STATUS
+    central.central.platform.agent       192.168.56.101 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65 127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082 127.0.0.1      APPROVED
 
 
 In either case, you should start seeing messages from "collector1" instance on the "central" instance's VOLTTRON log now.
@@ -457,8 +514,39 @@ instance.
 
 .. image:: files/remote_rmq_pending.png
 
-
 Approve the CSR request to allow authenticated SSL based connection to the "central" instance.
+
+
+As before, this can be done via the command line as follows:
+
+.. code-block:: console
+
+    vctl auth remote list
+
+.. code-block:: console
+
+    USER_ID                                 ADDRESS        STATUS
+    central.central.platform.agent          192.168.56.101 APPROVED
+    central.collector2.forwarderagent-5.1_1 192.168.56.101 PENDING
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65    127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082    127.0.0.1      APPROVED
+
+
+Approve the pending CSR using the ``approve`` command.
+
+.. code-block:: console
+
+    vctl auth remote approve central.collector2.forwarderagent-5.1_1
+
+Run the list command again, and see that the CSR has been approved.
+
+.. code-block:: console
+
+    USER_ID                                 ADDRESS        STATUS
+    central.central.platform.agent          192.168.56.101 APPROVED
+    central.collector2.forwarderagent-5.1_1 192.168.56.101 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65    127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082    127.0.0.1      APPROVED
 
 Now go back to the terminal and check the status of Volttron Central Platform agent. It should be set to "GOOD".
 
@@ -486,6 +574,39 @@ instance.
 Approve the CSR request to allow authenticated SSL based connection to the "central" instance.
 
 .. image:: files/rmq_remote_forwarder_accepted.png
+
+If using command line for this process:
+
+.. code-block:: console
+
+    vctl auth remote list
+
+.. code-block:: console
+
+    USER_ID                                 ADDRESS        STATUS
+    central.central.platform.agent          192.168.56.101 APPROVED
+    central.collector2.platform.agent       192.168.56.103 APPROVED
+    central.collector2.forwarderagent-5.1_1 192.168.56.103 PENDING
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65    127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082    127.0.0.1      APPROVED
+
+
+Approve the pending CSR using the ``approve`` command.
+
+.. code-block:: console
+
+    vctl auth remote approve central.collector2.forwarderagent-5.1_1
+
+Run the list command again, and see that the CSR has been approved.
+
+.. code-block:: console
+
+    USER_ID                                 ADDRESS        STATUS
+    central.central.platform.agent          192.168.56.101 APPROVED
+    central.collector2.platform.agent       192.168.56.103 APPROVED
+    central.collector2.forwarderagent-5.1_1 192.168.56.103 APPROVED
+    68ef33c4-97bc-4e1b-b5f6-2a6049993b65    127.0.0.1      APPROVED
+    fb30249d-b267-4bdd-b29a-d9112e6a6082    127.0.0.1      APPROVED
 
 Now go back to the terminal and check the status of forwarder agent. It should be set to "GOOD".
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -300,6 +300,7 @@ connection. You will need to add the public key of VCP agent on the "central" in
 At this point, you can either accept the connection through the admin page or the command line.
 
 Using the admin page:
+^^^^^^^^^^^^^^^^^^^^
 
 Navigate back to the platform web admin authentication page. You should see a pending request under the ZMQ Keys Pending
 Authorization header.
@@ -310,6 +311,7 @@ Accept the credential in the same method as a CSR.
 
 
 Using the command line:
+^^^^^^^^^^^^^^^^^^^^^^
 
 As with the pending CSR, list the current pending certs and credentials.
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -9,7 +9,8 @@ This guide describes the setup process for a multi-platform connection that has 
 instance to a single "central" instance for storage.  It will also have a Volttron Central agent running on the
 "central" instance and Volttron Central Platform agents on all 3 instances and connected to "central" instance to
 provide operational status of it's instance to the "central" instance. For this document "node" will be used
-interchangeably with VOLTTRON instance.
+interchangeably with VOLTTRON instance. The authentication of remote connections can be performed either using 
+admin web interface or using command line interface. We will demonstrate both the approaches.
 
 Node Setup
 ----------
@@ -196,6 +197,9 @@ request to the web interface.
 
   vctl start --tag vcp
 
+Using the web interface:
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 Now go to the platform web admin page to check if there is a new pending CSR request. You will see a "PENDING" request
 from "central.central.platform.agent"
 
@@ -205,7 +209,10 @@ Approve the CSR request to allow authenticated SSL based connection to the "cent
 
 Go back to the terminal and check the status of Volttron Central Platform agent. It should be set to "GOOD".
 
-You can also check the status of pending CSRs via the command line.
+Using command line:
+^^^^^^^^^^^^^^^^^^^
+
+Alternatively, you can also check the status of pending CSRs via the command line.
 
 After starting the Volttron Central Platform agent,
 use the auth remote sub-command's ``list`` to display the current pending certs.
@@ -365,9 +372,10 @@ Install and start forwarder agent.
   python scripts/install-agent.py -s services/core/ForwardHistorian -c services/core/ForwardHistorian/rmq_config.yml --start
 
 
-To accept the credential using the admin page:
+Using the admin page:
+^^^^^^^^^^^^^^^^^^^^^
 
-Navigate back to the platform web admin authentication page. You should see another pending request under the ZMQ Keys
+To accept the credential, navigate back to the platform web admin authentication page. You should see another pending request under the ZMQ Keys
 Pending Authorization header.
 
 .. image:: files/zmq_pending_credential_2.png
@@ -375,7 +383,10 @@ Pending Authorization header.
 Accept this credential in the same method as before.
 
 
-To accept via the command line:
+Using the command line:
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To accept the credential via the command line,
 
 .. code-block:: console
 
@@ -513,6 +524,11 @@ Start Volttron Central Platform on this platform manually.
 
   vctl start --tag vcp
 
+Accept the pending CSR request.
+
+Using the admin page:
+^^^^^^^^^^^^^^^^^^^^^
+
 Go the master admin authentication page and check if there is a new pending CSR request from VCP agent of "collector2"
 instance.
 
@@ -520,6 +536,9 @@ instance.
 
 Approve the CSR request to allow authenticated SSL based connection to the "central" instance.
 
+
+Using the command line:
+^^^^^^^^^^^^^^^^^^^^^^^
 
 As before, this can be done via the command line as follows:
 
@@ -570,6 +589,9 @@ Start forwarder agent.
 
   python scripts/install-agent.py -s services/core/ForwardHistorian -c services/core/ForwardHistorian/rmq_config.yml --start
 
+Using the admin page:
+^^^^^^^^^^^^^^^^^^^^
+
 Go the master admin authentication page and check if there is a new pending CSR request from forwarder agent of "collector2"
 instance.
 
@@ -578,6 +600,9 @@ instance.
 Approve the CSR request to allow authenticated SSL based connection to the "central" instance.
 
 .. image:: files/rmq_remote_forwarder_accepted.png
+
+Using the command line:
+^^^^^^^^^^^^^^^^^^^^^^^
 
 If using command line for this process:
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -165,6 +165,9 @@ Start VOLTTRON instance and check if the agents are installed.
   ./start-volttron
   vctl status
 
+Using the web interface:
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 Open browser and go to the platform web admin authentication page `https://central:8443/index.html` to accept/reject
 incoming certificate signing request (CSR) from other platforms.
 
@@ -196,9 +199,6 @@ request to the web interface.
 .. code-block:: console
 
   vctl start --tag vcp
-
-Using the web interface:
-^^^^^^^^^^^^^^^^^^^^^^^^
 
 Now go to the platform web admin page to check if there is a new pending CSR request. You will see a "PENDING" request
 from "central.central.platform.agent"

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-multi-bus.rst
@@ -227,7 +227,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.central.platform.agent
 
-Run the ``list`` command again, and see that the CSR has been approved.
+Run the ``list`` command again to verify that the CSR has been approved.
 
 .. code-block:: console
 
@@ -331,7 +331,7 @@ Approve the pending ZMQ credential using the ``approve`` command.
 
     vctl auth remote approve 68ef33c4-97bc-4e1b-b5f6-2a6049993b65
 
-Run the ``list`` command again, and see that the credential has been approved.
+Run the ``list`` command again to verify that the credential has been approved.
 
 .. code-block:: console
 
@@ -394,7 +394,7 @@ Approve the pending ZMQ credential using the ``approve`` command.
 
     vctl auth remote approve fb30249d-b267-4bdd-b29a-d9112e6a6082
 
-Run the ``list`` command again, and see that the credential has been approved.
+Run the ``list`` command again to verify that the credential has been approved.
 
 .. code-block:: console
 
@@ -540,7 +540,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.collector2.forwarderagent-5.1_1
 
-Run the ``list`` command again, and see that the CSR has been approved.
+Run the ``list`` command again to verify that the CSR has been approved.
 
 .. code-block:: console
 
@@ -599,7 +599,7 @@ Approve the pending CSR using the ``approve`` command.
 
     vctl auth remote approve central.collector2.forwarderagent-5.1_1
 
-Run the ``list`` command again, and see that the CSR has been approved.
+Run the ``list`` command again to verify that the CSR has been approved.
 
 .. code-block:: console
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-rabbitmq-deployment.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-rabbitmq-deployment.rst
@@ -213,7 +213,7 @@ upstream servers on the downstream server and make the VOLTTRON exchange
 
             vctl auth remote approve volttron2.volttron1.federation
 
-        Run the ``list`` command again, and see that the CSR has been approved.
+        Run the ``list`` command again to verify that the CSR has been approved.
 
         .. code-block:: console
 
@@ -490,7 +490,7 @@ Please note that each instance should have a unique instance name.
 
         vctl auth remote approve volttron2.volttron1.shovelvolttron2
 
-    Run the ``list`` command again, and see that the CSR has been approved.
+    Run the ``list`` command again to verify that the CSR has been approved.
 
     .. code-block:: console
 

--- a/docs/source/deploying-volttron/multi-platform/multi-platform-rabbitmq-deployment.rst
+++ b/docs/source/deploying-volttron/multi-platform/multi-platform-rabbitmq-deployment.rst
@@ -192,6 +192,35 @@ upstream servers on the downstream server and make the VOLTTRON exchange
 
         .. image:: files/csr_accepted_federation.png
 
+
+        You can also find and accept the pending CSR via the command line, using the vctl auth remote sub-commands.
+
+        First list the pending certs and credentials.
+
+        .. code-block:: console
+
+            vctl auth remote list
+
+        .. code-block:: console
+
+            USER_ID                                 ADDRESS        STATUS
+            volttron2.volttron1.federation          172.20.0.2     PENDING
+
+
+        Approve the pending CSR using the ``approve`` command.
+
+        .. code-block:: console
+
+            vctl auth remote approve volttron2.volttron1.federation
+
+        Run the ``list`` command again, and see that the CSR has been approved.
+
+        .. code-block:: console
+
+            USER_ID                                 ADDRESS        STATUS
+            volttron2.volttron1.federation          172.20.0.2     APPROVED
+
+
     c.  Create a user in the upstream server (publisher) and provide it access to the virtual host of the upstream RabbitMQ server.
         The username should take the form of <instance name of local><instance name of downstream>.federation.
         For example, if the downstream server name is "volttron1", and instance of local instance is "volttron2" then the instance name would be "volttron2.volttron1.federation".
@@ -440,6 +469,34 @@ Please note that each instance should have a unique instance name.
 
 
     Accept the incoming CSR request from "volttron1" instance.
+
+    As before, you can find and accept the pending CSR via the command line, using the vctl auth remote sub-commands.
+
+    First list the pending certs and credentials.
+
+    .. code-block:: console
+
+        vctl auth remote list
+
+    .. code-block:: console
+
+        USER_ID                                 ADDRESS        STATUS
+        volttron2.volttron1.shovelvolttron2     172.20.0.2     PENDING
+
+
+    Approve the pending CSR using the ``approve`` command.
+
+    .. code-block:: console
+
+        vctl auth remote approve volttron2.volttron1.shovelvolttron2
+
+    Run the ``list`` command again, and see that the CSR has been approved.
+
+    .. code-block:: console
+
+        USER_ID                                 ADDRESS        STATUS
+        volttron2.volttron1.shovelvolttron2     172.20.0.2     APPROVED
+
 
     .. image:: files/csr_accepted.png
 

--- a/docs/source/deploying-volttron/secure-deployment-considerations.rst
+++ b/docs/source/deploying-volttron/secure-deployment-considerations.rst
@@ -129,7 +129,7 @@ Limit Access to RPC Methods Using Capabilities
 RPC enabled methods provide convenient interfaces between agents.
 When they are unrestricted however, they open up the potential for malicious agents
 to cause harm to your system. The best way to prevent this is through the use of capabilities.
-A capability is a user defined arbitary string used by an agent to describe its exported RPC method.
+A capability is a user defined arbitrary string used by an agent to describe its exported RPC method.
 It is used to limit the access to that RPC method to only those agents who have that capability listed in
 their authentication record.
 


### PR DESCRIPTION
Modified demos that used the web based cert authorization to include an optional method using the new auth remote sub-commands.