### PR TITLE
Change test setup  and add GH Workflows for mysqlfunct, postgresqlfuncts; update DNP3 tests

### DIFF
--- a/.github/workflows/pytest-dbutils-backup_db.yml
+++ b/.github/workflows/pytest-dbutils-backup_db.yml
@@ -14,7 +14,16 @@
 name: Testing BackupDatabase
 
 # Determine what events are going to trigger a running of the workflow
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-dbutils-influxdbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-influxdbfuncts.yml
@@ -6,7 +6,16 @@
 
 
 name: Testing influxdbutils
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-dbutils-mysqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-mysqlfuncts.yml
@@ -5,7 +5,7 @@
 # and retrieval of cache for quicker setup of test environments.
 
 
-name: Testing mysqlfucnts
+name: Testing mysqlfuncts
 on:
   push:
     branches:

--- a/.github/workflows/pytest-dbutils-mysqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-mysqlfuncts.yml
@@ -1,0 +1,58 @@
+---
+# This workflow is meant as a foundational workflow for running integration/unit tests on the
+# platform.
+# This workflow also shows the caching mechanisms available for storage
+# and retrieval of cache for quicker setup of test environments.
+
+
+name: Testing mysqlfucnts
+on: [pull_request]
+
+jobs:
+  build:
+    env:
+      TEST_FILE: volttrontesting/platform/dbutils/test_mysqlfuncts.py
+
+    # The strategy allows customization of the build and allows matrixing the version of os and software
+    # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry in the os and python-version matrix will be run so for the 3 x 4 there will be 12 jobs run
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout the volttron repository and set current directory to it
+      - uses: actions/checkout@v2
+
+      # Attempt to restore the cache from the build-dependency-cache workflow if present then
+      # the output value steps.check_files.outputs.files_exists will be set (see the next step for usage)
+      - name: Set up Python ${{matrix.os}} ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Run the specified tests and save the results to a unique file that can be archived for later analysis.
+      - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+        uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
+        with:
+            python_version: ${{ matrix.python-version }}
+            os: ${{ matrix.os }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
+
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: pytest-report
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/.github/workflows/pytest-dbutils-mysqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-mysqlfuncts.yml
@@ -6,7 +6,16 @@
 
 
 name: Testing mysqlfucnts
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
@@ -6,7 +6,16 @@
 
 
 name: Testing postgresqlfuncts
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
@@ -1,0 +1,58 @@
+---
+# This workflow is meant as a foundational workflow for running integration/unit tests on the
+# platform.
+# This workflow also shows the caching mechanisms available for storage
+# and retrieval of cache for quicker setup of test environments.
+
+
+name: Testing postgresqlfuncts
+on: [pull_request]
+
+jobs:
+  build:
+    env:
+      TEST_FILE: volttrontesting/platform/dbutils/test_postgresqlfuncts.py
+
+    # The strategy allows customization of the build and allows matrixing the version of os and software
+    # https://docs.github.com/en/free-pro-team@l.atest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry in the os and python-version matrix will be run so for the 3 x 4 there will be 12 jobs run
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7] # , 3.8, 3.9 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout the volttron repository and set current directory to it
+      - uses: actions/checkout@v2
+
+      # Attempt to restore the cache from the build-dependency-cache workflow if present then
+      # the output value steps.check_files.outputs.files_exists will be set (see the next step for usage)
+      - name: Set up Python ${{matrix.os}} ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Run the specified tests and save the results to a unique file that can be archived for later analysis.
+      - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+        uses: volttron/volttron-build-action@v1
+        timeout-minutes: 600
+        with:
+            python_version: ${{ matrix.python-version }}
+            os: ${{ matrix.os }}
+            test_path: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.TEST_FILE }}
+
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: pytest-report
+          # should match test-<test_output_suffix>- ...
+          path: output/test-${{ env.OUTPUT_SUFFIX }}-${{matrix.os}}-${{ matrix.python-version }}-results.xml

--- a/.github/workflows/pytest-dbutils-sqlitefuncts.yml
+++ b/.github/workflows/pytest-dbutils-sqlitefuncts.yml
@@ -6,7 +6,16 @@
 
 
 name: Testing sqlitefuncts
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
@@ -6,7 +6,16 @@
 
 
 name: Testing postgresql_timescaledb_functs
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-testutils.yml
+++ b/.github/workflows/pytest-testutils.yml
@@ -8,7 +8,16 @@
 # and retrieval of cache for quicker setup of test environments.
 
 name: Testing testutils directory
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   build:

--- a/.github/workflows/pytest-vctl.yml
+++ b/.github/workflows/pytest-vctl.yml
@@ -14,7 +14,16 @@
 name: Testing volttron-ctl
 
 # Determine what events are going to trigger a running of the workflow
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   # The job named build

--- a/.github/workflows/pytest-web.yml
+++ b/.github/workflows/pytest-web.yml
@@ -13,8 +13,16 @@
 # https://github.com/VOLTTRON/volttron/actions (or if you are pushing to your own fork change the user)
 name: Testing platform web
 
-# Determine what events are going to trigger a running of the workflow
-on: [pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - releases/**
+  pull_request:
+    branches:
+    - main
+    - develop
+    - releases/**
 
 jobs:
   # The job named build

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ with a log file named volttron.log.
 Next, start an example listener to see it publish and subscribe to the message bus:
 
 ```sh
-scripts/core/upgrade-listener
+vctl install examples/ListenerAgent
 ```
 
 This script handles several commands for installing and starting an agent after removing an old copy. This 

--- a/services/core/PlatformDriverAgent/tests/test_dnp3_driver.py
+++ b/services/core/PlatformDriverAgent/tests/test_dnp3_driver.py
@@ -1,6 +1,16 @@
 import pytest
 import gevent
 import logging
+
+try:
+    import pydnp3
+except ModuleNotFoundError:
+    pytest.skip(
+        "DNP3 driver is currently not supported and not tested. "
+        "If you still want to run this test, install the import with: pip install pydnp3",
+        allow_module_level=True
+    )
+
 from services.core.DNP3Agent.dnp3 import DATA_TYPE_ANALOG_INPUT
 from volttron.platform.agent.known_identities import PLATFORM_DRIVER
 from volttron.platform import get_services_core

--- a/volttrontesting/platform/dbutils/test_mongoutils.py
+++ b/volttrontesting/platform/dbutils/test_mongoutils.py
@@ -14,11 +14,9 @@ from volttrontesting.fixtures.docker_wrapper import create_container
 from volttrontesting.utils.utils import get_rand_port
 
 
-IMAGES = ["mongo:latest"]
+IMAGES = ["mongo:5.0"]
 if "CI" in os.environ:
-    IMAGES.extend(
-        ["mongo:5.0", "mongo:4.0"]
-    )
+    IMAGES.extend(["mongo:4.0"])
 
 TEST_DATABASE = "test_historian"
 ROOT_USERNAME = "mongoadmin"

--- a/volttrontesting/platform/dbutils/test_mysqlfuncts.py
+++ b/volttrontesting/platform/dbutils/test_mysqlfuncts.py
@@ -23,7 +23,7 @@ pytestmark = [pytest.mark.mysqlfuncts, pytest.mark.dbutils, pytest.mark.unit]
 
 
 IMAGES = [
-    "mysql:latest",
+    "mysql:8.0",
     "mysql:5.7.35",
     "mysql:5.6"
 ]

--- a/volttrontesting/platform/dbutils/test_postgresql_timescaledb.py
+++ b/volttrontesting/platform/dbutils/test_postgresql_timescaledb.py
@@ -52,20 +52,52 @@ AGG_META_TABLE = "aggregate_meta"
 METADATA_TABLE = "metadata"
 
 
+def test_insert_meta_should_return_true(get_container_func):
+    container, postgresqlfuncts, port_on_host, historian_version = get_container_func
+    if historian_version != "<4.0.0":
+        pytest.skip("insert_meta() is called by historian only for schema <4.0.0")
+    topic_id = "44"
+    metadata = "foobar44"
+    expected_data = (44, '"foobar44"')
+
+    res = postgresqlfuncts.insert_meta(topic_id, metadata)
+
+    assert res is True
+    assert get_data_in_table(port_on_host, "meta")[0] == expected_data
+
+
+def test_update_meta_should_succeed(get_container_func):
+    container, sqlfuncts, connection_port, historian_version = get_container_func
+    metadata = {"units": "count"}
+    metadata_s = jsonapi.dumps(metadata)
+    topic = "foobar"
+
+    id = sqlfuncts.insert_topic(topic)
+    sqlfuncts.insert_meta(id, {"fdjlj": "XXXX"})
+    assert metadata_s not in get_data_in_table(connection_port, TOPICS_TABLE)[0]
+
+    res = sqlfuncts.update_meta(id, metadata)
+
+    expected_lt_4 = [(1, metadata_s)]
+    expected_gteq_4 = [(1, topic, metadata_s)]
+    assert res is True
+    if historian_version == "<4.0.0":
+        assert get_data_in_table(connection_port, META_TABLE) == expected_lt_4
+    else:
+        assert get_data_in_table(connection_port, TOPICS_TABLE) == expected_gteq_4
+
+
 def test_setup_historian_tables_should_create_tables(get_container_func):
     container, sqlfuncts, connection_port, historian_version = get_container_func
     # get_container initializes db and sqlfuncts
     # to test setup explicitly drop tables and see if tables get created correctly
     drop_all_tables(connection_port)
-    try:
-        assert get_tables(connection_port) == set()
-        expected_tables = set(["data", "topics"])
-        sqlfuncts.setup_historian_tables()
-        actual_tables = get_tables(connection_port)
-        assert actual_tables == expected_tables
-    finally:
-        # create all tables so that other test cases can use it
-        create_all_tables(container, historian_version)
+
+    assert get_tables(connection_port) == set()
+    expected_tables = set(["data", "topics"])
+    sqlfuncts.setup_historian_tables()
+    actual_tables = get_tables(connection_port)
+    assert actual_tables == expected_tables
 
 
 def test_setup_aggregate_historian_tables_should_create_aggregate_tables(
@@ -163,20 +195,6 @@ def test_insert_agg_topic_should_return_agg_topic_id(get_container_func):
     assert get_data_in_table(port_on_host, AGG_TOPICS_TABLE)[0] == expected_data
 
 
-def test_insert_meta_should_return_true(get_container_func):
-    container, postgresqlfuncts, port_on_host, historian_version = get_container_func
-    if historian_version != "<4.0.0":
-        pytest.skip("insert_meta() is called by historian only for schema <4.0.0")
-    topic_id = "44"
-    metadata = "foobar44"
-    expected_data = (44, '"foobar44"')
-
-    res = postgresqlfuncts.insert_meta(topic_id, metadata)
-
-    assert res is True
-    assert get_data_in_table(port_on_host, "meta")[0] == expected_data
-
-
 def test_insert_data_should_return_true(get_container_func):
     container, postgresqlfuncts, port_on_host, historian_version = get_container_func
 
@@ -219,26 +237,6 @@ def test_update_topic_and_metadata_should_succeed(get_container_func):
     assert result is True
     assert (actual_id, "soccer", '{"test": "test value"}') == get_data_in_table(connection_port, "topics")[0]
 
-
-def test_update_meta_should_succeed(get_container_func):
-    container, sqlfuncts, connection_port, historian_version = get_container_func
-    metadata = {"units": "count"}
-    metadata_s = jsonapi.dumps(metadata)
-    topic = "foobar"
-
-    id = sqlfuncts.insert_topic(topic)
-    sqlfuncts.insert_meta(id, {"fdjlj": "XXXX"})
-    assert metadata_s not in get_data_in_table(connection_port, TOPICS_TABLE)[0]
-
-    res = sqlfuncts.update_meta(id, metadata)
-
-    expected_lt_4 = [(1, metadata_s)]
-    expected_gteq_4 = [(1, topic, metadata_s)]
-    assert res is True
-    if historian_version == "<4.0.0":
-        assert get_data_in_table(connection_port, META_TABLE) == expected_lt_4
-    else:
-        assert get_data_in_table(connection_port, TOPICS_TABLE) == expected_gteq_4
 
 
 def test_get_aggregation_list_should_return_list(get_container_func):
@@ -486,7 +484,7 @@ def get_postgresqlfuncts(port):
     return PostgreSqlFuncts(connect_params, table_names)
 
 
-@pytest.fixture(params=itertools.product(IMAGES, ["<4.0.0", ">=4.0.0"]))
+@pytest.fixture(scope="module", params=itertools.product(IMAGES, ["<4.0.0", ">=4.0.0"]))
 def get_container_func(request):
     global CONNECTION_HOST
     historian_version = request.param[1]
@@ -693,3 +691,10 @@ def drop_all_tables(port):
     finally:
         if cursor:
             cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_tables(get_container_func):
+    container, sqlfuncts, connection_port, historian_version = get_container_func
+    drop_all_tables(connection_port)
+    create_all_tables(container, historian_version)


### PR DESCRIPTION
* Refactors integ tests for mysqlfuncts, postgresqlfuncts, and timescaledb to use one container as the test db container instead of creating a new container for every tests, significantly reduces testing time (e.g. for postgresqlfuncts on one image, test completion went from 10m 45seconds to 49 seconds when run locally on a VM. 

* Adds GH Workflows for postgresql and mysqlfuncts

* Adds pytest skip for DNP3 Driver test, which is unsupported

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested alll tests locally on my machine. Used the following commands:

```shell
pytest  ~/volttron/volttrontesting/platform/dbutils/test_mysqlfuncts.py
pytest  ~/volttron/volttrontesting/platform/dbutils/test_postgresqlfuncts.py
pytest  ~/volttron/volttrontesting/platform/dbutils/test_timescaledbfuncts.py
pytest pytest  ~volttron/services/core/PlatformDriverAgent/tests/test_dnp3_driver.py
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
