### PR TITLE
Web Admin Page Timeout Fix

### DIFF
--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -41,8 +41,6 @@ import os
 import re
 from urllib.parse import parse_qs
 
-import jwt
-
 from volttron.platform.agent.known_identities import PLATFORM_WEB, AUTH
 from volttron.platform.jsonrpc import RemoteError
 

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -162,7 +162,7 @@ class AdminEndpoints(object):
             claims = self._rpc_caller(PLATFORM_WEB, 'get_user_claims', get_bearer(env)).get()
         except RemoteError as e:
             if "ExpiredSignatureError" in e.exc_info["exc_type"]:
-                _log.warn("Access token has expired! Please re-login to renew.")
+                _log.warning("Access token has expired! Please re-login to renew.")
                 template = template_env(env).get_template('login.html')
                 _log.debug("Login.html: {}".format(env.get('PATH_INFO')))
                 return Response(template.render(), content_type='text/html')

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -160,6 +160,9 @@ class AdminEndpoints(object):
         from volttron.platform.web import get_bearer, NotAuthorized
         try:
             claims = self._rpc_caller(PLATFORM_WEB, 'get_user_claims', get_bearer(env)).get()
+        except NotAuthorized:
+            _log.error("Unauthorized user attempted to connect to {}".format(env.get('PATH_INFO')))
+            return Response('<h1>Unauthorized User</h1>', status="401 Unauthorized")
         except RemoteError as e:
             if "ExpiredSignatureError" in e.exc_info["exc_type"]:
                 _log.warning("Access token has expired! Please re-login to renew.")


### PR DESCRIPTION
# Description

When the access token expires and the admin web page is refreshed, an exception is caused. With this fix, when the access token expires and the page is refreshed, a warning will be stored in the log and the user will be redirected to the login page.

Fixes # (issue)

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test using a very reduced access token expiration time (30 seconds).
Verified that on a refresh the warning is logged, and the website is reset to the login page.
Ran web pytests and verified all pass.

