### PR TITLE
Add sleep for config_store_connection fixture

### DIFF
--- a/services/core/PlatformDriverAgent/tests/test_device_groups.py
+++ b/services/core/PlatformDriverAgent/tests/test_device_groups.py
@@ -75,7 +75,7 @@ class _subscriber_agent(Agent):
 
 
 @pytest.fixture(scope="module")
-def subscriber_agent(request, volttron_instance):
+def subscriber_agent(volttron_instance):
 
     agent = volttron_instance.build_agent(identity='subscriber_agent', agent_class=_subscriber_agent)
 
@@ -118,9 +118,10 @@ FloatNoDefault,FloatNoDefault,F,-100 to 300,TRUE,,float,CO2 Reading 0.00-2000.0 
 
 
 @pytest.fixture(scope="module")
-def config_store_connection(request, volttron_instance):
+def config_store_connection(volttron_instance):
     capabilities = [{'edit_config_store': {'identity': PLATFORM_DRIVER}}]
     connection = volttron_instance.build_connection(peer=CONFIGURATION_STORE, capabilities=capabilities)
+    gevent.sleep(1)
     # Reset platform driver config store
     connection.call("manage_delete_store", PLATFORM_DRIVER)
 
@@ -141,14 +142,14 @@ def config_store_connection(request, volttron_instance):
 
 
 @pytest.fixture(scope="function")
-def config_store(request, config_store_connection):
+def config_store(config_store_connection):
     # Always have fake.csv ready to go.
     print("Adding fake.csv into store")
     config_store_connection.call("manage_store", PLATFORM_DRIVER, "fake.csv", registry_config_string, config_type="csv")
 
     yield config_store_connection
-    # Reset platform driver config store
-    print("Wiping out store.")
+
+    print("Resetting platform driver config store")
     config_store_connection.call("manage_delete_store", PLATFORM_DRIVER)
     gevent.sleep(0.1)
 


### PR DESCRIPTION
# Description

* Add sleep to config_store_connection fixture so that connection fixture can reset the driver config store as part of the test setup (this fixture fails to build for integ tests running on Volttron platform running on RMQ)
* Remove unused parameters in fixtures

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran pytest. See output below:

```shell
$ pytest services/core/PlatformDriverAgent/tests/test_device_groups.py 

======================================================== test session starts ========================================================
platform linux -- Python 3.7.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/mark2/Workplace/volttron/env/bin/python
cachedir: .pytest_cache
rootdir: /home/mark2/Workplace/volttron, configfile: pytest.ini
plugins: timeout-1.4.2
timeout: 240.0s
timeout method: signal
timeout func_only: False
collected 8 items                                                                                                                   

services/core/PlatformDriverAgent/tests/test_device_groups.py::test_no_groups[volttron_instance0] PASSED                      [ 12%]
services/core/PlatformDriverAgent/tests/test_device_groups.py::test_groups_no_interval[volttron_instance0] PASSED             [ 25%]

                                                                                                  PASSED                      [ 62%]
services/core/PlatformDriverAgent/tests/test_device_groups.py::test_groups_no_interval[volttron_instance1] PASSED             [ 75%]
services/core/PlatformDriverAgent/tests/test_device_groups.py::test_groups_interval[volttron_instance1] PASSED                [ 87%]
services/core/PlatformDriverAgent/tests/test_device_groups.py::test_add_remove_drivers[volttron_instance1] PASSED             [100%]

============================================= 8 passed, 5 warnings in 136.38s (0:02:16) =============================================
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
