### PR TITLE
Add CI env var to dbutils workflow

### DIFF
--- a/.github/workflows/pytest-dbutils.yml
+++ b/.github/workflows/pytest-dbutils.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
         TEST_TYPE: dbutils
+        CI: true
     steps:
       # checkout the volttron repository and set current directory to it
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Set CI env var in dbutils workflow so that only a limited number of images are run.
For details on env var in GitHub Workflows see https://docs.github.com/en/actions/reference/environment-variables

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the workflow on my GitHub account. See https://github.com/bonicim/volttron/actions/runs/1121248820

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
