### PR TITLE
Feature/docs.historian methods

### DIFF
--- a/docs/source/developing-volttron/developing-agents/developing-historian-agents.rst
+++ b/docs/source/developing-volttron/developing-agents/developing-historian-agents.rst
@@ -4,8 +4,10 @@
 Developing Historian Agents
 ===========================
 
-VOLTTRON provides a convenient base class for developing new historian agents. The base class automatically performs
-a number of important functions:
+Developing custom historians is considered an advanced development topic. If this is your first time developing
+a custom agent, consider starting with the general :ref:`agent-development` page first.
+VOLTTRON provides a convenient base class for developing new historian agents.  The base class automatically
+performs a number of important functions:
 
 * subscribes to all pertinent topics
 * caches published data to disk until it is successfully recorded to a historian
@@ -103,6 +105,8 @@ startup. It is meant for connection setup.
 Example Historian
 -----------------
 
-An example historian can be found in the `examples/CSVHistorian` directory in the VOLTTRON repository.  This example
+An example historian can be found in the `examples/CSVHistorian` directory in the VOLTTRON repository. This example
 historian uses a CSV file as the persistent data store.  It is recommended to use this agent as a reference for
-developing new historian agents.
+developing new historian agents. The example is described in more detail
+:ref:`under the Example Agents subsection <CSV-Historian>`.
+

--- a/docs/source/developing-volttron/developing-agents/example-agents/csv-historian.rst
+++ b/docs/source/developing-volttron/developing-agents/example-agents/csv-historian.rst
@@ -19,21 +19,12 @@ The Utils module of the VOLTTRON platform includes functions for setting up glob
     _log = logging.getLogger(__name__)
 
 
-The ``historian`` method is called by ``utils.vip_main`` when the agents is started (see below).  ``utils.vip_main``
+The ``historian`` function is called by ``utils.vip_main`` when the agents is started (see below).  ``utils.vip_main``
 expects a callable object that returns an instance of an Agent.  This method of dealing with a configuration file and
 instantiating an Agent is common practice.
 
-.. code-block:: python
-
-    def historian(config_path, **kwargs):
-        if isinstance(config_path, dict):
-            config_dict = config_path
-        else:
-            config_dict = utils.load_config(config_path)
-
-        output_path = config_dict.get("output", "~/historian_output.csv")
-
-        return CSVHistorian(output_path = output_path, **kwargs)
+.. literalinclude:: ../../../../../examples/CSVHistorian/csv_historian/historian.py
+   :pyobject: historian
 
 All historians must inherit from `BaseHistorian`.  The `BaseHistorian` class handles the capturing and caching of all
 device, logging, analysis, and record data published to the message bus.
@@ -48,12 +39,8 @@ Historian calls two methods on the created historian, ``historian_setup`` and ``
 The Base Historian created the new thread in it's ``__init__`` method. This means that any instance variables
 must assigned in ``__init__`` before calling the Base Historian's ``__init__`` method.
 
-.. code-block:: python
-
-    def __init__(self, output_path="", **kwargs):
-        self.output_path = output_path
-        self.csv_dict = None
-        super(CSVHistorian, self).__init__(**kwargs)
+.. literalinclude:: ../../../../../examples/CSVHistorian/csv_historian/historian.py
+   :pyobject: CSVHistorian.__init__
 
 Historian setup is called shortly after the new thread starts. This is where a Historian sets up a connect the first
 time.  In our example we create the `Dictwriter` object that we will use to create and add lines to the CSV file.
@@ -63,13 +50,8 @@ have written new data to the file.
 
 The CSV file we create will have 4 columns: `timestamp`, `source`, `topic`, and `value`.
 
-.. code-block:: python
-
-    def historian_setup(self):
-        self.f = open(self.output_path, "wb")
-        self.csv_dict = csv.DictWriter(self.f, ["timestamp", "source", "topic", "value"])
-        self.csv_dict.writeheader()
-        self.f.flush()
+.. literalinclude:: ../../../../../examples/CSVHistorian/csv_historian/historian.py
+   :pyobject: CSVHistorian.historian_setup
 
 ``publish_to_historian`` is called when data is ready to be published. It is passed a list of dictionaries.  Each
 dictionary contains a record of a single value that was published to the message bus.
@@ -91,21 +73,8 @@ Once the data is written to the historian we call ``self.report_all_handled()`` 
 data we received was successfully published and can be removed from the cache.  Then we can flush the file to ensure
 that the data is written to disk.
 
-.. code-block:: python
-
-    def publish_to_historian(self, to_publish_list):
-        for record in to_publish_list:
-            row = {}
-            row["timestamp"] = record["timestamp"]
-
-            row["source"] = record["source"]
-            row["topic"] = record["topic"]
-            row["value"] = record["value"]
-
-            self.csv_dict.writerow(row)
-
-        self.report_all_handled()
-        self.f.flush()
+.. literalinclude:: ../../../../../examples/CSVHistorian/csv_historian/historian.py
+   :pyobject: CSVHistorian.publish_to_historian
 
 This agent does not support the Historian Query interface.
 
@@ -119,5 +88,5 @@ The CSV Historian can be tested by running the included `launch_my_historian.sh`
 Agent Installation
 ------------------
 
-This Agent may be installed on the platform using the standard method.
+This Agent may be installed on the platform using the :ref:`standard method <installing-and-running-agents>`.
 

--- a/docs/source/introduction/platform-install.rst
+++ b/docs/source/introduction/platform-install.rst
@@ -441,6 +441,8 @@ or use the included `stop-volttron` script:
         volttron -vv -l volttron.log > /dev/null 2>&1&
 
 
+.. _installing-and-running-agents:
+
 Installing and Running Agents
 -----------------------------
 


### PR DESCRIPTION
# Description

Modifies CSVHistorian example documentation to include actual source rather than duplicating it (ensures changes to the implementation will automatically be reflected in the docs).

## Type of change

Docs update

# How Has This Been Tested?

Local build of docs complete and render changed pages correctly. No changes made to any python source.