### PR TITLE
Fix bug in load_config

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -156,7 +156,10 @@ def load_config(config_path):
     # Then if that fails we fallback to our modified json parser.
     try:
         with open(config_path) as f:
-            return yaml.safe_load(f.read())
+            config = yaml.safe_load(f.read())
+            if config is None:
+                return {}
+            return config
     except yaml.scanner.ScannerError as e:
         try:
             with open(config_path) as f:


### PR DESCRIPTION
# Description

Fixes issue where volttron.platform.agent.utils.load_config can return None when the agent config file is empty, potentially causing agent installation to fail.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
