### PR TITLE
Added toctree link to web-api documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with that data.
 
 ## Upgrading to VOLTTRON 8.x
 
-VOLTTRON 8 introduces three changes that require an explict upgrade step when upgrading from a earlier VOLTTRON version
+VOLTTRON 8 introduces three changes that require an explict upgrade step when upgrading from an earlier VOLTTRON version
 
     1. Dynamic RPC authorization feature - This requires a modification to the auth file. If you have a pre-existing
        instance of VOLTTRON running on an older version, the auth file will need to be updated.

--- a/docs/source/agent-framework/web-framework.rst
+++ b/docs/source/agent-framework/web-framework.rst
@@ -8,6 +8,10 @@ This document describes the interaction between web enabled agents and the Platf
 
 The web framework enables agent developers to expose JSON, static, and websocket endpoints.
 
+.. note::
+    The Platform Web Service Agent also provides a RESTful API which can be used to interact
+    with the VOLTTRON Platform, the documentation for which can be found :ref:`here <Web-API>`.
+
 Web SubSystem
 =============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -137,6 +137,7 @@ at our bi-weekly office-hours and on Slack. To be invited to office-hours or sla
    platform-features/control/index
    platform-features/config-store/configuration-store
    platform-features/security/volttron-security
+   platform-features/web-api/introduction
 
 
 .. toctree::

--- a/docs/source/platform-features/web-api/introduction.rst
+++ b/docs/source/platform-features/web-api/introduction.rst
@@ -157,7 +157,8 @@ following sections:
     - :ref:`Status <Platforms-Status-Endpoints>`: Endpoints for determining and clearing the status of all agents on
       the platform.
 
-.. toctree::
+ .. toctree::
+    :hidden:
 
-    authentication-endpoints
-    platforms-endpoints
+    Authentication <authentication-endpoints>
+    Platforms <platform-endpoints>

--- a/docs/source/platform-features/web-api/introduction.rst
+++ b/docs/source/platform-features/web-api/introduction.rst
@@ -1,7 +1,7 @@
 .. _Web-API:
 
 ======================================
-VOLTTRON User Interface API
+RESTful Web Interface
 ======================================
 
 The VOLTTRON User Interface API (VUI) is provided by the VOLTTRON Web Service, and is

--- a/docs/source/platform-features/web-api/introduction.rst
+++ b/docs/source/platform-features/web-api/introduction.rst
@@ -156,3 +156,8 @@ following sections:
       platform.
     - :ref:`Status <Platforms-Status-Endpoints>`: Endpoints for determining and clearing the status of all agents on
       the platform.
+
+.. toctree::
+
+    authentication-endpoints
+    platforms-endpoints

--- a/docs/source/platform-features/web-api/platform-endpoints.rst
+++ b/docs/source/platform-features/web-api/platform-endpoints.rst
@@ -118,3 +118,14 @@ Response:
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    Agents <platforms/agent-endpoints>
+    Configs <platforms/config-endpoints>
+    Devices <platforms/device-endpoints>
+    Health <platforms/health-endpoints>
+    Historians <platforms/historian-endpoints>
+    Pubsub <platforms/pubsub-endpoints>
+    Status <platforms/status-endpoints>

--- a/docs/source/platform-features/web-api/platforms/agent-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agent-endpoints.rst
@@ -111,3 +111,14 @@ Response:
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    ConfigStore <agents/config-endpoints>
+    Enabled <agents/enabled-endpoints>
+    Health <agents/health-endpoints>
+    RPC <agents/rpc-endpoints>
+    Running <agents/running-endpoints>
+    Status <agents/status-endpoints>
+    Tag <agents/tag-endpoints>

--- a/docs/source/platform-features/web-api/platforms/agents/config-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/config-endpoints.rst
@@ -226,3 +226,8 @@ Response
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/enabled-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/enabled-endpoints.rst
@@ -112,3 +112,8 @@ Response:
           }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/health-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/health-endpoints.rst
@@ -48,3 +48,8 @@ Response:
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/rpc-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/rpc-endpoints.rst
@@ -157,3 +157,8 @@ Response:
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/running-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/running-endpoints.rst
@@ -110,3 +110,8 @@ Response:
                 }
 
     * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/status-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/status-endpoints.rst
@@ -54,3 +54,8 @@ Response:
                 }
 
     * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/agents/tag-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/agents/tag-endpoints.rst
@@ -114,3 +114,8 @@ Response:
             }
 
 * **With invalid BEARER token:** ``401 Unauthorized``
+
+.. toctree::
+    :hidden:
+
+    self

--- a/docs/source/platform-features/web-api/platforms/device-endpoints.rst
+++ b/docs/source/platform-features/web-api/platforms/device-endpoints.rst
@@ -312,4 +312,3 @@ Response:
          }
 
 -  **With invalid BEARER token:** ``401 Unauthorized``
-


### PR DESCRIPTION
# Description

Added link in index.rst for web-api documentation.

Fixes # (issue)
#2983

## Type of change

- [ ] documentation

# How Has This Been Tested?

make html, then pull up in browser. Currently, this has the top-level link to the web-api documentation, but does not expand the menu on the left with sub-topics.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
