### PR TITLE
Set timeout to max for the dbutils workflow.

### DIFF
--- a/.github/workflows/pytest-dbutils.yml
+++ b/.github/workflows/pytest-dbutils.yml
@@ -38,6 +38,7 @@ jobs:
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
         with:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}


### PR DESCRIPTION
# Description

This PR sets max to 600 seconds for the dbutils workflow.  