### PR TITLE
Failed list only

### DIFF
--- a/.github/workflows/pytest-auth.yml
+++ b/.github/workflows/pytest-auth.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           source env/bin/activate
           pip install -e .
-          pytest volttrontesting/platform/auth_tests -o junit_family=xunit2 --junitxml=output/test-auth-${{matrix.os}}-${{ matrix.python-version }}-results.xml
+          pytest volttrontesting/platform/auth_tests -rf -o junit_family=xunit2 --junitxml=output/test-auth-${{matrix.os}}-${{ matrix.python-version }}-results.xml
 
       # Archive the results from the pytest to storage.
       - name: Archive test results

--- a/.github/workflows/pytest-testutils.yml
+++ b/.github/workflows/pytest-testutils.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           source env/bin/activate
           pip install -e .
-          pytest volttrontesting/testutils -o junit_family=xunit2 --junitxml=output/test-testutils-${{matrix.os}}-${{ matrix.python-version }}-results.xml
+          pytest volttrontesting/testutils -rf -o junit_family=xunit2 --junitxml=output/test-testutils-${{matrix.os}}-${{ matrix.python-version }}-results.xml
 
       # Archive the results from the pytest to storage.
       - name: Archive test results


### PR DESCRIPTION
# Description

Only changes the reporting of pytests in github actions.  Adds the -rf flag which reports failed tests at the end of the report.  This should not cause any other tests to fail!