### PR TITLE
Updated is_instance_running to respect volttron_home var

### DIFF
--- a/volttron/platform/__init__.py
+++ b/volttron/platform/__init__.py
@@ -183,7 +183,7 @@ def is_instance_running(volttron_home=None):
     if volttron_home is None:
         volttron_home = get_home()
 
-    instance_file = os.path.expanduser("~/.volttron_instances")
+    instance_file = os.path.join(volttron_home, ".volttron_instances")
     if not os.path.isfile(instance_file):
         return False
 


### PR DESCRIPTION
# Description

Makes is_instance_running respect volttron_home arguments and home resolution flow defined by get_home

Fixes #2929 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
