### PR TITLE
Requirement Pinned: idna

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -50,6 +50,7 @@ option_requirements = [('wheel==0.30', []), ('pyzmq==22.2.1', ['--zmq=bundled'])
 install_requires = ['gevent==21.12.0',
                     'grequests',
                     'requests==2.23.0',
+                    'idna<3,>=2.5',
                     'ply',
                     'psutil',
                     'python-dateutil',


### PR DESCRIPTION
# Description

VC login does not work correctly in develop. This is caused by an incorrect version of idna being set on a new bootstrap of the develop branch. Pinning the version of the idna package to prevent this from occurring 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by building develop, setting up and installing VC, and attempting to login.