### PR TITLE
Updated tests in proper directory

### DIFF
--- a/volttrontesting/platform/web/test_admin.py
+++ b/volttrontesting/platform/web/test_admin.py
@@ -29,7 +29,7 @@ def test_can_authenticate_admin_user(volttron_instance_web, user_pass):
 
     resp = webadmin.authenticate(user, password)
     assert resp.ok
-    assert resp.headers.get('Content-Type') == 'text/plain'
+    assert resp.headers.get('Content-Type') == 'application/json'
 
     resp = webadmin.authenticate('fake', password)
     assert resp.status_code == 401  # unauthorized
@@ -49,7 +49,7 @@ def test_can_create_admin_user(volttron_instance_web, user_pass):
 
     resp = webadmin.authenticate(user, password)
     assert resp.ok
-    assert resp.headers.get('Content-Type') == 'text/plain'
+    assert resp.headers.get('Content-Type') == 'application/json'
 
     resp = webadmin.authenticate('fake', password)
     assert resp.status_code == 401  # unauthorized

--- a/volttrontesting/platform/web/test_discovery.py
+++ b/volttrontesting/platform/web/test_discovery.py
@@ -42,7 +42,7 @@ import os
 from volttron.platform.web import DiscoveryInfo
 
 from volttrontesting.utils.web_utils import get_test_web_env
-
+from volttrontesting.fixtures.volttron_platform_fixtures import volttron_instance_web
 
 def test_discovery_endpoint(volttron_instance_web):
     """

--- a/volttrontesting/platform/web/test_web_authentication.py
+++ b/volttrontesting/platform/web/test_web_authentication.py
@@ -10,6 +10,7 @@ from deepdiff import DeepDiff
 import pytest
 
 from volttron.platform.web import PlatformWebService
+from volttrontesting.utils.utils import AgentMock
 
 try:
     import jwt

--- a/volttrontesting/platform/web/test_web_authentication.py
+++ b/volttrontesting/platform/web/test_web_authentication.py
@@ -1,3 +1,4 @@
+import os
 import json
 from urllib.parse import urlencode
 
@@ -5,21 +6,32 @@ import gevent
 from datetime import datetime, timedelta
 from mock import MagicMock
 from deepdiff import DeepDiff
-import jwt
+
 import pytest
 
+from volttron.platform.web import PlatformWebService
+
+try:
+    import jwt
+except ImportError:
+    pytest.mark.skip(reason="JWT is missing! Web is not enabled for this installation of VOLTTRON")
+
+from volttron.platform import is_rabbitmq_available
 from volttron.platform.agent.known_identities import AUTH
-from volttron.platform.certs import CertWrapper
+from volttron.platform.certs import CertWrapper, Certs
 from volttron.platform.vip.agent import Agent
 from volttron.utils import get_random_key
-from volttrontesting.utils.platformwrapper import create_volttron_home
-from volttrontesting.utils.utils import AgentMock
+from volttrontesting.utils.platformwrapper import create_volttron_home, with_os_environ
 from volttrontesting.utils.web_utils import get_test_web_env
-from volttron.platform.web.platform_web_service import PlatformWebService
 from volttron.platform.web.admin_endpoints import AdminEndpoints
 from volttron.platform.web.authenticate_endpoint import AuthenticateEndpoints
 from volttrontesting.fixtures.cert_fixtures import certs_profile_1
-from volttrontesting.fixtures.volttron_platform_fixtures import get_test_volttron_home
+from volttrontesting.fixtures.volttron_platform_fixtures import get_test_volttron_home, volttron_instance_web
+
+HAS_RMQ = is_rabbitmq_available()
+ci_skipif = pytest.mark.skipif(os.getenv('CI', None) == 'true', reason='SSL does not work in CI')
+rmq_skipif = pytest.mark.skipif(not HAS_RMQ,
+                                reason='RabbitMQ is not setup and/or SSL does not work in CI')
 
 
 @pytest.mark.parametrize("encryption_type", ("private_key", "tls"))
@@ -177,27 +189,137 @@ def mock_platformweb_service():
     platformweb._admin_endpoints = AdminEndpoints(rpc_caller=rpc_caller)
     yield platformweb
 
-# TODO: These tests are updated in PR#2650
 
-# @pytest.mark.web
-# def test_get_credentials(mock_platformweb_service):
-#     mock_platformweb_service._admin_endpoints._pending_auths = mock_platformweb_service._admin_endpoints._rpc_caller.call(AUTH, 'get_authorization_pending')
-#     mock_platformweb_service._admin_endpoints._denied_auths = mock_platformweb_service._admin_endpoints._rpc_caller.call(AUTH, 'get_authorization_denied')
-#     pass
-#
-#
-# @pytest.mark.web
-# def test_accept_credential(mock_platformweb_service):
-#     mock_platformweb_service._admin_endpoints._pending_auths = mock_platformweb_service._admin_endpoints._rpc_caller.call(AUTH, 'get_authorization_pending').get()
-#     mock_platformweb_service._admin_endpoints._denied_auths = mock_platformweb_service._admin_endpoints._rpc_caller.call(AUTH, 'get_authorization_denied').get()
-#     pass
-#
-#
-# @pytest.mark.web
-# def test_deny_credential():
-#     pass
-#
-#
-# @pytest.mark.web
-# def test_delete_credential():
-#     pass
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_authenticate_endpoint(scheme):
+    kwargs = {}
+
+    # Note this is not a context wrapper, it just does the creation for us
+    vhome = create_volttron_home()
+
+    if scheme == 'https':
+        with certs_profile_1(vhome) as certs:
+            kwargs['web_ssl_key'] = certs.server_certs[0].key_file
+            kwargs['web_ssl_cert'] = certs.server_certs[0].cert_file
+    else:
+        kwargs['web_secret_key'] = get_random_key()
+
+    # We are specifying the volttron_home here so we don't create an additional one.
+    with get_test_volttron_home(messagebus='zmq', config_params=kwargs, volttron_home=vhome):
+
+        user = 'bogart'
+        passwd = 'cat'
+        adminep = AdminEndpoints()
+        adminep.add_user(user, passwd)
+
+        env = get_test_web_env('/authenticate', method='POST')
+
+        if scheme == 'http':
+            authorizeep = AuthenticateEndpoints(web_secret_key=kwargs.get('web_secret_key'))
+        else:
+            authorizeep = AuthenticateEndpoints(tls_private_key=CertWrapper.load_key(kwargs.get('web_ssl_key')))
+
+        invalid_login_username_params = dict(username='fooey', password=passwd)
+
+        response = authorizeep.get_auth_tokens(env, invalid_login_username_params)
+
+        # assert '401 Unauthorized' in response.content
+        assert '401 UNAUTHORIZED' == response.status
+
+        invalid_login_password_params = dict(username=user, password='hazzah')
+        response = authorizeep.get_auth_tokens(env, invalid_login_password_params)
+
+        assert '401 UNAUTHORIZED' == response.status
+        valid_login_params = urlencode(dict(username=user, password=passwd))
+        response = authorizeep.get_auth_tokens(env, valid_login_params)
+        assert '200 OK' == response.status
+        assert "application/json" in response.content_type
+        response_data = json.loads(response.data.decode('utf-8'))
+        assert 3 == len(response_data["refresh_token"].split('.'))
+        assert 3 == len(response_data["access_token"].split('.'))
+
+
+@pytest.mark.web
+def test_get_credentials(volttron_instance_web):
+    instance = volttron_instance_web
+    auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+    print(f"Auth pending is: {auth_pending}")
+    assert len(auth_pending) == 0
+    with with_os_environ(instance.env):
+        pending_agent = Agent(identity="PendingAgent")
+        task = gevent.spawn(pending_agent.core.run)
+        task.join(timeout=5)
+        pending_agent.core.stop()
+
+    auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+    print(f"Auth pending is: {auth_pending}")
+
+    assert len(auth_pending) == 1
+
+
+@pytest.mark.web
+def test_accept_credential(volttron_instance_web):
+    instance = volttron_instance_web
+    with with_os_environ(instance.env):
+        pending_agent = Agent(identity="PendingAgent")
+        task = gevent.spawn(pending_agent.core.run)
+        task.join(timeout=5)
+        pending_agent.core.stop()
+
+        auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+        print(f"Auth pending is: {auth_pending}")
+        assert len(auth_pending) == 1
+
+        auth_approved = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_approved").get()
+        assert len(auth_approved) == 0
+
+        print(f"agent uuid: {pending_agent.core.agent_uuid}")
+        instance.dynamic_agent.vip.rpc.call(AUTH, "approve_authorization_failure", auth_pending[0]["user_id"]).get()
+        auth_approved = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_approved").get()
+
+        assert len(auth_approved) == 1
+
+
+@pytest.mark.web
+def test_deny_credential(volttron_instance_web):
+    instance = volttron_instance_web
+    with with_os_environ(instance.env):
+        pending_agent = Agent(identity="PendingAgent")
+        task = gevent.spawn(pending_agent.core.run)
+        task.join(timeout=5)
+        pending_agent.core.stop()
+
+        auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+        print(f"Auth pending is: {auth_pending}")
+        assert len(auth_pending) == 1
+
+        auth_denied = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_denied").get()
+        assert len(auth_denied) == 0
+
+        print(f"agent uuid: {pending_agent.core.agent_uuid}")
+        instance.dynamic_agent.vip.rpc.call(AUTH, "deny_authorization_failure", auth_pending[0]["user_id"]).get()
+        auth_denied = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_denied").get()
+
+        assert len(auth_denied) == 1
+
+
+@pytest.mark.web
+def test_delete_credential(volttron_instance_web):
+    instance = volttron_instance_web
+    auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+    print(f"Auth pending is: {auth_pending}")
+    assert len(auth_pending) == 0
+    with with_os_environ(instance.env):
+        pending_agent = Agent(identity="PendingAgent")
+        task = gevent.spawn(pending_agent.core.run)
+        task.join(timeout=5)
+        pending_agent.core.stop()
+
+        auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+        print(f"Auth pending is: {auth_pending}")
+        assert len(auth_pending) == 1
+
+        instance.dynamic_agent.vip.rpc.call(AUTH, "delete_authorization_failure", auth_pending[0]["user_id"]).get()
+        auth_pending = instance.dynamic_agent.vip.rpc.call(AUTH, "get_authorization_pending").get()
+
+        assert len(auth_pending) == 0


### PR DESCRIPTION
Description
-------------
Added integration tests to test_web_authentication.py for testing RPC calls to AuthService for management of pending ZMQ credentials.
Added check to test_web_authentication.py to verify if the user has a web-enabled VOLTTRON installation before running tests.

Type of change
-----------------
Updated Tests

How Has This Been Tested?
------------------------------
Ran pytest on the web/tests directory using PyCharm IDE. Some of the new integration tests in test_web_authentication.py needed to be re-ran separately before they passed. These were re-ran using the re-run failed tests option from within PyCharm, or by running the tests individually. All tests are passing.
