### PR TITLE
FIXED bacnet scan

### DIFF
--- a/scripts/bacnet/grab_bacnet_config.py
+++ b/scripts/bacnet/grab_bacnet_config.py
@@ -220,11 +220,14 @@ def process_object(app, address, obj_type, index, max_range_report, config_write
     
         if not object_notes:
             enum_strings = []
-            for name in Enumerated.keylist(present_value_type(0)):
-                value = present_value_type.enumerations[name]
-                enum_strings.append(str(value) + '=' + name)
+            try:
+                for name in Enumerated.keylist(present_value_type(0)):
+                    value = present_value_type.enumerations[name]
+                    enum_strings.append(str(value) + '=' + name)
                 
-            object_notes = present_value_type.__name__ + ': ' + ', '.join(enum_strings)
+                object_notes = present_value_type.__name__ + ': ' + ', '.join(enum_strings)
+            except AttributeError:
+                pass
 
     elif issubclass(present_value_type, Boolean):
         object_units = 'Boolean'


### PR DESCRIPTION
# Description

binaryValue and binaryOutput  without a note set on line 187. 

`object_notes = read_prop(app, address, obj_type, index, "description")`

Fails on line 224.  `Enumerated.keylist(present_value_type(0))`

 Therefore we wrap it with a try / catch

 


Fixes # (issue)

https://github.com/VOLTTRON/volttron/issues/2818


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran this on my live system peer coding with Mark



# Checklist:

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ na] I have commented my code, particularly in hard-to-understand areas
- [ na] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ no] I have added tests that prove my fix is effective or that my feature works
- [ not sure] New and existing unit tests pass locally with my changes
- [na ] Any dependent changes have been merged and published in downstream modules
