### PR TITLE
vctl auth serverkey requires volttron to be running.

### DIFF
--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1735,7 +1735,14 @@ def show_serverkey(opts):
 
     return 0 if success, 1 if false
     """
-    q = Query(opts.connection.server.core)
+    conn = opts.connection
+    if not conn:
+        _stderr.write(
+            "VOLTTRON is not running. This command "
+            "requires VOLTTRON platform to be running\n"
+        )
+        return
+    q = Query(conn.server.core)
     pk = q.query("serverkey").get(timeout=2)
     del q
     if pk is not None:

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -1741,7 +1741,7 @@ def show_serverkey(opts):
             "VOLTTRON is not running. This command "
             "requires VOLTTRON platform to be running\n"
         )
-        return
+        return 1
     q = Query(conn.server.core)
     pk = q.query("serverkey").get(timeout=2)
     del q


### PR DESCRIPTION
# Description

vctl auth parser has some commands that do not require the platform to be running to execute. vctl auth serverkey relies on the platform to be running, but does not check if a connection to the platform is available. This PR is to address that.

Fixes #

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested using vctl with and without platform running.
