### PR TITLE
Rtd pages for ops agents readme.md files

### DIFF
--- a/docs/source/api_doc_config.yml
+++ b/docs/source/api_doc_config.yml
@@ -9,3 +9,6 @@ services:
         - IEEE2030_5Agent
     file_excludes:
         - CrateHistorian/scripts/*
+ops:
+    path: services/ops
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -138,13 +138,22 @@ at our bi-weekly office-hours and on Slack. To be invited to office-hours or sla
    platform-features/security/volttron-security
 
 .. toctree::
-   :caption: VOLTTRON Core Agents
+   :caption: VOLTTRON Core Service Agents
    :hidden:
    :titlesonly:
    :maxdepth: 2
    :glob:
 
    volttron-api/services/*/modules
+
+.. toctree::
+   :caption: VOLTTRON Core Operations Agents
+   :hidden:
+   :titlesonly:
+   :maxdepth: 2
+   :glob:
+
+   volttron-api/ops/*/modules
 
 .. toctree::
    :caption: VOLTTRON Topics


### PR DESCRIPTION
Included ops agents' readme.md files into readthedocs. 
jira_376