### PR TITLE
Remove influxdb:latest image

### DIFF
--- a/volttrontesting/platform/dbutils/test_influxdbutils.py
+++ b/volttrontesting/platform/dbutils/test_influxdbutils.py
@@ -17,10 +17,10 @@ import volttron.platform.dbutils.influxdbutils as influxdbutils
 from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
-IMAGES = ["influxdb"]
+IMAGES = ["influxdb:1.7"]
 
 if "CI" not in os.environ:
-    IMAGES.extend(["influxdb:1.7", "influxdb:1.8.1", "influxdb:1.7.10"])
+    IMAGES.extend(["influxdb:1.8.1", "influxdb:1.7.10"])
 
 TEST_DATABASE = "test_historian"
 ENV_INFLUXDB = {"INFLUXDB_DB": TEST_DATABASE}


### PR DESCRIPTION
# Description

Remove influxdb:latest image from influxdb tests. Influxdb:latest requires specific configuration on Docker and thus negatively impacts the influxdb test setup, which uses a different Docker configuration.

Related to issue #2738 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Ran tests locally and verified that influxdb:latest was not used for testing. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
