### PR TITLE
Fix Single Machine install tags and fake driver

### DIFF
--- a/docs/source/deploying-volttron/single-machine.rst
+++ b/docs/source/deploying-volttron/single-machine.rst
@@ -180,9 +180,9 @@ For a simple setup example, a Platform Driver, SQLite Historian, and Listener ar
 
 .. code-block:: bash
 
-   python scripts/install-agent.py -s services/core/SQLHistorian -c configs/config.sqlite --tag listener
+   python scripts/install-agent.py -s services/core/SQLHistorian -c configs/config.sqlite --tag platform_historian
    python scripts/install-agent.py -s services/core/PlatformDriverAgent -c configs/platform-driver.agent --tag platform_driver
-   python scripts/install-agent.py -s examples/ListenerAgent -c configs/listener.config --tag platform_historian
+   python scripts/install-agent.py -s examples/ListenerAgent -c configs/listener.config --tag listener
 
    .. note::
 
@@ -232,15 +232,15 @@ concrete drivers such as the BACnet or Modbus drivers, view their respective doc
 
 .. note::
 
-   This section will assume the user has created a `configs` directory in the volttron root directory, activated
-   the Python virtual environment, and started the platform as noted above.
+   This section will assume the user is currently in the volttron root directory and has created a `configs` directory,
+   activated the Python virtual environment, and started the platform as noted above.
 
 .. code-block:: console
 
-   cp examples/configurations/drivers/fake.config <VOLTTRON root>/configs
-   cp examples/configurations/drivers/fake.csv <VOLTTRON root>/configs
+   cp examples/configurations/drivers/fake.config configs
+   cp examples/configurations/drivers/fake.csv configs
    vctl config store platform.driver devices/campus/building/fake configs/fake.config
-   vctl config store platform.driver fake.csv devices/fake.csv
+   vctl config store platform.driver fake.csv configs/fake.csv --csv
 
 .. note::
 


### PR DESCRIPTION
- Fix tag naming so that SQLHistorian is tagged platform_historian and
  ListenerAgent is tagged listener.
- Change note under section Install a Fake Driver so that it explicitly
  states the assumption that the user is currently in the volttron root
  directory like the previous section.
- Change following commands to reflect change in note.
- Fix final command in code-block to both point to the correct directory
  and load the csv file correctly.

Signed-off-by: Elijah J. Passmore <elijah@elijahjpassmore.com>

# Description

A few small changes to the documentation section Single Machine under Deploying VOLTTRON. There are a few errors in tag naming, inconsistency in assumptions present in the section Install Agents and Historian compared to Install a Fake Driver, and finally incorrect code-block commands.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?

I built the website and did manual testing to make sure that it looked correct.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
