### PR TITLE
Update Agent Auto-Start Documentation

### DIFF
--- a/docs/source/platform-features/control/agent-management-control.rst
+++ b/docs/source/platform-features/control/agent-management-control.rst
@@ -239,5 +239,5 @@ used with the ``--tag`` or ``--name`` options.
 
 .. code-block:: bash
 
-    vctl enable <AGENT_UUID> <PRIORITY>
+    vctl enable <AGENT_UUID> -p <PRIORITY>
 


### PR DESCRIPTION
Clarify in the example command that the -p option is needed to set the priority.