### PR TITLE
Fixed reference to long type removed in python3

### DIFF
--- a/services/core/MasterDriverAgent/master_driver/interfaces/modbus_tk/helpers.py
+++ b/services/core/MasterDriverAgent/master_driver/interfaces/modbus_tk/helpers.py
@@ -136,7 +136,7 @@ def parse_transform_arg(func, arg):
     """
     parse_arg = arg
     if func in (scale, scale_int, scale_decimal_int_signed):
-        if type(arg) not in (int, long, float):
+        if type(arg) not in (int, float):
             try:
                 parse_arg = int(arg, 10)
             except ValueError:


### PR DESCRIPTION
# Description

Fixed reference to long type removed in python3 in ModbusTK

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Master driver unit/integration tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
