### PR TITLE
Modify default python type based on BACnet object type

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/bacnet.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/bacnet.py
@@ -50,6 +50,10 @@ _log = logging.getLogger(__name__)
 
 DEFAULT_COV_LIFETIME = 180
 COV_UPDATE_BUFFER = 3
+BACNET_TYPE_MAPPING = {"multiStateValue": int, "multiStateInput": int, "multiStateOutput": int,
+                       "analogValue": float, "analogInput": float, "analogOutput": float,
+                       "binaryValue": bool, "binaryInput": bool, "binaryOutput": bool
+                      }
 
 
 class Register(BaseRegister):
@@ -61,6 +65,7 @@ class Register(BaseRegister):
         self.property = property_name
         self.priority = priority
         self.index = list_index
+        self.python_type = BACNET_TYPE_MAPPING[object_type]
 
 
 class Interface(BaseInterface):


### PR DESCRIPTION
Currently, all registers default to int type, some historians attempt to cast raw values to float regardless, others respect the python_type property of the register, this will enable those historians to preserve more information by default.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
