### PR TITLE
Fix VCP Install Agent Bug (hotfix 8.1.3)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,9 +43,9 @@ copyright = '2020, The VOLTTRON Community'
 author = 'The VOLTTRON Community'
 
 # The short X.Y version
-version = '8.1.2'
+version = '8.1.3'
 # The full version, including alpha/beta/rc tags
-release = '8.1.2'
+release = '8.1.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/services/core/VolttronCentral/tests/test_webapi.py
+++ b/services/core/VolttronCentral/tests/test_webapi.py
@@ -299,10 +299,12 @@ def test_installagent(auto_registered_local):
         print(f"Package is {hold}")
         filestr = "base64,"+base64.b64encode(hold).decode('utf-8')
         print(f"file string is {filestr}")
+    vip_id = f"test_listener_{random.randint(1,100000)}"
     file_props = dict(
         file_name=os.path.basename(agent_wheel),
         file=filestr,
-        vip_identity='bar.full.{}'.format(random.randint(1, 100000))
+        vip_identity=vip_id,
+        force=True
     )
     gevent.sleep(5)
     platform = webapi.list_platforms()[0]

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -58,7 +58,7 @@ import psutil
 from enum import Enum
 
 from volttron.platform.agent import utils
-from volttron.platform.install_agents import install_agent_vctl
+from volttron.platform.install_agents import install_agent_remote
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -1149,6 +1149,14 @@ class VolttronCentralPlatform(Agent):
         try:
             _log.debug('Installing agent FILEARGS: {}'.format(fileargs))
             vip_identity = fileargs.get('vip_identity', None)
+            agent_tag = fileargs.get('tag', None)
+            agent_enable = fileargs.get('enable', None)
+            agent_start = fileargs.get('start', None)
+            agent_priority = fileargs.get('priority', -1)
+            agent_force = fileargs.get('force', False)
+            agent_csv = fileargs.get('csv', None)
+            agent_json = fileargs.get('json', None)
+            agent_st = fileargs.get('st', 5)
             if 'local' in fileargs:
                 path = fileargs['file_name']
             else:
@@ -1169,16 +1177,16 @@ class VolttronCentralPlatform(Agent):
             opts = Namespace(connection=self._vc_connection,
                              install_path=path,
                              vip_identity=vip_identity,
-                             tag=None,
-                             enable=None,
-                             start=None,
-                             priority=-1,
-                             force=False,
-                             csv=None,
-                             json=None,
-                             st=5
+                             tag=agent_tag,
+                             enable=agent_enable,
+                             start=agent_start,
+                             priority=agent_priority,
+                             force=agent_force,
+                             csv=agent_csv,
+                             json=agent_json,
+                             st=agent_st
                              )
-            uuid = install_agent_vctl(opts)
+            uuid = install_agent_remote(opts)
             result = dict(uuid=uuid)
         except Exception as e:
             err_str = "EXCEPTION: " + str(e)

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -58,7 +58,7 @@ import psutil
 from enum import Enum
 
 from volttron.platform.agent import utils
-from volttron.platform.install_agents import install_agent_remote
+from volttron.platform.install_agents import install_agent_local
 
 utils.setup_logging()
 _log = logging.getLogger(__name__)
@@ -1170,7 +1170,7 @@ class VolttronCentralPlatform(Agent):
                 # after base64,
                 with open(path, 'wb') as fout:
                     fout.write(
-                        base64.decodestring(
+                        base64.decodebytes(
                             fileargs['file'].split(base64_sep)[1].encode('utf-8')
                         )
                     )
@@ -1186,7 +1186,7 @@ class VolttronCentralPlatform(Agent):
                              json=agent_json,
                              st=agent_st
                              )
-            uuid = install_agent_remote(opts)
+            uuid = install_agent_local(opts)
             result = dict(uuid=uuid)
         except Exception as e:
             err_str = "EXCEPTION: " + str(e)

--- a/services/core/VolttronCentralPlatform/vcplatform/vcconnection.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/vcconnection.py
@@ -42,7 +42,7 @@
 import logging
 
 from volttron.platform.agent.known_identities import (
-    VOLTTRON_CENTRAL)
+    VOLTTRON_CENTRAL, CONTROL)
 from volttron.platform.vip.agent import (Agent, RPC)
 
 _log = logging.getLogger(__name__)
@@ -59,6 +59,8 @@ class VCConnection(Agent):
         self._log = logging.getLogger(self.__class__.__name__)
         super(VCConnection, self).__init__(**kwargs)
         self._main_agent = None
+        self.server = None
+        self.peer = CONTROL
 
     def set_main_agent(self, main_agent):
         """
@@ -69,6 +71,7 @@ class VCConnection(Agent):
         :type VolttronCentralPlatform:
         """
         self._main_agent = main_agent
+        self.server = self._main_agent
 
     def publish_to_vc(self, topic, message=None, headers={}):
         """
@@ -286,6 +289,10 @@ class VCConnection(Agent):
     @RPC.export
     def call(self, platform_method, *args, **kwargs):
         return self._main_agent.call(platform_method, *args, **kwargs)
+
+    def kill(self):
+        """Dummy method to use install_agent_vctl"""
+        pass
 
     def is_connected(self):
         connected = self.vip.hello().get(timeout=5) is not None

--- a/services/core/VolttronCentralPlatform/vcplatform/vcconnection.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/vcconnection.py
@@ -336,35 +336,6 @@ class VCConnection(Agent):
         return self._main_agent.get_instance_name()
 
     @RPC.export
-    def start_agent(self, agent_uuid):
-        """
-        Calls start_agent method on the vcp main agent instance.
-
-        .. note::
-
-            This method only valid for installed agents not dynamic agents.
-
-        :param agent_uuid:
-        :return:
-        """
-        self._main_agent.start_agent(agent_uuid)
-
-    @RPC.export
-    def stop_agent(self, agent_uuid):
-        """
-        Calls stop_agent method on the vcp main agent instance.
-
-        .. note::
-
-            This method only valid for installed agents not dynamic agents.
-
-        :param agent_uuid:
-        :return:
-        """
-        proc_result = self._main_agent.stop_agent(agent_uuid)
-        return proc_result
-
-    @RPC.export
     def restart_agent(self, agent_uuid):
         """
         Calls restart method on the vcp main agent instance.
@@ -377,33 +348,6 @@ class VCConnection(Agent):
         :return:
         """
         return self._main_agent.restart(agent_uuid)
-
-    @RPC.export
-    def agent_status(self, agent_uuid):
-        """
-        Calls agent_status method on the vcp main agent instance.
-
-        .. note::
-
-            This method only valid for installed agents not dynamic agents.
-
-        :param agent_uuid:
-        :return:
-        """
-        return self._main_agent.agent_status(agent_uuid)
-
-    @RPC.export
-    def status_agents(self):
-        """
-        Calls status_agents method on the vcp main agent instance.
-
-        .. note::
-
-            This method only valid for installed agents not dynamic agents.
-
-        :return:
-        """
-        return self._main_agent.status_agents()
 
     @RPC.export
     def list_agents(self):

--- a/volttron/platform/__init__.py
+++ b/volttron/platform/__init__.py
@@ -49,7 +49,7 @@ from configparser import ConfigParser
 from urllib.parse import urlparse
 
 from ..utils.frozendict import FrozenDict
-__version__ = '8.1.2'
+__version__ = '8.1.3'
 
 _log = logging.getLogger(__name__)
 

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -609,6 +609,13 @@ class ControlService(BaseAgent):
         return agent_uuid
 
     @RPC.export
+    def install_agent_local(self, filename, vip_identity=None, publickey=None,
+                            secretkey=None):
+        return self._aip.install_agent(filename, vip_identity=vip_identity,
+                                       publickey=publickey,
+                                       secretkey=secretkey)
+
+    @RPC.export
     def install_agent(
         self,
         filename,

--- a/volttron/platform/control.py
+++ b/volttron/platform/control.py
@@ -607,13 +607,7 @@ class ControlService(BaseAgent):
             )
         _log.debug(f"Returning {agent_uuid}")
         return agent_uuid
-
-    @RPC.export
-    def install_agent_local(self, filename, vip_identity=None, publickey=None,
-                            secretkey=None):
-        return self._aip.install_agent(filename, vip_identity=vip_identity,
-                                       publickey=publickey,
-                                       secretkey=secretkey)
+   
 
     @RPC.export
     def install_agent(

--- a/volttron/platform/install_agents.py
+++ b/volttron/platform/install_agents.py
@@ -211,6 +211,7 @@ def _send_and_intialize_agent(opts, publickey, secretkey):
                 keyline += "%s" % keys[k]
                 valueline += "%s" % output_dict[keys[k]]
         sys.stdout.write("%s\n%s\n" % (keyline, valueline))
+    return agent_uuid
 
 
 def install_agent_vctl(opts, publickey=None, secretkey=None, callback=None):

--- a/volttron/platform/install_agents.py
+++ b/volttron/platform/install_agents.py
@@ -220,7 +220,7 @@ def install_agent_vctl(opts, publickey=None, secretkey=None, callback=None):
     vctl install sub-parser.
     """
 
-    agent_uuid = install_agent_remote(opts, publickey=publickey,
+    agent_uuid = install_agent_local(opts, publickey=publickey,
                          secretkey=secretkey, callback=callback)
     if agent_uuid:
         return 0
@@ -228,9 +228,10 @@ def install_agent_vctl(opts, publickey=None, secretkey=None, callback=None):
         return 1
 
 
-def install_agent_remote(opts, publickey=None, secretkey=None, callback=None):
+def install_agent_local(opts, publickey=None, secretkey=None, callback=None):
     """
-    Used by install_agent_vctl and vc for installing agents.
+    Install agents via either directory or wheel
+    Used by VC and VCTL
     """
     try:
         install_path = opts.install_path


### PR DESCRIPTION
# Description

There was a bug in VOLTTRON Central, preventing agents from being installed properly from the interface. This was caused by the updated install agent functionality removing the method called by VCP (VOLTTRON Central Platform). To fix, VCP now uses the same functionality that Control Services uses, with a client-server structure for installing the agent.

Fixes #2841

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested through manual set up of a VC and VCP instance on a local machine, and verified that a packaged listener agent could be installed, started, stopped, and removed. 
- Tested by creating a separate instance of VOLTTRON on the same machine, and remotely connecting to the VC instance. Verified that a packaged listener agent could be installed, started, stopped, and removed on this remote instance through the VC interface.
