### PR TITLE
Added volttron-update-auth

### DIFF
--- a/volttron/platform/update_auth_file.py
+++ b/volttron/platform/update_auth_file.py
@@ -65,8 +65,9 @@ def get_agent_name(agent_dir_path):
     """
 
     for agent_name in agent_dir_path.iterdir():
-        if agent_name.match(".dist-info"):
-            return agent_name.stem
+        dist_info = agent_name.joinpath(agent_name.name + ".dist-info")
+        if dist_info.exists():
+            return agent_name.name
 
     raise KeyError(agent_dir_path.stem)
 

--- a/volttron/platform/vip/agent/subsystems/auth.py
+++ b/volttron/platform/vip/agent/subsystems/auth.py
@@ -61,7 +61,7 @@ from volttron.platform.agent.utils import (
     get_messagebus,
 )
 from volttron.platform.certs import Certs
-from volttron.platform.jsonrpc import RemoteError
+from volttron.platform.jsonrpc import RemoteError, MethodNotFound
 from volttron.utils.rmq_config_params import RMQConfig
 from volttron.platform.keystore import KeyStore
 from volttron.platform.vip.agent.subsystems.health import BAD_STATUS, Status
@@ -683,16 +683,23 @@ class Auth(SubsystemBase):
                 rpc_method_authorizations[method] = self.get_rpc_authorizations(
                     method
                 )
-        updated_rpc_authorizations = (
-            self._rpc()
-            .call(
-                AUTH,
-                "update_id_rpc_authorizations",
-                self._core().identity,
-                rpc_method_authorizations,
+        try:
+            updated_rpc_authorizations = (
+                self._rpc()
+                .call(
+                    AUTH,
+                    "update_id_rpc_authorizations",
+                    self._core().identity,
+                    rpc_method_authorizations,
+                )
+                .get(timeout=4)
             )
-            .get(timeout=4)
-        )
+        except MethodNotFound:
+            _log.warning("update_id_rpc_authorization method is missing from "
+                         "AuthService! The VOLTTRON Instance you are "
+                         "attempting to connect to is to old to support "
+                         "dynamic RPC authorizations.")
+            return
         if updated_rpc_authorizations is None:
             _log.warning(
                 f"Auth entry not found for {self._core().identity}: "

--- a/volttron/platform/vip/agent/subsystems/auth.py
+++ b/volttron/platform/vip/agent/subsystems/auth.py
@@ -694,9 +694,12 @@ class Auth(SubsystemBase):
             .get(timeout=4)
         )
         if updated_rpc_authorizations is None:
-            _log.error(
+            _log.warning(
                 f"Auth entry not found for {self._core().identity}: "
-                f"rpc_method_authorizations not updated."
+                f"rpc_method_authorizations not updated. If this agent "
+                f"does have an auth entry, verify that the 'identity' field "
+                f"has been included in the auth entry. This should be set to "
+                f"the identity of the agent"
             )
             return
         if rpc_method_authorizations != updated_rpc_authorizations:

--- a/volttrontesting/platform/auth_tests/test_auth_file.py
+++ b/volttrontesting/platform/auth_tests/test_auth_file.py
@@ -253,7 +253,7 @@ def test_groups_and_roles(auth_file_platform_tuple):
 
 
 @pytest.mark.auth
-def test_upgrade_file_verison_0_to_1_2(tmpdir_factory):
+def test_upgrade_file_verison_0_to_latest(tmpdir_factory):
     mechanism = "CURVE"
     publickey = "A" * 43
     version0 = {
@@ -275,7 +275,11 @@ def test_upgrade_file_verison_0_to_1_2(tmpdir_factory):
         },
         "groups": {
             "admin": ["reader", "writer"]
-        }
+        },
+        "version": {
+            "major": 0,
+            "minor": 0
+        },
     }
 
     filename = str(tmpdir_factory.mktemp('auth_test').join('auth.json'))
@@ -293,16 +297,23 @@ def test_upgrade_file_verison_0_to_1_2(tmpdir_factory):
     expected["mechanism"] = mechanism
     expected["capabilities"] = {'can_publish_temperature': None,
                                 'edit_config_store': {'identity': entries[0].user_id}}
+    expected["rpc_method_authorizations"] = {}
     assert_auth_entries_same(expected, vars(entries[0]))
-
+    # RPC Method Authorizations added with 1.3
+    for entry in upgraded.auth_data["allow_list"]:
+        assert entry["rpc_method_authorizations"] == {}
 
 @pytest.mark.auth
-def test_upgrade_file_verison_0_to_1_2_minimum_entries(tmpdir_factory):
+def test_upgrade_file_verison_0_to_latest_minimum_entries(tmpdir_factory):
     """The only required field in 'version 0' was credentials"""
     mechanism = "CURVE"
     publickey = "A" * 43
     version0 = {
         "allow": [{"credentials": mechanism + ":" + publickey}],
+        "version": {
+            "major": 0,
+            "minor": 0
+        },
     }
 
     filename = str(tmpdir_factory.mktemp('auth_test').join('auth.json'))
@@ -323,10 +334,14 @@ def test_upgrade_file_verison_0_to_1_2_minimum_entries(tmpdir_factory):
     expected["enabled"] = True
     expected["comments"] = None
     expected["capabilities"] = {'edit_config_store': {'identity': entries[0].user_id}}
+    expected["rpc_method_authorizations"] = {}
     expected["roles"] = []
     expected["groups"] = []
     assert_auth_entries_same(expected, vars(entries[0]))
 
+    # RPC Method Authorizations added with 1.3
+    for entry in upgraded.auth_data["allow_list"]:
+        assert entry["rpc_method_authorizations"] == {}
 
 @pytest.mark.auth
 def test_upgrade_file_version_1_1_to_1_2(tmpdir_factory):
@@ -422,7 +437,7 @@ def test_upgrade_file_version_1_1_to_1_2(tmpdir_factory):
 def test_upgrade_file_version_1_2_to_1_3(tmpdir_factory):
     """The only required field in 'version 0' was credentials"""
 
-    version1_1 = {
+    version1_2 = {
       "roles":{
         "manager":[
           "can_managed_platform"
@@ -495,7 +510,7 @@ def test_upgrade_file_version_1_2_to_1_3(tmpdir_factory):
 
     filename = str(tmpdir_factory.mktemp('auth_test').join('auth.json'))
     with open(filename, 'w') as fp:
-        fp.write(jsonapi.dumps(version1_1, indent=2))
+        fp.write(jsonapi.dumps(version1_2, indent=2))
 
     upgraded = AuthFile(filename)
     entries = upgraded.read()[0]


### PR DESCRIPTION
# Description

Added volttron-update-auth to upgrade older auth files. This will include the identity field in each auth entry so long as the agent is installed on the platform. The command uses the publickey of the agent to map the identity from the installed agent's directory to the auth entry. This command must be run locally. Once this is done, the agent can use dynamic rpc authorizations.

# Fixes

Allows backwards compatibility for dynamic rpc authorization. 
Prevents the "Auth entry not found for <agent_id>: rpc_method_authorizations not updated" from occurring unexpectedly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verified that by running the command, empty/missing identity fields for existing installed agents were added.
