### PR TITLE
Add workflows for dbutils tests; update db images for testing

### DIFF
--- a/.github/workflows/pytest-dbutils-backup_db.yml
+++ b/.github/workflows/pytest-dbutils-backup_db.yml
@@ -1,0 +1,68 @@
+---
+# This workflow is meant as a foundational workflow for running integration/unit tests on multiple targeted
+# ubuntu versions with multiple python versions.
+#
+# This workflow utilizes the build-dependency-cache workflow which sets up the environment dependencies using
+# bootstrap.py --all
+#
+
+# Documentation for the syntax of this file is located
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+
+# The workflow name will show up in the action tab on github during execution
+# https://github.com/VOLTTRON/volttron/actions (or if you are pushing to your own fork change the user)
+name: Testing BackupDatabase
+
+# Determine what events are going to trigger a running of the workflow
+on: [pull_request]
+
+jobs:
+  build:
+    env:
+        TEST_FILE: volttrontesting/platform/dbutils/test_backup_database.py
+
+    # The strategy allows customization of the build and allows matrixing the version of os and software
+    # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry in the os and python-version matrix will be run. For example, on a list of 3 os's and 4 python versions, 12 jobs will be run
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
+
+    # Run-on determines the operating system available to run on
+    # - At the current time there is only ubuntu machines between 16.04 and 20.04 available
+    # - This uses the matrix os from the strategy above
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout the volttron repository and set current directory to it
+      - uses: actions/checkout@v2
+
+      # setup the python environment for the operating system
+      - name: Set up Python ${{matrix.os}} ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Run the specified tests and save the results to a unique file that can be archived for later analysis.
+      - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+        uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
+        with:
+            python_version: ${{ matrix.python-version }}
+            os: ${{ matrix.os }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
+
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: pytest-report
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/.github/workflows/pytest-dbutils-influxdbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-influxdbfuncts.yml
@@ -1,0 +1,58 @@
+---
+# This workflow is meant as a foundational workflow for running integration/unit tests on the
+# platform.
+# This workflow also shows the caching mechanisms available for storage
+# and retrieval of cache for quicker setup of test environments.
+
+
+name: Testing influxdbutils
+on: [pull_request]
+
+jobs:
+  build:
+    env:
+      TEST_FILE: volttrontesting/platform/dbutils/test_influxdbutils.py
+
+    # The strategy allows customization of the build and allows matrixing the version of os and software
+    # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry in the os and python-version matrix will be run so for the 3 x 4 there will be 12 jobs run
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout the volttron repository and set current directory to it
+      - uses: actions/checkout@v2
+
+      # Attempt to restore the cache from the build-dependency-cache workflow if present then
+      # the output value steps.check_files.outputs.files_exists will be set (see the next step for usage)
+      - name: Set up Python ${{matrix.os}} ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Run the specified tests and save the results to a unique file that can be archived for later analysis.
+      - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+        uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
+        with:
+            python_version: ${{ matrix.python-version }}
+            os: ${{ matrix.os }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
+
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: pytest-report
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/.github/workflows/pytest-dbutils-sqlitefuncts.yml
+++ b/.github/workflows/pytest-dbutils-sqlitefuncts.yml
@@ -1,0 +1,58 @@
+---
+# This workflow is meant as a foundational workflow for running integration/unit tests on the
+# platform.
+# This workflow also shows the caching mechanisms available for storage
+# and retrieval of cache for quicker setup of test environments.
+
+
+name: Testing sqlitefuncts
+on: [pull_request]
+
+jobs:
+  build:
+    env:
+      TEST_FILE: volttrontesting/platform/dbutils/test_sqlitefuncts.py
+
+    # The strategy allows customization of the build and allows matrixing the version of os and software
+    # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry in the os and python-version matrix will be run so for the 3 x 4 there will be 12 jobs run
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout the volttron repository and set current directory to it
+      - uses: actions/checkout@v2
+
+      # Attempt to restore the cache from the build-dependency-cache workflow if present then
+      # the output value steps.check_files.outputs.files_exists will be set (see the next step for usage)
+      - name: Set up Python ${{matrix.os}} ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Run the specified tests and save the results to a unique file that can be archived for later analysis.
+      - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+        uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
+        with:
+            python_version: ${{ matrix.python-version }}
+            os: ${{ matrix.os }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
+
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: pytest-report
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
@@ -1,30 +1,29 @@
 ---
 # This workflow is meant as a foundational workflow for running integration/unit tests on the
-# platform.  For this workflow we are testing the
-#
-# volttrontesting/testutils directory using pytest.
-#
+# platform.
 # This workflow also shows the caching mechanisms available for storage
 # and retrieval of cache for quicker setup of test environments.
 
-name: Testing dbutils directory
+
+name: Testing postgresql_timescaledb_functs
 on: [pull_request]
 
 jobs:
   build:
+    env:
+      TEST_FILE: volttrontesting/platform/dbutils/test_postgresql_timescaledb.py
+
     # The strategy allows customization of the build and allows matrixing the version of os and software
     # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
     strategy:
       fail-fast: false
       matrix:
         # Each entry in the os and python-version matrix will be run so for the 3 x 4 there will be 12 jobs run
-        os: [ ubuntu-18.04 ] # , ubuntu-20.04  ]
-        python-version: [ 3.7 ] # 3.6, 3.7] # , 3.8, 3.9 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
 
     runs-on: ${{ matrix.os }}
-    env:
-        TEST_TYPE: dbutils
-        CI: true
+
     steps:
       # checkout the volttron repository and set current directory to it
       - uses: actions/checkout@v2
@@ -43,13 +42,17 @@ jobs:
         with:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
-            test_path: volttrontesting/platform/${{ env.TEST_TYPE }}
-            test_output_suffix: ${{ env.TEST_TYPE }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
 
 #       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: pytest-report
-          path: output/${{ env.TEST_TYPE }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/volttrontesting/platform/dbutils/test_influxdbutils.py
+++ b/volttrontesting/platform/dbutils/test_influxdbutils.py
@@ -17,10 +17,9 @@ import volttron.platform.dbutils.influxdbutils as influxdbutils
 from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
-IMAGES = ["influxdb:1.7"]
-
-if "CI" not in os.environ:
-    IMAGES.extend(["influxdb:1.8.1", "influxdb:1.7.10"])
+IMAGES = ["influxdb:1.8"]
+if "CI" in os.environ:
+    IMAGES.extend(["influxdb:1.7"])
 
 TEST_DATABASE = "test_historian"
 ENV_INFLUXDB = {"INFLUXDB_DB": TEST_DATABASE}

--- a/volttrontesting/platform/dbutils/test_mongoutils.py
+++ b/volttrontesting/platform/dbutils/test_mongoutils.py
@@ -14,21 +14,10 @@ from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
 
-IMAGES = ["mongo:3-xenial", "mongo:bionic"]
-
-if "CI" not in os.environ:
+IMAGES = ["mongo:latest"]
+if "CI" in os.environ:
     IMAGES.extend(
-        [
-            "mongo:3.6-xenial",
-            "mongo:3.6.19-xenial",
-            "mongo:4.0-xenial",
-            "mongo:4.0.19-xenial",
-            "mongo:4-bionic",
-            "mongo:4.2-bionic",
-            "mongo:4.2.8-bionic",
-            "mongo:4.4-bionic",
-            "mongo:4.4.0-bionic",
-        ]
+        ["mongo:5.0", "mongo:4.0"]
     )
 
 TEST_DATABASE = "test_historian"

--- a/volttrontesting/platform/dbutils/test_mysqlfuncts.py
+++ b/volttrontesting/platform/dbutils/test_mysqlfuncts.py
@@ -23,12 +23,10 @@ pytestmark = [pytest.mark.mysqlfuncts, pytest.mark.dbutils, pytest.mark.unit]
 
 
 IMAGES = [
-    "mysql:5.6.49",
-    "mysql:8.0.25"
+    "mysql:latest"
+    "mysql:5.7.35",
+    "mysql:5.6"
 ]
-
-if "CI" in os.environ:
-    IMAGES.extend(["mysql:5.7.31", "mysql:5", "mysql:5.6", "mysql:5.7"])
 
 CONNECTION_HOST = "localhost"
 TEST_DATABASE = "test_historian"

--- a/volttrontesting/platform/dbutils/test_postgresql_timescaledb.py
+++ b/volttrontesting/platform/dbutils/test_postgresql_timescaledb.py
@@ -28,10 +28,10 @@ pytestmark = [
 ]
 
 
-IMAGES = ["timescale/timescaledb:latest-pg10"]
+IMAGES = ["timescale/timescaledb:latest-pg12"]
 if "CI" in os.environ:
     IMAGES.extend(
-        ["timescale/timescaledb:latest-pg12", "timescale/timescaledb:latest-pg11"]
+        ["timescale/timescaledb:latest-pg11", "timescale/timescaledb:latest-pg10"]
     )
 
 CONNECTION_HOST = "localhost"

--- a/volttrontesting/platform/dbutils/test_postgresqlfuncts.py
+++ b/volttrontesting/platform/dbutils/test_postgresqlfuncts.py
@@ -24,24 +24,12 @@ logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
 pytestmark = [pytest.mark.postgresqlfuncts, pytest.mark.dbutils, pytest.mark.unit]
 
 
-# Current documentation claims that we have tested Historian on Postgres 10
-# See https://volttron.readthedocs.io/en/develop/core_services/historians/SQL-Historian.html#postgresql-and-redshift
-IMAGES = ["postgres:9.6.18", "postgres:10.13"]
-
+IMAGES = ["postgres:13"]
 if "CI" in os.environ:
     IMAGES.extend(
-        [
-            "postgres:11.8",
-            "postgres:9",
-            "postgres:9.5",
-            "postgres:10",
-            "postgres:11",
-            "postgres:12",
-            "postgres:12.3",
-            "postgres:13",
-            "postgres:13-beta2",
-        ]
+        ["postgres:12", "postgres:11"]
     )
+
 ALLOW_CONNECTION_TIME = 10
 CONNECTION_HOST = "localhost"
 TEST_DATABASE = "test_historian"
@@ -297,7 +285,6 @@ def test_insert_agg_topic_should_return_true(get_container_func):
 def test_update_agg_topic_should_return_true(get_container_func):
     container, sqlfuncts, connection_port, historian_version = get_container_func
 
-
     topic = "cars"
     agg_type = "SUM"
     agg_time_period = "2100ZULU"
@@ -444,7 +431,6 @@ def test_create_aggregate_store_should_succeed(get_container_func):
 
 def test_insert_aggregate_stmt_should_succeed(get_container_func):
     container, sqlfuncts, connection_port, historian_version = get_container_func
-
 
     # be aware that Postgresql will automatically fold unquoted names into lower case
     # From : https://www.postgresql.org/docs/current/sql-syntax-lexical.html


### PR DESCRIPTION
# Description

Creates separate Workflows for each of the test for dbutils except for mongoutils because MongoDBHistorian is unsupported. 

Reduces number of database images to be tested to 2-3 images in accordance with what documentation states on what databases have been tested on. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran Workflows on my personal Github account. See https://github.com/bonicim/volttron/actions


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
