### PR TITLE
AGENT_CONFIG not existing should be an error

### DIFF
--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -149,8 +149,7 @@ def load_config(config_path):
         return {}
 
     if not os.path.exists(config_path):
-        _log.info("Config file specified by AGENT_CONFIG does not exist. load_config returning empty configuration.")
-        return {}
+        raise ValueError(f"Config file specified by AGENT_CONFIG path {config_path} does not exist.")
 
     # First attempt parsing the file with a yaml parser (allows comments natively)
     # Then if that fails we fallback to our modified json parser.


### PR DESCRIPTION
# Description
Added a ValueError that is raised in load_config when the config_path does not exist. 

Fixes #2847 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tried installing some example agents with an agent config path that does not exist and was given an error. The error that is displayed is thrown in the install_agent_directory function which runs before we reach the load_config function so we don't see the load_config error. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
