### PR TITLE
Update error msg on ZMQError in socket.bind()

### DIFF
--- a/volttron/platform/vip/socket.py
+++ b/volttron/platform/vip/socket.py
@@ -242,11 +242,11 @@ class Address(object):
         try:
             (bind_fn or sock.bind)(self.base)
             self.base = sock.last_endpoint.decode("utf-8")
-        except ZMQError:
-            message = 'Attempted to bind Volttron to already bound address {}, stopping'
-            message = message.format(self.base)
-            _log.error(message)
-            print("\n" + message + "\n")
+        except ZMQError as exc:
+            urlmsg = f'Attempt to bind ZMQ socket to address: {self.base}'
+            errcodemsg = f'Returned socket error code: {exc.errno}, exiting.'
+            _log.error(f'{urlmsg} {errcodemsg}')
+            print(f"\n{urlmsg} {errcodemsg}\n")
             sys.exit(1)
 
     def connect(self, sock, connect_fn=None):


### PR DESCRIPTION
# Description

Under the function socket.bind(), the function will raise the following message on ZMQError:

> Attempted to bind Volttron to already bound address {}, stopping

However, according to @jak42: "[T]his message is misleading as the error can occur if, for example ZMQ is asked to open a socket on an IP address which is not bound to the container/instance/machine." For details, see #2885. 

This PR updates that error message to provide the error number to help the user root cause the error. The patch was provided courtesy of @jak42.

The new errror message would look like the following:

> Attempt to bind ZMQ socket to address: {} Returned socket error code: {}, exiting.

Fixes #2885 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
