### PR TITLE
Removing duplicate package entries in requirements.py and bootstrap.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -133,7 +133,7 @@ def update(operation, verbose=None, upgrade=False, offline=False, optional_requi
     # We must install wheel first to eliminate a bunch of scary looking
     # errors at first install.
     # TODO Look towards fixing the packaging so that it works with 0.31
-    pip('install', ['wheel==0.30'], verbose, True, offline=offline)
+    # option_requirements contains wheel as first entry
 
     # Build option_requirements separately to pass install options
     build_option = '--build-option' if wheeling else '--install-option'

--- a/requirements.py
+++ b/requirements.py
@@ -66,8 +66,7 @@ install_requires = [
     'cryptography==2.3',
     # Cross platform way of handling changes in file/directories.
     # https://github.com/Bogdanp/watchdog_gevent
-    'watchdog-gevent',
-    'wheel==0.30'
+    'watchdog-gevent'
 ]
 
 extras_require = {

--- a/requirements.py
+++ b/requirements.py
@@ -40,7 +40,12 @@
 # setup.py the import may fail if setuptools in not installed
 # in the global python3.
 
-option_requirements = [('pyzmq', ['--zmq=bundled'])]
+# We must install wheel first to eliminate a bunch of scary looking
+# errors at first install.
+# TODO Look towards fixing the packaging so that it works with 0.31
+# option_requirements contains wheel as first entry and
+# bootstrap.py installs contents of option_requirements first
+option_requirements = [('wheel==0.30', []), ('pyzmq==22.2.1', ['--zmq=bundled'])]
 
 
 install_requires = [
@@ -54,7 +59,6 @@ install_requires = [
     'python-dateutil',
     'pytz',
     'PyYAML',
-    'pyzmq',
     'setuptools>=40.0.0',
     # tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/
     'tzlocal==2.1',


### PR DESCRIPTION
fix for jira-533 - Removing duplicate package entries in requirements.py. 
moved wheel to list of requirements in requirements.py instead of explicit install from bootstrap.py. 
Pinned version of pyzmq to 22.2.1 as current version(22.3.1) does not install correctly

Tested by bootstrapping for zmq and rmq and did a sanity test that includes
1. start and stop platform
2. vctl install listener
3. vcfg rabittmq single
4. vctl install sqlite historian