### PR TITLE
Change importing abstract base classes from collections to collections.abc

### DIFF
--- a/services/core/DNP3Agent/dnp3/mesa/functions.py
+++ b/services/core/DNP3Agent/dnp3/mesa/functions.py
@@ -29,7 +29,7 @@
 import argparse
 import logging
 import os
-import collections
+import collections.abc
 import yaml
 
 from dnp3.points import PointDefinitions, PointDefinition, DNP3Exception
@@ -59,7 +59,7 @@ ACTION_NONE = 'none'
 _log = logging.getLogger(__name__)
 
 
-class FunctionDefinitions(collections.Mapping):
+class FunctionDefinitions(collections.abc.Mapping):
     """In-memory repository of FunctionDefinitions."""
 
     def __init__(self, point_definitions, function_definitions_path=None):

--- a/volttron/platform/messaging/socket.py
+++ b/volttron/platform/messaging/socket.py
@@ -39,9 +39,6 @@
 '''VOLTTRON platform™ messaging classes.'''
 
 
-
-import collections
-
 import zmq
 from volttron.platform import jsonapi
 


### PR DESCRIPTION
# Description

From #2472: "Importing ABC directly from collections has been deprecated and will be removed in Python 3.10". This PR changes all deprecated uses of importing ABC's directly from collections in favor of 'collections.abc".

For details, see https://docs.python.org/3/library/collections.abc.html

Fixes #2472 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
