### PR TITLE
removed double_precision parameter when doing ujson.dumps. 

### DIFF
--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -260,7 +260,7 @@ try:
 
     def dumps(data):
         try:
-            return ujson.dumps(data, double_precision=15)
+            return ujson.dumps(data)
         except Exception:
             return _dumps(data)
 


### PR DESCRIPTION
removed double_precision parameter when doing ujson.dumps(). This was removed in ujson version > 2
jira396
Tested:
Ran mongo historian integration test cases to verify that nothing breaks. 