### PR TITLE
Fix all W605 invalid escape sequence warnings

### DIFF
--- a/services/contrib/PrometheusScrapeAgent/prometheus_scrape/agent.py
+++ b/services/contrib/PrometheusScrapeAgent/prometheus_scrape/agent.py
@@ -32,7 +32,7 @@ class PrometheusScrapeAgent(Agent):
         self._cache = defaultdict(dict)
         self._cache_time = self._config_dict.get('cache_timeout', 660)
         self._tag_delimiter_re = self._config_dict.get('tag_delimiter_re',
-                                                       "\s+|:|_|\.|/")
+                                                       r"\s+|:|_|\.|/")
 
     @Core.receiver("onstart")
     def _starting(self, sender, **kwargs):

--- a/services/core/Darksky/darksky/agent.py
+++ b/services/core/Darksky/darksky/agent.py
@@ -72,7 +72,7 @@ SERVICES_MAPPING = {
  'get_minutely_forecast': {'json_name': 'minutely', 'type': 'forecast'}
 }
 
-LAT_LONG_REGEX = re.compile("^-?[0-9]{1,3}(\.[0-9]{1,4})?$")
+LAT_LONG_REGEX = re.compile(r"^-?[0-9]{1,3}(\.[0-9]{1,4})?$")
 
 
 def darksky(config_path, **kwargs):

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/maps/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/maps/__init__.py
@@ -113,7 +113,7 @@ class CSVRegister(object):
 
         # string[length] format: "string[4]"
         if csv_type.startswith('string'):
-            match = re.match('string\[(\d+)\]', csv_type)
+            match = re.match(r'string\[(\d+)\]', csv_type)
             if match:
                 try:
                     length = int(match.group(1))
@@ -124,7 +124,7 @@ class CSVRegister(object):
 
         # array(type, length) format: "array(int16, 4)"
         if csv_type.startswith('array'):
-            match = re.match("array\((\w+)\, (\d+)\)", csv_type)
+            match = re.match(r"array\((\w+)\, (\d+)\)", csv_type)
             try:
                 type = data_type_map[match.group(1)]
             except KeyError:
@@ -169,7 +169,7 @@ class CSVRegister(object):
 
         try:
             if csv_transform:
-                match = re.match('(\w+)\(([a-zA-z0-9.]*)\)', csv_transform)
+                match = re.match(r'(\w+)\(([a-zA-z0-9.]*)\)', csv_transform)
                 func = match.group(1)
                 arg = match.group(2)
 

--- a/services/core/WeatherDotGov/weatherdotgov/agent.py
+++ b/services/core/WeatherDotGov/weatherdotgov/agent.py
@@ -63,7 +63,7 @@ _log = logging.getLogger(__name__)
 SERVICE_HOURLY_FORECAST = "get_hourly_forecast"
 
 LAT_LONG_REGEX = re.compile(
-    "^-?[0-9]{1,3}(\.[0-9]{1,4})?,( |t?)-?[0-9]{1,3}(\.[0-9]{1,4})?$")
+    r"^-?[0-9]{1,3}(\.[0-9]{1,4})?,( |t?)-?[0-9]{1,3}(\.[0-9]{1,4})?$")
 STATION_REGEX = re.compile("^[Kk][a-zA-Z]{3}$")
 WFO_REGEX = re.compile("^[A-Z]{3}$")
 

--- a/services/unsupported/MongodbHistorian/mongodb/historian.py
+++ b/services/unsupported/MongodbHistorian/mongodb/historian.py
@@ -930,7 +930,7 @@ class MongodbHistorian(BaseHistorian):
     def query_topics_by_pattern(self, topics_pattern):
         _log.debug("In query topics by pattern: {}".format(topics_pattern))
         db = self._client.get_default_database()
-        topics_pattern = topics_pattern.replace('/', '\/')
+        topics_pattern = topics_pattern.replace('/', r'\/')
         pattern = {'topic_name': {'$regex': topics_pattern, '$options': 'i'}}
         cursor = db[self._topic_collection].find(pattern)
         topic_id_map = dict()

--- a/volttron/platform/agent/base_tagging.py
+++ b/volttron/platform/agent/base_tagging.py
@@ -823,7 +823,7 @@ def t_DQUOTE_STRING(t):
 
 
 def t_FPOINT(t):
-    '[-+]?\d+(\.(\d+)?([eE][-+]?\d+)?|[eE][-+]?\d+)'
+    r'[-+]?\d+(\.(\d+)?([eE][-+]?\d+)?|[eE][-+]?\d+)'
     try:
         t.value = float(t.value)
         pass

--- a/volttron/platform/dbutils/influxdbutils.py
+++ b/volttron/platform/dbutils/influxdbutils.py
@@ -324,7 +324,7 @@ def insert_data_point(client, time, topic_id, source, value, value_string):
     try:
         client.write_points(json_body)
     except InfluxDBClientError as e:
-        matching = re.findall('type \w+', jsonapi.loads(e.content)["error"])
+        matching = re.findall(r'type \w+', jsonapi.loads(e.content)["error"])
         inserted_type = matching[1]
         existed_type = matching[2]
         _log.warning('{} value exists as {}, while inserted value={} has {}'.format(measurement,

--- a/volttron/platform/dbutils/mysqlfuncts.py
+++ b/volttron/platform/dbutils/mysqlfuncts.py
@@ -86,7 +86,7 @@ class MySqlFuncts(DbDriver):
 
     def init_microsecond_support(self):
         rows = self.select("SELECT version()", None)
-        p = re.compile('(\d+)\D+(\d+)\D+(\d+)\D*')
+        p = re.compile(r'(\d+)\D+(\d+)\D+(\d+)\D*')
         version_nums = p.match(rows[0][0]).groups()
         _log.debug(f"MYSQL version number components {version_nums}")
         self.MICROSECOND_SUPPORT = True
@@ -216,7 +216,7 @@ class MySqlFuncts(DbDriver):
                 start = start_str[:start_str.rfind('.')]
 
         if end is not None:
-            if end.tzinfo !=pytz.UTC:
+            if end.tzinfo != pytz.UTC:
                 end = end.astimezone(pytz.UTC)
             if not self.MICROSECOND_SUPPORT:
                 end_str = end.isoformat()

--- a/volttron/utils/__init__.py
+++ b/volttron/utils/__init__.py
@@ -73,10 +73,10 @@ def is_ip_private(vip_address):
 
     # https://en.wikipedia.org/wiki/Private_network
 
-    priv_lo = re.compile("^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-    priv_24 = re.compile("^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-    priv_20 = re.compile("^192\.168\.\d{1,3}.\d{1,3}$")
-    priv_16 = re.compile("^172.(1[6-9]|2[0-9]|3[0-1]).[0-9]{1,3}.[0-9]{1,3}$")
+    priv_lo = re.compile(r"^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+    priv_24 = re.compile(r"^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+    priv_20 = re.compile(r"^192\.168\.\d{1,3}.\d{1,3}$")
+    priv_16 = re.compile(r"^172.(1[6-9]|2[0-9]|3[0-1]).[0-9]{1,3}.[0-9]{1,3}$")
 
     return priv_lo.match(ip) is not None or priv_24.match(
         ip) is not None or priv_20.match(ip) is not None or priv_16.match(

--- a/volttrontesting/platform/auth_tests/test_auth_control.py
+++ b/volttrontesting/platform/auth_tests/test_auth_control.py
@@ -78,7 +78,7 @@ def auth_list(platform):
 
 def auth_list_json(platform):
     output = auth_list(platform)
-    entries = re.findall('\nINDEX: \d+(\n{.*?\n}\n)', output, re.DOTALL)
+    entries = re.findall(r'\nINDEX: \d+(\n{.*?\n}\n)', output, re.DOTALL)
     return [jsonapi.loads(entry) for entry in entries]
 
 

--- a/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
+++ b/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
@@ -787,7 +787,7 @@ def test_single_topic(aggregate_agent, query_agent):
 
 
 def compute_timediff_seconds(time1_str, time2_str):
-    if re.match('\+[0-9][0-9]:[0-9][0-9]', time1_str[-6:]):
+    if re.match(r'\+[0-9][0-9]:[0-9][0-9]', time1_str[-6:]):
         time1_str = time1_str[:-6]
         time2_str = time2_str[:-6]
     datetime1 = datetime.strptime(time1_str,

--- a/volttrontesting/services/historian/test_historian.py
+++ b/volttrontesting/services/historian/test_historian.py
@@ -276,7 +276,7 @@ def setup_mysql(connection_params, table_names, historian_version):
     cursor = db_connection.cursor()
     cursor.execute("SELECT version()")
     version = cursor.fetchone()
-    p = re.compile('(\d+)\D+(\d+)\D+(\d+)\D*')
+    p = re.compile(r'(\d+)\D+(\d+)\D+(\d+)\D*')
     version_nums = p.match(version[0]).groups()
 
     print(version)


### PR DESCRIPTION
# Description

Starting with Python 3.6, invalid escape sequences in string literals are now deprecated[1]. Automatic style checkers such as flake8 will complains about invalid escape sequences (W605)[2].

[1] https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior
[2] https://www.flake8rules.com/rules/W605.html

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran flake8 on specific directories to catch all valid W605 warnings. 

```shell
$ flake8 --select W605 examples integrations scripts services volttron volttron_data volttrontesting bootstrap.py
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
