### PR TITLE
Fixed deprecated function call to threading library. The old name no …

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/server.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/server.py
@@ -192,7 +192,7 @@ class Server (object):
         self._server.stop()
 
     def is_alive(self):
-        return self._server._thread.isAlive()
+        return self._server._thread.is_alive()
 
     def set_verbose(self, on=True):
         self._server.set_verbose(on)

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -910,7 +910,7 @@ def start_volttron_process(opts):
             thread.start()
 
             gevent.sleep(0.1)
-            if not thread.isAlive():
+            if not thread.is_alive():
                 sys.exit()
         else:
             # Start RabbitMQ server if not running
@@ -941,7 +941,7 @@ def start_volttron_process(opts):
             thread.start()
 
             gevent.sleep(0.1)
-            if not thread.isAlive():
+            if not thread.is_alive():
                 sys.exit()
 
             gevent.sleep(1)


### PR DESCRIPTION
…longer works as of Python 3.9.

# Description

VOLTTRON does not start in Python 3.9 due to removal of a deprecated function name from the threading library used in main.py (and in modbus_tk/server.py, though that doesn't affect startup).  This PR updates the function name to one which should be compatible for all Python 3 versions.

The deprecated function is threading.Thread.isAlive(). The new name of the function has been changed to threading.Thread.is_alive(). Both versions worked prior to Python 3.9, but the deprecated version has now been removed. The function name has been updated in three places: two in main.py, and one in modbus_tk/server.py.

Fixes # (issue)
#2472 (There is more in that ticket, which is not addressed here).
## Type of change
Deprecation fix.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

 - VOLTTRON starts with the fix on Fedora 33 (Python version 3.9.2), but not without.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
