### PR TITLE
Add pytest markers for contributed agent tests; add sleep for test_global_override and settings tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -62,3 +62,4 @@ markers =
         sqlitefuncts: level one integration tests for sqlitefuncts
         unit: Run all unit/level one integration tests
         influxdbutils: level one integration tests for influxdb
+        contrib: tests for community-contributed agents

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/chargepoint/tests/test_chargepoint_driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/chargepoint/tests/test_chargepoint_driver.py
@@ -42,6 +42,8 @@ import gevent
 
 from volttron.platform import get_services_core
 
+pytestmark = [pytest.mark.contrib]
+
 DRIVER1_CONFIG_STRING = """{
     "driver_config": {
         "stationID" : "1:34003",

--- a/services/core/PlatformDriverAgent/tests/test_eagle.py
+++ b/services/core/PlatformDriverAgent/tests/test_eagle.py
@@ -45,6 +45,8 @@ from volttron.platform import get_services_core, jsonapi
 from volttrontesting.utils.utils import get_rand_http_address
 from volttron.platform.agent.known_identities import CONFIGURATION_STORE, PLATFORM_DRIVER
 
+pytestmark = [pytest.mark.skip(reason='Community-contributed driver'), pytest.mark.contrib]
+
 server_addr = get_rand_http_address()
 no_scheme = server_addr[7:]
 ip, port = no_scheme.split(':')

--- a/services/core/PlatformDriverAgent/tests/test_global_override.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_override.py
@@ -85,6 +85,7 @@ platform_driver_config = """
 def config_store_connection(request, volttron_instance):
     capabilities = [{'edit_config_store': {'identity': PLATFORM_DRIVER}}]
     connection = volttron_instance.build_connection(peer=CONFIGURATION_STORE, capabilities=capabilities)
+    gevent.sleep(1)
     # Reset platform driver config store
     connection.call("manage_delete_store", PLATFORM_DRIVER)
 

--- a/services/core/PlatformDriverAgent/tests/test_global_settings.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_settings.py
@@ -152,6 +152,7 @@ breadth_set = set(['devices/Float/fake', 'devices/FloatNoDefault/fake'])
 def config_store_connection(request, volttron_instance):
     capabilities = [{'edit_config_store': {'identity': PLATFORM_DRIVER}}]
     connection = volttron_instance.build_connection(peer=CONFIGURATION_STORE, capabilities=capabilities)
+    gevent.sleep(1)
     # Reset platform driver config store
     connection.call("manage_delete_store", PLATFORM_DRIVER)
 


### PR DESCRIPTION
# Description

* Adds 'contrib' marker for pytests on community-contributed code
* Skip tests on test_eagle.py, which is community-contributed and does not work
* Add sleep for connection fixture in test_global_override and test_global_settings so that tests setup succeeds on RMQ-related tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran pytest on all tests in a VM running Ubuntu 18.04. All tests pass or are skipped as configured.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
