### PR TITLE
Added handler for devices that do not support use_read_multiple by de…

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/bacnet.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/bacnet.py
@@ -171,6 +171,10 @@ class Interface(BaseInterface):
                     self.max_per_request = max(int(self.register_count/self.register_count_divisor), 1)
                     _log.info("Device requires a lower max_per_request setting. Trying: "+str(self.max_per_request))
                     continue
+                elif e.message.endswith("rejected the request: 9") and self.use_read_multiple:
+                    _log.info("Device rejected request with 'unrecognized-service' error, attempting to access with use_read_multiple false")
+                    self.use_read_multiple = False
+                    continue
                 else:
                     raise
             except errors.Unreachable:


### PR DESCRIPTION
…fault

# Description

Automatically resolves situation where a device is configured to use_read_multiple but rejects read_multiple requests with the 'unrecognized-service' error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Had device configured to use_read_multiple that was responding with  rejection errors and deployed code, scrapes happened successfully.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
