### PR TITLE
Web Authentication updates

### DIFF
--- a/docs/source/driver-framework/fake-driver/fake-driver.rst
+++ b/docs/source/driver-framework/fake-driver/fake-driver.rst
@@ -137,7 +137,7 @@ All local config files will be worked on here.
 .. code-block:: bash
 
     vctl config store platform.driver devices/campus/building/fake config/fake.config
-    vcfl config store platform.driver fake.csv config/fake.csv --csv
+    vctl config store platform.driver fake.csv config/fake.csv --csv
 
 - Edit `fake-platform-driver.config` to reflect paths on your system
 

--- a/volttron/platform/web/__init__.py
+++ b/volttron/platform/web/__init__.py
@@ -66,6 +66,8 @@ def get_bearer(env):
         auth_type, bearer = http_auth.split(' ')
         if auth_type.upper() != 'BEARER':
             raise NotAuthorized("Invalid HTTP_AUTHORIZATION header passed, must be Bearer")
+        else:
+            return bearer
     else:
         cookiestr = env.get('HTTP_COOKIE')
         if not cookiestr:

--- a/volttron/platform/web/__init__.py
+++ b/volttron/platform/web/__init__.py
@@ -39,6 +39,7 @@
 from http.cookies import SimpleCookie
 import logging
 
+from datetime import datetime
 from volttron.platform import get_platform_config
 
 try:
@@ -123,7 +124,7 @@ def get_user_claim_from_bearer(bearer, web_secret_key=None, tls_public_key=None)
         pubkey = tls_public_key
         # if isinstance(tls_public_key, str):
         #     pubkey = CertWrapper.load_cert(tls_public_key)
-    return jwt.decode(bearer, pubkey, algorithms=algorithm)
-
-
-
+    claims = jwt.decode(bearer, pubkey, algorithms=algorithm)
+    exp = datetime.utcfromtimestamp(claims['exp'])
+    nbf = datetime.utcfromtimestamp(claims['nbf'])
+    return claims if not (exp < datetime.utcnow() <= nbf) else {}

--- a/volttron/platform/web/__init__.py
+++ b/volttron/platform/web/__init__.py
@@ -112,7 +112,7 @@ def __get_key_and_algorithm__(env, ssl_public_key):
 def get_user_claim_from_bearer(bearer, web_secret_key=None, tls_public_key=None):
     if web_secret_key is None and tls_public_key is None:
         raise ValueError("web_secret_key or tls_public_key must be set")
-    if web_secret_key is None and tls_public_key is None:
+    if web_secret_key is not None and tls_public_key is not None:
         raise ValueError("web_secret_key or tls_public_key must be set not both")
 
     if web_secret_key is not None:

--- a/volttron/platform/web/authenticate_endpoint.py
+++ b/volttron/platform/web/authenticate_endpoint.py
@@ -2,6 +2,8 @@ import logging
 import os
 import re
 from urllib.parse import parse_qs
+from datetime import datetime, timedelta
+import json
 
 import jwt
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateNotFound
@@ -32,9 +34,12 @@ tplenv = Environment(
 
 class AuthenticateEndpoints(object):
 
-    def __init__(self, tls_private_key=None, web_secret_key=None):
+    def __init__(self, tls_private_key=None, tls_public_key=None, web_secret_key=None):
 
+        self.refresh_token_timeout = 240  # minutes before token expires. TODO: Should this be a setting somewhere?
+        self.access_token_timeout = 15  # minutes before token expires. TODO: Should this be a setting somewhere?
         self._tls_private_key = tls_private_key
+        self._tls_public_key = tls_public_key
         self._web_secret_key = web_secret_key
         if self._tls_private_key is None and self._web_secret_key is None:
             raise ValueError("Must have either ssl_private_key or web_secret_key specified!")
@@ -72,21 +77,44 @@ class AuthenticateEndpoints(object):
         :return:
         """
         return [
-            (re.compile('^/authenticate'), 'callable', self.get_auth_token)
+            (re.compile('^/authenticate'), 'callable', self.handle_authenticate)
         ]
 
-    def get_auth_token(self, env, data):
+    def handle_authenticate(self, env, data):
         """
-        Creates an authentication token to be returned to the caller.  The
-        response will be a text/plain encoded user
+        Callback for /authenticate endpoint.
 
+        Routes request based on HTTP method and returns a text/plain encoded token or error.
+
+        :param env:
+        :param data:
+        :return: Response
+        """
+        method = env.get('REQUEST_METHOD')
+        if method == 'POST':
+            response = self.get_auth_tokens(env, data)
+        elif method == 'PUT':
+            response = self.renew_auth_token(env, data)
+        elif method == 'DELETE':
+            response = self.revoke_auth_token(env, data)
+        else:
+            error = f"/authenticate endpoint accepts only POST, PUT, or DELETE methods. Received: {method}"
+            _log.warning(error)
+            return Response(error, status='405 Method Not Allowed', content_type='text/plain')
+        return response
+
+    def get_auth_tokens(self, env, data):
+        """
+        Creates an authentication refresh and acccss tokens to be returned to the caller.  The
+        response will be a text/plain encoded user.  Data should contain:
+        {
+            "username": "<username>",
+            "password": "<password>"
+        }
         :param env:
         :param data:
         :return:
         """
-        if env.get('REQUEST_METHOD') != 'POST':
-            _log.warning("Authentication must use POST request.")
-            return Response('401 Unauthorized', status='401 Unauthorized', content_type='text/html')
 
         assert len(self._userdict) > 0, "No users in user dictionary, set the administrator password first!"
 
@@ -118,12 +146,63 @@ class AuthenticateEndpoints(object):
         if user is None:
             _log.error("No matching user for passed username: {}".format(username))
             return Response('', status='401')
+        access_token, refresh_token = self._get_tokens(user)
+        response = Response(json.dumps({"refresh_token": refresh_token, "access_token": access_token}),
+                            content_type="application/json")
+        return response
 
+    def _get_tokens(self, claims):
+        now = datetime.utcnow()
+        claims['iat'] = now
+        claims['nbf'] = now
+        claims['exp'] = now + timedelta(minutes=self.access_token_timeout)
+        claims['grant_type'] = 'access_token'
         algorithm = 'RS256' if self._tls_private_key is not None else 'HS256'
         encode_key = self._tls_private_key if algorithm == 'RS256' else self._web_secret_key
-        encoded = jwt.encode(user, encode_key, algorithm=algorithm)
+        access_token = jwt.encode(claims, encode_key, algorithm=algorithm)
+        claims['exp'] = now + timedelta(minutes=self.refresh_token_timeout)
+        claims['grant_type'] = 'refresh_token'
+        refresh_token = jwt.encode(claims, encode_key, algorithm=algorithm)
+        return access_token.decode('utf-8'), refresh_token.decode('utf8')
 
-        return Response(encoded, content_type="text/plain")
+    def renew_auth_token(self, env, data):
+        """
+        Creates a new authentication access token to be returned to the caller.  The
+        response will be a text/plain encoded user.  Request should contain:
+            • Content Type: application/json
+            • Authorization: BEARER <jwt_refresh_token>
+            • Body (optional):
+                {
+                "current_access_token": "<jwt_access_token>"
+                }
+
+        :param env:
+        :param data:
+        :return:
+        """
+        current_access_token = data.get('current_access_token')
+        from volttron.platform.web import get_bearer, get_user_claim_from_bearer, NotAuthorized
+        try:
+            current_refresh_token = get_bearer(env)
+            claims = get_user_claim_from_bearer(current_refresh_token, web_secret_key=self._web_secret_key,
+                                                tls_public_key=self._tls_public_key)
+        except NotAuthorized:
+            _log.error("Unauthorized user attempted to connect to {}".format(env.get('PATH_INFO')))
+            return Response('Unauthorized User', status="401 Unauthorized")
+
+        if claims.get('grant_type') != 'refresh_token' or not claims.get('groups'):
+            return Response('Invalid refresh token.', status="401 Unauthorized")
+        else:
+            # TODO: Consider blacklisting and reissuing refresh tokens also when used.
+            new_access_token, _ = self._get_tokens(claims)
+            if current_access_token:
+                pass  # TODO: keep current subscriptions? blacklist old token?
+            return Response(json.dumps({"access_token": new_access_token}), content_type="application/json")
+
+    def revoke_auth_token(self, env, data):
+        # TODO: Blacklist old token? Immediately close websockets?
+        return Response('DELETE /authenticate is not yet implemented', status='501 Not Implemented',
+                        content_type='text/plain')
 
     def __get_user(self, username, password):
         """

--- a/volttron/platform/web/platform_web_service.py
+++ b/volttron/platform/web/platform_web_service.py
@@ -491,11 +491,6 @@ class PlatformWebService(Agent):
 
                     if isinstance(retvalue, Response):
                         return retvalue(env, start_response)
-                        #return self.process_response(start_response, retvalue)
-                    elif isinstance(retvalue, Response):  # werkzueg Response
-                        for d in retvalue(env, start_response):
-                            print(d)
-                        return retvalue(env, start_response)
                     else:
                         return retvalue[0]
 


### PR DESCRIPTION
# Description

JWT tokens used by the web framework are updated to include expiry information, and checks are made to refuse access if the token is not valid at the current time. The authenticate endpoint now accepts POST (which returns a refresh token and an access token), PUT, which returns a new access_token, and DELETE (though this currently just returns UNIMPLEMENTED). The response is now application/json, rather than text/plain. Several fixes have also been made in separate commits to unreachable code and a missing return statement which were discovered while making these changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tests have not been updated, but the authentication mechanism has been tested manually using Postman.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
