### PR TITLE
Pin tzlocal to 2.1

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -57,7 +57,8 @@ install_requires = [
     'PyYAML',
     'pyzmq',
     'setuptools',
-    'tzlocal',
+    # tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/
+    'tzlocal==2.1',
     'pyOpenSSL==19.0.0',
     'cryptography==2.3',
     # Cross platform way of handling changes in file/directories.


### PR DESCRIPTION
# Description

# tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/

This pr pins tzlocal==2.1

```
2021-08-17 23:24:33,863 volttron.platform.vip.agent.core DEBUG: Running onstart methods.
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 854, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/runner/work/volttron/volttron/volttron/platform/vip/agent/subsystems/heartbeat.py", line 79, in onstart
    self.start()
  File "/home/runner/work/volttron/volttron/volttron/platform/vip/agent/subsystems/heartbeat.py", line 91, in start
    self.scheduled = self.core().schedule(periodic(self.period), self.publish)
  File "/home/runner/work/volttron/volttron/volttron/platform/vip/agent/core.py", line 430, in schedule
    self._schedule_iter(it, event)
  File "/home/runner/work/volttron/volttron/volttron/platform/vip/agent/core.py", line 462, in _schedule_iter
    self._schedule_callback(deadline, wrapper)
  File "/home/runner/work/volttron/volttron/volttron/platform/vip/agent/core.py", line 438, in _schedule_callback
    deadline = utils.get_utc_seconds_from_epoch(deadline)
  File "/home/runner/work/volttron/volttron/volttron/platform/agent/utils.py", line 653, in get_utc_seconds_from_epoch
    timestamp = local_tz.localize(timestamp)
AttributeError: 'backports.zoneinfo.ZoneInfo' object has no attribute 'localize'
2021-08-17T23:24:33Z <Greenlet at 0x7f07782d43b0: onstart(<volttron.platform.vip.agent.core.ZMQCore object a)> failed with AttributeError
```

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Fixed in github actions test runs.