### PR TITLE
Added default permissions to federation user in the upstream instance

### DIFF
--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -430,6 +430,9 @@ class AuthService(Agent):
             try:
                 self._certs.approve_csr(user_id)
                 permissions = self.core.rmq_mgmt.get_default_permissions(user_id)
+
+                if "federation" in user_id:  # federation needs more than the current default permissions # TODO: Fix authorization in rabbitmq
+                    permissions = dict(configure=".*", read=".*", write=".*")
                 self.core.rmq_mgmt.create_user_with_permissions(user_id, permissions, True)
                 _log.debug("Created cert and permissions for user: {}".format(user_id))
             # Stores error message in case it is caused by an unexpected failure

--- a/volttron/utils/rmq_setup.py
+++ b/volttron/utils/rmq_setup.py
@@ -1059,7 +1059,7 @@ def _prompt_csr_request(rmq_user, host, type, verbose=False):
 
         remote_addr = prompt_response(prompt, default=remote_https_address)
         parsed_address = urlparse(remote_addr)
-        if parsed_address.scheme in ('https',):
+        if parsed_address.scheme not in ('https',):
             raise IOError(f"Remote web interface is not valid: {parsed_address}. Please check and try again")
 
         # request CSR from remote host


### PR DESCRIPTION
# Description
The federation user on upstream instance is getting created with insufficient permissions. Giving it full default permissions for now.


Fixes # Jira ticket number VOLTDEV-385

## Type of change

