### PR TITLE
Fixed Agent Install Config in VCFG

### DIFF
--- a/volttron/platform/instance_setup.py
+++ b/volttron/platform/instance_setup.py
@@ -217,7 +217,7 @@ def _install_agent(agent_dir, config, tag):
         with open(cfg.name, 'w') as fout:
             fout.write(jsonapi.dumps(config))
         config_file = cfg.name
-    _cmd(['volttron-ctl', 'install', "--config", config_file, "--tag", tag, "--force", agent_dir])
+    _cmd(['volttron-ctl', 'install', "--agent-config", config_file, "--tag", tag, "--force", agent_dir])
 
 
 def _is_agent_installed(tag):


### PR DESCRIPTION
# Description

Vcfg used **vctl install** internally to install agents to the volttron instance with the "--config" option to set the agent configuration.  The "--config" option is used to select the configuration of the volttron instance that vctl is using, not the agent config. This has been corrected to use the correct option for setting the agent's configuration file "--agent-config". This bug was discovered when attempting to install the SQL Platform Historian with vcfg. The agent installed correctly, but was unable to start due to a broken configuration.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested using vcfg to install the SQL Platform Historian, and verified it was able to start correctly.
