### PR TITLE
Update SchedulerExample agent and Actuator README docs

### DIFF
--- a/examples/SchedulerExample/schedule_example/agent.py
+++ b/examples/SchedulerExample/schedule_example/agent.py
@@ -72,7 +72,7 @@ def schedule_example(config_path, **kwargs):
 
     class SchedulerExample(Agent):
         '''This agent can be used to demonstrate scheduling and 
-        acutation of devices. It reserves a non-existant device, then
+        acutation of devices. It reserves a non-existent device, then
         acts when its time comes up. Since there is no device, this 
         will cause an error.
         '''
@@ -126,18 +126,16 @@ def schedule_example(config_path, **kwargs):
     
     
             msg = [
-                   ['campus/building/unit',start,end]
-                   #Could add more devices
-    #                 ["campus/building/device1", #First time slot.
-    #                  "2014-1-31 12:27:00",     #Start of time slot.
-    #                  "2016-1-31 12:29:00"],     #End of time slot.
-    #                 ["campus/building/device2", #Second time slot.
-    #                  "2014-1-31 12:26:00",     #Start of time slot.
-    #                  "2016-1-31 12:30:00"],     #End of time slot.
-    #                 ["campus/building/device3", #Third time slot.
-    #                  "2014-1-31 12:30:00",     #Start of time slot.
-    #                  "2016-1-31 12:32:00"],     #End of time slot.
-                    #etc...
+                   ['campus/building/unit', start, end],
+                    ["campus/building/device1", #First time slot.
+                     "2014-1-31 12:27:00",     #Start of time slot.
+                     "2016-1-31 12:29:00"],     #End of time slot.
+                    ["campus/building/device2", #Second time slot.
+                     "2014-1-31 12:26:00",     #Start of time slot.
+                     "2016-1-31 12:30:00"],     #End of time slot.
+                    ["campus/building/device3", #Third time slot.
+                     "2014-1-31 12:30:00",     #Start of time slot.
+                     "2016-1-31 12:32:00"],     #End of time slot.
                 ]
             self.vip.pubsub.publish(
             'pubsub', topics.ACTUATOR_SCHEDULE_REQUEST, headers, msg)
@@ -160,7 +158,7 @@ def schedule_example(config_path, **kwargs):
                                            msg).get(timeout=10)
                 print("schedule result", result)
             except Exception as e:
-                print ("Could not contact actuator. Is it running?")
+                print("Could not contact actuator. Is it running?")
                 print(e)
                 return
             
@@ -173,13 +171,22 @@ def schedule_example(config_path, **kwargs):
                                            'campus/building/unit3/some_point',
                                            '0.0').get(timeout=10)
                     print("Set result", result)
+
+                    topic_values = []
+                    for x in msg:
+                        topic = x[0]
+                        value = '0.0'
+                        topic_values.append((topic, value))
+                    result = self.vip.rpc.call(
+                                            'platform.actuator',
+                                            'set_multiple_points',
+                                            self.core.identity,
+                                            topic_values).get(timeout=10)
+                    print("Set_multiple_points result", result)
             except Exception as e:
-                print ("Expected to fail since there is no real device to set")
+                print("Expected to fail since there is no real device to set")
                 print(e)    
-                
-                
-            
-            
+
     Agent.__name__ = 'ScheduleExampleAgent'
     return SchedulerExample(**kwargs)
             

--- a/services/core/ActuatorAgent/README.md
+++ b/services/core/ActuatorAgent/README.md
@@ -5,6 +5,9 @@ devices.
 
 Agents may interact with the ActuatorAgent via either PUB/SUB or RPC, 
 but it is recommended agents use RPC to interact with the ActuatorAgent.
+For an example of an agent using RPC to interact with the ActuatorAgent, see the 
+`SchedulerExample agent <https://github.com/VOLTTRON/volttron/blob/main/examples/SchedulerExample/schedule_example/agent.py>`__ 
+from the Volttron repository.
 
 The PUB/SUB interface remains primarily for VOLTTRON 2.0 agents. 
 


### PR DESCRIPTION
# Description

* Adds `set_multiple_points` RPC call to SchedulerExample agent in examples.
* Update Actuator README with link to SchedulerExample

Fixes #2675 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Built docs locally and checked hyperlink. Screenshot attached:

![Screen Shot 2021-05-05 at 10 59 30 AM](https://user-images.githubusercontent.com/6901848/117188200-a381fb80-ad91-11eb-858d-3819500ab171.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
