### PR TITLE
Fixed config path not working if not running tests from Volttron root…

### DIFF
--- a/services/core/PlatformDriverAgent/tests/test_global_override.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_override.py
@@ -41,9 +41,9 @@ py.test cases for global override settings.
 """
 
 import pytest
+import os
 
-from volttron.platform import get_services_core
-from volttrontesting.utils.platformwrapper import start_wrapper_platform
+from volttron.platform import get_services_core, get_volttron_root
 from volttron.platform.agent.known_identities import PLATFORM_DRIVER, CONFIGURATION_STORE
 import gevent
 from volttron.platform.jsonrpc import RemoteError
@@ -112,7 +112,7 @@ def config_store(request, config_store_connection):
     # Always have fake.csv ready to go.
 
     # Add up fake.csv to config store
-    config_path = "scripts/scalability-testing/fake_unit_testing.csv"
+    config_path = os.path.join(get_volttron_root(), "scripts/scalability-testing/fake_unit_testing.csv")
     with open(config_path, 'r') as f:
         registry_config_string = f.read()
 
@@ -138,6 +138,7 @@ def setup_config(config_store, config_name, config_string, **kwargs):
 @pytest.fixture(scope="module")
 def test_agent(request, volttron_instance):
     test_agent = volttron_instance.build_agent(identity=TEST_AGENT)
+
     def stop_agent():
         test_agent.core.stop()
 
@@ -251,8 +252,8 @@ def test_set_hierarchical_override(config_store, test_agent):
         True
     ).get(timeout=10)
 
+    fakedriver1_path = 'fakedriver2'
     try:
-        fakedriver1_path = 'fakedriver2'
         point = 'SampleWritableFloat'
         value = 12.5
         result = test_agent.vip.rpc.call(
@@ -434,9 +435,9 @@ def test_overlapping_override_onoff(config_store, test_agent):
         assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
 
+    fakedriver2_device_path = 'fakedriver2'
     try:
         # Try to set a point on fakedriver2
-        fakedriver2_device_path = 'fakedriver2'
         result = test_agent.vip.rpc.call(
             PLATFORM_DRIVER,  # Target agent
             'set_point',  # Method
@@ -522,9 +523,9 @@ def test_overlapping_override_onoff2(config_store, test_agent):
         assert e.exc_info['exc_type'] == '__main__.OverrideError'
         assert e.message == 'Cannot set point on device {} since global override is set'.format(fakedriver1_device_path)
 
+    fakedriver2_device_path = 'fakedriver2'
     try:
         # Try to set a point on fakedriver2
-        fakedriver2_device_path = 'fakedriver2'
         result = test_agent.vip.rpc.call(
             PLATFORM_DRIVER,  # Target agent
             'set_point',  # Method


### PR DESCRIPTION
# Description

Fixed config path not working if not running tests from Volttron root dir as well as some 'variable may not be assigned before reference' issues and unused imports.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Global override integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
