### PR TITLE
Change output_suffix in build-action step

### DIFF
--- a/.github/workflows/pytest-dbutils-backup_db.yml
+++ b/.github/workflows/pytest-dbutils-backup_db.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create output suffix
+        run: |
+            echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -62,12 +66,9 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
 #       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/pytest-dbutils-influxdbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-influxdbfuncts.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -52,12 +56,9 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
 #       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/pytest-dbutils-mysqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-mysqlfuncts.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -52,12 +56,9 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
 #       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
+++ b/.github/workflows/pytest-dbutils-postgresqlfuncts.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -52,12 +56,9 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
 #       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/pytest-dbutils-sqlitefuncts.yml
+++ b/.github/workflows/pytest-dbutils-sqlitefuncts.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+#       Archive the results from the pytest to storage.
+      - name: Create output suffix
+        run: |
+          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -52,12 +57,8 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
-#       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
+++ b/.github/workflows/pytest-dbutils-timescaldbfuncts.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create output suffix
+        run: |
+            echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
+
       # Run the specified tests and save the results to a unique file that can be archived for later analysis.
       - name: Run pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
         uses: volttron/volttron-build-action@v1
@@ -52,12 +56,9 @@ jobs:
             python_version: ${{ matrix.python-version }}
             os: ${{ matrix.os }}
             test_path: ${{ env.TEST_FILE }}
-            test_output_suffix: ${{ env.TEST_FILE }}
+            test_output_suffix: ${{ env.OUTPUT_SUFFIX }}
 
 #       Archive the results from the pytest to storage.
-      - name: Create output suffix
-        run: |
-          echo "OUTPUT_SUFFIX=$(basename $TEST_FILE)" >> $GITHUB_ENV
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
# Description

For the GitHub Workflows that run the dbutils tests, the workflow step, Archive test results, shows the following warning:

```
Warning: No files were found with the provided path: output/test-test_postgresql_timescaledb.py-ubuntu-20.04-3.6-results.xml. No artifacts will be uploaded.
```

Note that even though the Workflows UI shows all green checkmarks, the warnings are highlighted in the 'annotations' section in the Workflow Summary page. 

The cause of the problem is that the 'test_output_suffix' parameter in the 'Run pytest on...' test is incorrectly configured. That parameter must match the output suffix used in the step, 'Archive test results'. 



## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the affected Workflows on my personal GH account. Checked the summary page and ensured that the warning did not show up and that the output file was successfully written. 

See: 
sqlitefuncts: https://github.com/bonicim/volttron/actions/runs/1195327398
backupdb: https://github.com/bonicim/volttron/actions/runs/1195327402
influxdb: https://github.com/bonicim/volttron/actions/runs/1195327396
mysqlfuncts: https://github.com/bonicim/volttron/actions/runs/1195327397
timescale: https://github.com/bonicim/volttron/actions/runs/1195327400
postgresqlfuncts: https://github.com/bonicim/volttron/actions/runs/1195327401

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
