### PR TITLE
Fix Integ tests for Security features 

### DIFF
--- a/volttron/platform/__init__.py
+++ b/volttron/platform/__init__.py
@@ -284,3 +284,19 @@ def build_vip_address_string(vip_root, serverkey, publickey, secretkey):
         raise ValueError('Invalid vip root specified!')
 
     return root
+
+
+def update_volttron_script_path(path: str) -> str:
+    """
+    Assumes that path's current working directory is in the root directory of the volttron codebase.
+
+    Prepend 'VOLTTRON_ROOT' to internal volttron script if 'VOLTTRON_ROOT' is set and return new path;
+    otherwise, return original path
+    :param path: relative path to the internal volttron script
+    :return: updated path to volttron script
+    """
+    if os.environ['VOLTTRON_ROOT']:
+        args = path.split("/")
+        path = f"{os.path.join(os.environ['VOLTTRON_ROOT'], *args)}"
+    _log.debug(f"Path to script: {path}")
+    return path

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -74,6 +74,7 @@ from .packages import UnpackedPackage
 from .vip.agent import Agent
 from .auth import AuthFile, AuthEntry, AuthFileEntryAlreadyExists
 from volttron.utils.rmq_mgmt import RabbitMQMgmt
+from volttron.platform import update_volttron_script_path
 
 try:
     from volttron.restricted import auth
@@ -236,7 +237,7 @@ class SecureExecutionEnvironment(object):
 
     def stop(self):
         if self.process.poll() is None:
-            cmd = ["sudo", "scripts/secure_stop_agent.sh", self.agent_user, str(self.process.pid)]
+            cmd = ["sudo", update_volttron_script_path("scripts/secure_stop_agent.sh"), self.agent_user, str(self.process.pid)]
             _log.debug("In aip secureexecutionenv {}".format(cmd))
             process = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
             stdout, stderr = process.communicate()

--- a/volttrontesting/platform/security/test_aip_security.py
+++ b/volttrontesting/platform/security/test_aip_security.py
@@ -1,19 +1,15 @@
 import pwd
-from datetime import datetime
-
 import gevent
 import pytest
+
 from mock import MagicMock
 
-from volttron.platform import get_home, is_rabbitmq_available
-from volttron.platform import get_services_core, get_examples
-from volttron.platform.agent import utils
+from volttron.platform import is_rabbitmq_available
+from volttron.platform import get_services_core
 from volttron.platform.agent.utils import execute_command
-from volttron.platform.messaging import headers as headers_mod
 from volttron.platform.vip.agent import *
-from volttrontesting.fixtures.volttron_platform_fixtures import \
-    build_wrapper, cleanup_wrapper, volttron_multi_messagebus
-from volttrontesting.utils.utils import get_hostname_and_random_port, get_rand_vip, get_rand_ip_and_port
+from volttrontesting.fixtures.volttron_platform_fixtures import build_wrapper, cleanup_wrapper
+from volttrontesting.utils.utils import get_rand_vip
 
 
 HAS_RMQ = is_rabbitmq_available()
@@ -31,12 +27,13 @@ INSTANCE_NAME1 = "volttron1"
 INSTANCE_NAME2 = "volttron2"
 
 
-def get_agent_user_from_dir(agent_name, agent_uuid):
+def get_agent_user_from_dir(agent_uuid, home):
     """
+    :param home: path to volttron home
     :param agent_uuid:
     :return: Unix user ID if installed Volttron agent
     """
-    user_id_path = os.path.join(get_home(), "agents", agent_uuid, "USER_ID")
+    user_id_path = os.path.join(home, "agents", agent_uuid, "USER_ID")
     with open(user_id_path, 'r') as id_file:
         return id_file.readline()
 
@@ -89,7 +86,7 @@ def query_agent(request, secure_volttron_instance):
 def security_agent(request, secure_volttron_instance):
     agent = secure_volttron_instance.install_agent(
         vip_identity="security_agent",
-        agent_dir="volttrontesting/platform/security/SecurityAgent",
+        agent_dir=f"{secure_volttron_instance.volttron_root}/volttrontesting/platform/security/SecurityAgent",
         start=False,
         config_file=None)
 
@@ -98,8 +95,7 @@ def security_agent(request, secure_volttron_instance):
     assert secure_volttron_instance.is_agent_running(agent)
 
     users = [user[0] for user in pwd.getpwall()]
-    # TODO find an alternative for the agent name here
-    agent_user = get_agent_user_from_dir("securityagent-0.1", agent)
+    agent_user = get_agent_user_from_dir(agent, secure_volttron_instance.volttron_home)
     assert agent_user in users
 
     def stop_agent():
@@ -170,7 +166,7 @@ def test_agent_rpc(secure_volttron_instance, security_agent, query_agent):
     try:
         agent2 = secure_volttron_instance.install_agent(
             vip_identity="security_agent2",
-            agent_dir="volttrontesting/platform/security/SecurityAgent",
+            agent_dir=f"{secure_volttron_instance.volttron_root}/volttrontesting/platform/security/SecurityAgent",
             start=False,
             config_file=None)
 
@@ -287,7 +283,7 @@ def test_vhome_file_permissions(secure_volttron_instance, security_agent, query_
     try:
         agent2 = secure_volttron_instance.install_agent(
             vip_identity="security_agent2",
-            agent_dir="volttrontesting/platform/security/SecurityAgent",
+            agent_dir=f"{secure_volttron_instance.volttron_root}/volttrontesting/platform/security/SecurityAgent",
             start=False,
             config_file=None)
 
@@ -330,7 +326,7 @@ def test_config_store_access(secure_volttron_instance, security_agent, query_age
     try:
         agent2 = secure_volttron_instance.install_agent(
             vip_identity="security_agent2",
-            agent_dir="volttrontesting/platform/security/SecurityAgent",
+            agent_dir=f"{secure_volttron_instance.volttron_root}/volttrontesting/platform/security/SecurityAgent",
             start=False,
             config_file=None)
 

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -1,5 +1,4 @@
 import configparser as configparser
-from datetime import datetime
 import logging
 import os
 from pathlib import Path
@@ -261,7 +260,8 @@ class PlatformWrapper:
             # Elixir (rmq pre-req) requires locale to be utf-8
             'LANG': "en_US.UTF-8",
             'LC_ALL': "en_US.UTF-8",
-            'PYTHONDONTWRITEBYTECODE': '1'
+            'PYTHONDONTWRITEBYTECODE': '1',
+            'VOLTTRON_ROOT': VOLTTRON_ROOT
         }
         self.volttron_root = VOLTTRON_ROOT
 
@@ -1189,7 +1189,6 @@ class PlatformWrapper:
         with with_os_environ(self.env):
             _log.debug("REMOVING AGENT: {}".format(agent_uuid))
             self.__wait_for_control_connection_to_exit__()
-
             cmd = [self.vctl_exe]
             cmd.extend(['remove', agent_uuid])
             res = execute_command(cmd, env=self.env, logger=_log,


### PR DESCRIPTION

# Description

* Fixes paths to agent_dir, test helper methods to ensure both tests and fixtures are succesfully created
* Fixes SecureExecutionEnvironment's ```stop``` method to update path to internal volttron scripts
* Adds helper method to update paths to internal volttron script if not called from volttron root directory 
* Add ```VOLTTRON_ROOT``` env variable to PlatformWrapper to allow AIP tests to call internal volttron scripts (e.g. 'scripts/secure_stop_agent.sh`) 
* Remove unused imports and variables

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

VirtualBox 6.1
Ubuntu 18.04
Python 3.69

Ran securityagent tests on both PyCharm IDE and command line. 
Ran tests on both ZMQ and RMQ. 

<details>
<summary> <b> For Pytest results, CLICK HERE </b> </summary>

```bash
================================================================================================= test session starts =================================================================================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/mark2/Workplace/volttron/env/bin/python3
cachedir: .pytest_cache
rootdir: /home/mark2/Workplace/volttron, configfile: pytest.ini
plugins: timeout-1.4.2
timeout: 240.0s
timeout method: signal
timeout func_only: False
collected 14 items                                                                                                                                                                                                    

test_aip_security.py::test_agent_rpc[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_agent_rpc[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 150, 'test_agent_rpc[secure_volttron_instance0]')
PASSED                                                                                                                                          [  7%]test node: volttrontesting/platform/security/test_aip_security.py::test_agent_rpc[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 150, 'test_agent_rpc[secure_volttron_instance0]')

test_aip_security.py::test_agent_pubsub[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_agent_pubsub[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 186, 'test_agent_pubsub[secure_volttron_instance0]')
PASSED                                                                                                                                       [ 14%]test node: volttrontesting/platform/security/test_aip_security.py::test_agent_pubsub[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 186, 'test_agent_pubsub[secure_volttron_instance0]')

test_aip_security.py::test_install_dir_permissions[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 214, 'test_install_dir_permissions[secure_volttron_instance0]')
PASSED                                                                                                                            [ 21%]test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 214, 'test_install_dir_permissions[secure_volttron_instance0]')

test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 229, 'test_install_dir_file_permissions[secure_volttron_instance0]')
PASSED                                                                                                                       [ 28%]test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 229, 'test_install_dir_file_permissions[secure_volttron_instance0]')

test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 243, 'test_vhome_dir_permissions[secure_volttron_instance0]')
PASSED                                                                                                                              [ 35%]test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 243, 'test_vhome_dir_permissions[secure_volttron_instance0]')

test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 262, 'test_vhome_file_permissions[secure_volttron_instance0]')
PASSED                                                                                                                             [ 42%]test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 262, 'test_vhome_file_permissions[secure_volttron_instance0]')

test_aip_security.py::test_config_store_access[secure_volttron_instance0] test node: volttrontesting/platform/security/test_aip_security.py::test_config_store_access[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 307, 'test_config_store_access[secure_volttron_instance0]')
PASSED                                                                                                                                [ 50%]test node: volttrontesting/platform/security/test_aip_security.py::test_config_store_access[secure_volttron_instance0] location: ('volttrontesting/platform/security/test_aip_security.py', 307, 'test_config_store_access[secure_volttron_instance0]')

test_aip_security.py::test_agent_rpc[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_agent_rpc[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 150, 'test_agent_rpc[secure_volttron_instance1]')
PASSED                                                                                                                                          [ 57%]test node: volttrontesting/platform/security/test_aip_security.py::test_agent_rpc[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 150, 'test_agent_rpc[secure_volttron_instance1]')

test_aip_security.py::test_agent_pubsub[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_agent_pubsub[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 186, 'test_agent_pubsub[secure_volttron_instance1]')
PASSED                                                                                                                                       [ 64%]test node: volttrontesting/platform/security/test_aip_security.py::test_agent_pubsub[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 186, 'test_agent_pubsub[secure_volttron_instance1]')

test_aip_security.py::test_install_dir_permissions[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 214, 'test_install_dir_permissions[secure_volttron_instance1]')
PASSED                                                                                                                            [ 71%]test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 214, 'test_install_dir_permissions[secure_volttron_instance1]')

test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 229, 'test_install_dir_file_permissions[secure_volttron_instance1]')
PASSED                                                                                                                       [ 78%]test node: volttrontesting/platform/security/test_aip_security.py::test_install_dir_file_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 229, 'test_install_dir_file_permissions[secure_volttron_instance1]')

test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 243, 'test_vhome_dir_permissions[secure_volttron_instance1]')
PASSED                                                                                                                              [ 85%]test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_dir_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 243, 'test_vhome_dir_permissions[secure_volttron_instance1]')

test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 262, 'test_vhome_file_permissions[secure_volttron_instance1]')
PASSED                                                                                                                             [ 92%]test node: volttrontesting/platform/security/test_aip_security.py::test_vhome_file_permissions[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 262, 'test_vhome_file_permissions[secure_volttron_instance1]')

test_aip_security.py::test_config_store_access[secure_volttron_instance1] test node: volttrontesting/platform/security/test_aip_security.py::test_config_store_access[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 307, 'test_config_store_access[secure_volttron_instance1]')
PASSED                                                                                                                                [100%]test node: volttrontesting/platform/security/test_aip_security.py::test_config_store_access[secure_volttron_instance1] location: ('volttrontesting/platform/security/test_aip_security.py', 307, 'test_config_store_access[secure_volttron_instance1]')


================================================================================================== warnings summary ===================================================================================================
../../../env/lib/python3.6/site-packages/_pytest/config/__init__.py:1184
  /home/mark2/Workplace/volttron/env/lib/python3.6/site-packages/_pytest/config/__init__.py:1184: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    _pytest.deprecated.STRICT_OPTION, stacklevel=2

../../../env/lib/python3.6/site-packages/grequests.py:22
  /home/mark2/Workplace/volttron/env/lib/python3.6/site-packages/grequests.py:22: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.contrib.pyopenssl (/home/mark2/Workplace/volttron/env/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py)']. 
    curious_george.patch_all(thread=False, select=False)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================================================== 14 passed, 2 warnings in 215.73s (0:03:35) ======================================================================================

```

</details>


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
