### PR TITLE
hot fix CLI command error, sphinx syntax error

### DIFF
--- a/docs/source/deploying-volttron/single-machine.rst
+++ b/docs/source/deploying-volttron/single-machine.rst
@@ -144,23 +144,23 @@ Install Agents and Historian
 
 Out of the box, VOLTTRON includes a number of agents which may be useful for single machine deployments:
 
-    * historians - Historians automatically record a data from a number of topics published to the bus.  For more
-      information on the historian framework or one of the included concrete implementations, view the
-      :ref:`docs <Historian-Framework>`
-    * Listener - This example agent can be useful for debugging drivers or other agents publishing to the bus.
-      :ref:`docs <Listener-Agent>`
+    * historians - Historians automatically record a data from a number of topics published to the bus.  For more information on the historian framework or one of the included concrete implementations, view the :ref:`Historian-Framework`
+																									  
+									   
+    * Listener - This example agent can be useful for debugging drivers or other agents publishing to the bus. For more details please read :ref:`Listener-Agent`
+								  
     * Platform Driver - The :ref:`Platform-Driver` is responsible for managing device communication on a platform instance.
-    * weather agents - weather agents can be used to collect weather data from sources like
-      :ref:`Weather.gov <Weather-Dot-Gov>`
+    * weather agents - weather agents can be used to collect weather data from sources like `weather.gov <https://www.weather.gov/>`_
+										  
 
-    .. note::
+.. note::
 
        The `services/core`, `services/ops`, and `examples` directories in the repository contain additional agents to
        use to fit individual use cases.
 
 For a simple setup example, a Platform Driver, SQLite Historian, and Listener are installed using the following steps:
 
-#. Create a configuration file for the Platform Driver and SQLite Historian (it is advised to create a `configs` directory
+1. Create a configuration file for the Platform Driver and SQLite Historian (it is advised to create a `configs` directory
    in volttron root to keep configs for a deployment).  For information on how to create configurations for these
    agents, view their docs:
 
@@ -168,15 +168,19 @@ For a simple setup example, a Platform Driver, SQLite Historian, and Listener ar
     * :ref:`SQLite Historian <SQL-Historian>`
     * :ref:`Listener <Listener-Agent>`
 
-   For a simple example, the configurations can be copied as-is to the `configs` directory:
+For a simple example, the configurations can be copied as-is to the `configs` directory:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      cp services/core/PlatformDriverAgent/platform-driver.agent configs
-      cp services/core/SQLHistorian/config.sqlite configs
+      mkdir configs
+
+.. code-block:: bash
+
+      cp services/core/PlatformDriverAgent/platform-driver.agent configs/
+      cp services/core/SQLHistorian/config.sqlite configs/
       cp examples/ListenerAgent/config configs/listener.config
 
-#. Use the `install-agent.py` script to install the agent on the platform:
+2. Use the `install-agent.py` script to install the agent on the platform:
 
 .. code-block:: bash
 
@@ -184,11 +188,11 @@ For a simple setup example, a Platform Driver, SQLite Historian, and Listener ar
    python scripts/install-agent.py -s services/core/PlatformDriverAgent -c configs/platform-driver.agent --tag platform_driver
    python scripts/install-agent.py -s examples/ListenerAgent -c configs/listener.config --tag listener
 
-   .. note::
+.. note::
 
       The `volttron.log` file will contain logging indicating that the agent has installed successfully.
 
-      .. code-block:: console
+.. code-block:: console
 
          2020-10-27 11:42:08,882 () volttron.platform.auth INFO: AUTH: After authenticate user id: control.connection, b'c61dff8e-f362-4906-964f-63c32b99b6d5'
          2020-10-27 11:42:08,882 () volttron.platform.auth INFO: authentication success: userid=b'c61dff8e-f362-4906-964f-63c32b99b6d5' domain='vip', address='localhost:1000:1000:3249', mechanism='CURVE', credentials=['ZrDvPG4JNLE26GoPUrTP22rV0PV8uGCnrXThrNFk_Ec'], user='control.connection'
@@ -202,7 +206,7 @@ For a simple setup example, a Platform Driver, SQLite Historian, and Listener ar
          2020-10-27 11:42:11,415 () volttron.platform.auth WARNING: Get list of peers from subsystem directly
          2020-10-27 11:42:11,419 () volttron.platform.auth INFO: auth file /home/james/.volttron/auth.json loaded
 
-#. Use the `vctl status` command to ensure that the agents have been successfully installed:
+3. Use the `vctl status` command to ensure that the agents have been successfully installed:
 
 .. code-block:: bash
 
@@ -237,8 +241,8 @@ concrete drivers such as the BACnet or Modbus drivers, view their respective doc
 
 .. code-block:: console
 
-   cp examples/configurations/drivers/fake.config configs
-   cp examples/configurations/drivers/fake.csv configs
+   cp examples/configurations/drivers/fake.config configs/
+   cp examples/configurations/drivers/fake.csv configs/
    vctl config store platform.driver devices/campus/building/fake configs/fake.config
    vctl config store platform.driver fake.csv configs/fake.csv --csv
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2942 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Sphinx rendering test. (Please view https://volttron-km-readthedocs.readthedocs.io/en/latest/deploying-volttron/single-machine.html)

### p.s.: list of fixes (See issue #2942 for more details)
- command line: `cp <some_file> configs/` (using the original file name) missing `/`
      - cp services/core/PlatformDriverAgent/platform-driver.agent configs/
      - cp services/core/SQLHistorian/config.sqlite configs/
      - cp examples/configurations/drivers/fake.config configs/
      - cp examples/configurations/drivers/fake.csv configs/

- Add `mkdir configs`. (To make the instruction completed.)
- Modified "Out of the box, VOLTTRON includes a number of agents which may be useful for single machine deployments:" block
      - changed `doc` to names more explicit reference
      - changed `weather.gov` to http link (instead of internal reference)
- Modified the note-block with bad rendering (... file will contain logging indicating that the agent has installed successfully)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
