### PR TITLE
Bug fixes in platform driver tests

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/helpers.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/helpers.py
@@ -136,7 +136,7 @@ def parse_transform_arg(func, arg):
     """
     parse_arg = arg
     if func in (scale, scale_int, scale_decimal_int_signed):
-        if type(arg) not in (int, long, float):
+        if type(arg) not in (int, float):
             try:
                 parse_arg = int(arg, 10)
             except ValueError:

--- a/services/core/PlatformDriverAgent/tests/test_eagle.py
+++ b/services/core/PlatformDriverAgent/tests/test_eagle.py
@@ -203,7 +203,7 @@ def agent(volttron_instance):
                        'manage_delete_store',
                        PLATFORM_DRIVER).get(timeout=10)
 
-    #Add test configurations.
+    # Add test configurations.
     agent.vip.rpc.call(CONFIGURATION_STORE,
                        'manage_store',
                        PLATFORM_DRIVER,
@@ -233,7 +233,6 @@ def agent(volttron_instance):
     volttron_instance.stop_agent(platform_uuid)
     agent.core.stop()
     server.stop()
-
 
 def test_NetworkStatus(agent):
     point = agent.vip.rpc.call(PLATFORM_DRIVER,

--- a/services/core/PlatformDriverAgent/tests/test_global_override.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_override.py
@@ -653,7 +653,6 @@ def test_indefinite_override_on(config_store, test_agent):
     ).get(timeout=10)
 
 
-@pytest.mark.dev
 @pytest.mark.driver
 def test_indefinite_override_after_restart(config_store, test_agent, volttron_instance):
 

--- a/services/core/PlatformDriverAgent/tests/test_global_override.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_override.py
@@ -179,7 +179,7 @@ def test_set_override(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(device_path)
 
     try:
@@ -191,7 +191,7 @@ def test_set_override(config_store, test_agent):
 
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot revert device {} since global override is set'.format(device_path)
 
 
@@ -228,7 +228,7 @@ def test_set_point_after_override_elapsed_interval(config_store, test_agent):
         ).get(timeout=10)
         assert result == new_value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
 
@@ -264,7 +264,7 @@ def test_set_hierarchical_override(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned: {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_path)
     gevent.sleep(4)
 
@@ -360,7 +360,7 @@ def test_set_override_off(config_store, test_agent):
         ).get(timeout=10)
         assert result == value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
 
@@ -431,7 +431,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
 
     try:
@@ -446,7 +446,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver2_device_path)
 
     # Wait for timeout
@@ -463,7 +463,7 @@ def test_overlapping_override_onoff(config_store, test_agent):
         assert result == new_value
         print("New value of fake driver2, SampleWritableFloat1: {}".format(new_value))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver2_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
 
@@ -519,7 +519,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
 
     try:
@@ -534,7 +534,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         ).get(timeout=10)
         assert result == new_value
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver2_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
 
@@ -553,7 +553,7 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         assert result == new_value
         print("New value of fake driver1, SampleWritableFloat1: {}".format(new_value))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
         pytest.fail("Expecting successful set point. Code raised OverrideError: {}".format(e.message))
 
@@ -600,7 +600,7 @@ def test_duplicate_override_on(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
 
 
@@ -645,7 +645,7 @@ def test_indefinite_override_on(config_store, test_agent):
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(device_path)
     test_agent.vip.rpc.call(
         PLATFORM_DRIVER,  # Target agent
@@ -702,8 +702,8 @@ def test_indefinite_override_after_restart(config_store, test_agent, volttron_in
         ).get(timeout=10)
         pytest.fail("Expecting Override Error. Code returned : {}".format(result))
     except RemoteError as e:
-        assert e.exc_info['exc_type'] == 'platform_driver.agent.OverrideError'
-        assert e.message == 'Cannot set point on device {} since global override is set'.format(device_path)
+        assert e.exc_info['exc_type'] == '__main__.OverrideError'
+        assert e.message == 'Cannot set point on device {} since global override is set'.format(device)
     test_agent.vip.rpc.call(
         PLATFORM_DRIVER,  # Target agent
         'clear_overrides'  # Method


### PR DESCRIPTION
# Description

Various bug fixes in tests in platform driver's tests collection

Fixes # (issue)

* modbus_tk test used "long" type (removed in python3)
* exception format change causing platform driver override tests to fail
* fixed override after restart test not actually restarting platform driver instance

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Platform driver integration test suite.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
