### PR TITLE
Add README for ConfigActuation example agent

### DIFF
--- a/examples/ConfigActuation/README.md
+++ b/examples/ConfigActuation/README.md
@@ -1,0 +1,15 @@
+## ConfigActuation Agent
+
+This agent is used to demonstrate scheduling and acutation of devices
+when a configstore item is added or updated. The name of a configuration 
+file must match the name of the device to be actuated. The configuration 
+file is a JSON dictionary of point name and value pairs. Any number of 
+points on the device can be listed in the config.
+
+To use this agent as-is, install it as normal with the provided configuration
+file ("config" in the agent's directory). For more information on installing and
+running agents, see the [Agent Control Commands](https://volttron.readthedocs.io/en/main/platform-features/control/agent-management-control.html).
+
+This agent may be used as an example for scheduling and acutation of devices
+when a configstore item is added or updated, and serve as a jumping-off point 
+for other simple test agents.


### PR DESCRIPTION
# Description
Added a README for the ConfigActuation example agent. Tested that I am able to run the agent.

This is a part of Jira ticket [VOLTDEV-143](https://jira.pnnl.gov/jira/browse/VOLTDEV-143) but does not close the ticket. 

## Type of change
- [x] This change is a documentation update

# How Has This Been Tested?
Looked through code and tested that I could run the example agent. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
