### PR TITLE
Set enable_config_store=True for test agents

### DIFF
--- a/volttrontesting/subsystems/test_config_store.py
+++ b/volttrontesting/subsystems/test_config_store.py
@@ -64,7 +64,8 @@ class _config_test_agent(Agent):
 def _module_config_test_agent(request, volttron_instance):
 
     agent = volttron_instance.build_agent(identity='config_test_agent',
-                                          agent_class=_config_test_agent)
+                                          agent_class=_config_test_agent,
+                                          enable_store=True)
 
     def cleanup():
         agent.core.stop()
@@ -371,7 +372,8 @@ def test_agent_default_config(request, volttron_instance):
             self.setup_callback()
 
     agent = volttron_instance.build_agent(identity='test_default_agent',
-                                          agent_class=test_default_agent)
+                                          agent_class=test_default_agent,
+                                          enable_store=True)
 
     # Give the agent a chance to process it's configurations.
     gevent.sleep(1.0)
@@ -412,7 +414,8 @@ def test_agent_sub_options(request, volttron_instance):
             self.setup_callback(actions="DELETE", pattern="delete/*")
 
     agent = volttron_instance.build_agent(identity='test_agent_sub_options',
-                                          agent_class=test_sub_pattern_agent)
+                                          agent_class=test_sub_pattern_agent,
+                                          enable_store=True)
 
     # Give the agent a chance to process it's configurations.
     gevent.sleep(1.0)


### PR DESCRIPTION
# Description
Tests need test agent with config store enabled and by default it is disabled


