### PR TITLE
hot fix sphinx ref syntax error

### DIFF
--- a/docs/source/agent-framework/core-service-agents/platform-driver/platform-driver-agent.rst
+++ b/docs/source/agent-framework/core-service-agents/platform-driver/platform-driver-agent.rst
@@ -63,7 +63,7 @@ The example platform driver configuration file above can be found in the VOLTTRO
 `services/core/PlatformDriverAgent/platform-driver.agent`.
 
 For information on configuring the Platform Driver with devices, including creating driver configs and using the config
-store, please read ref`configuration <Platform-Driver-Configuration>` the section in the Driver Framework docs.
+store, please read the :ref:`configuration <Platform-Driver-Configuration>` section in the Driver Framework docs.
 
 
 .. toctree::


### PR DESCRIPTION
# Description

Hot fix documentation typo/sphinx syntax error
In volttron/docs/source/agent-framework/core-service-agents/platform-driver/platform-driver-agent.rst
![image](https://user-images.githubusercontent.com/28743873/160333508-263ebb00-788a-4978-88e2-d5b169b639e6.png)


Fixes #2940 2940

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Rendering test
- [x] Functional unit test (i.e., the hyperlink works)

![image](https://user-images.githubusercontent.com/28743873/160333659-2306e736-9d8d-4451-8bd8-5a646722aca9.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
