### PR TITLE
prioritize_agent validation fix

### DIFF
--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -817,6 +817,8 @@ class AIPplatform(object):
         if priority is None:
             with ignore_enoent:
                 os.unlink(autostart)
+        elif not priority.isdigit() or not 0 <= int(priority) < 100:
+            raise ValueError(f'Priority must be an integer from 0 - 99. Received: {priority}.')
         else:
             with open(autostart, 'w') as file:
                 file.write(priority.strip())


### PR DESCRIPTION
# Description

Corrected missing validation of priority in aip.py:priortize_agent. Added tests for valid uuid and priority input to test_control.py.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested in ipython & with vui API.
Added tests to volttrontesting/platform/control_tests/test_control.py:
- [x] test_prioritize_agent_valid_input (passes)
- [ ] test_prioritize_agent_invalid_input (marked xfail)
    - 2 of 9 cases for this test xfail due to existing issue: both bytes calls in prioritize_agent method fail with TypeError('string argument without an encoding') when the uuid or priority is not a string. This preempts the intended TypeError from prioritize_agent. Note that the same pattern appears many other places in 9 other places in the file (always before raising different, meaningful TypeErrors). The offending code is:
        ```
        bytes(self.vip.rpc.context.vip_message.peer).decode("utf-8")
        ```
    My development environment is currently Python 3.9.9.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
