### PR TITLE
Bootstrap upgrade always

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -108,12 +108,12 @@ def bootstrap(dest, prompt='(volttron)', version=None, verbose=None):
     return os.path.join(dest, "bin/python")
 
 
-def pip(operation, args, verbose=None, upgrade=False, offline=False):
+def pip(operation, args, verbose=None, offline=False):
     """Call pip in the virtual environment to perform operation."""
     cmd = ['pip', operation]
     if verbose is not None:
         cmd.append('--verbose' if verbose else '--quiet')
-    if upgrade and operation == 'install':
+    if operation == 'install':
         cmd.append('--upgrade')
     if offline:
         cmd.extend(['--retries', '0', '--timeout', '1'])
@@ -123,7 +123,7 @@ def pip(operation, args, verbose=None, upgrade=False, offline=False):
     subprocess.check_call(cmd)
 
 
-def update(operation, verbose=None, upgrade=False, offline=False, optional_requirements=[], rabbitmq_path=None):
+def update(operation, verbose=None, offline=False, optional_requirements=[], rabbitmq_path=None):
     """Install dependencies in setup.py and requirements.txt."""
     print("UPDATE: {}".format(optional_requirements))
     assert operation in ['install', 'wheel']
@@ -144,7 +144,7 @@ def update(operation, verbose=None, upgrade=False, offline=False, optional_requi
         for opt in options:
             args.extend([build_option, opt])
         args.extend(['--no-deps', requirement])
-        pip(operation, args, verbose, upgrade, offline)
+        pip(operation, args, verbose, offline)
 
     # Install local packages and remaining dependencies
     args = []
@@ -160,7 +160,7 @@ def update(operation, verbose=None, upgrade=False, offline=False, optional_requi
         target += '[' + ','.join(optional_requirements) + ']'
     args.extend(['--editable', target])
     print(f"Target: {target}")
-    pip(operation, args, verbose, upgrade, offline)
+    pip(operation, args, verbose, offline)
 
     try:
         # Install rmq server if needed
@@ -172,7 +172,7 @@ def update(operation, verbose=None, upgrade=False, offline=False, optional_requi
 
 def install_rabbit(rmq_install_dir):
     # Install gevent friendly pika
-    pip('install', ['pika==1.2.0'], False, True, offline=False)
+    pip('install', ['pika==1.2.0'], False, offline=False)
     # try:
     process = subprocess.Popen(["which", "erl"], stderr=subprocess.PIPE,  stdout=subprocess.PIPE)
     (output, error) = process.communicate()
@@ -338,9 +338,6 @@ def main(argv=sys.argv):
         help='install from cache without downloading')
     ex = up.add_mutually_exclusive_group()
     ex.add_argument(
-        '-u', '--upgrade', action='store_true', default=False,
-        help='upgrade installed packages')
-    ex.add_argument(
         '-w', '--wheel', action='store_const', const='wheel', dest='operation',
         help='build wheels in the pip wheelhouse')
     path = os.path.dirname(__file__) or os.getcwd()
@@ -362,8 +359,7 @@ def main(argv=sys.argv):
     # Main script logic to perform bootstrapping or updating
     if sys.base_prefix != sys.prefix:
         # The script was called from a virtual environment Python, so update
-        update(options.operation, options.verbose,
-               options.upgrade, options.offline, options.optional_args, options.rabbitmq)
+        update(options.operation, options.verbose, options.offline, options.optional_args, options.rabbitmq)
     else:
         # The script was called from the system Python, so bootstrap
         try:

--- a/docs/source/deploying-volttron/bootstrap-process.rst
+++ b/docs/source/deploying-volttron/bootstrap-process.rst
@@ -63,14 +63,12 @@ The options for customizing the location of the virtual environment are as follo
     --prompt PROMPT       provide alternate prompt in activated environment
                           (default: volttron)
 
-Additional options are available for customizing where an environment will retrieve packages and/or upgrade
-existing packages installed.
+Additional options are available for customizing where an environment will retrieve packages installed.
 
 .. code-block:: bash
 
     update options:
       --offline             install from cache without downloading
-      -u, --upgrade         upgrade installed packages
       -w, --wheel           build wheels in the pip wheelhouse
 
 To help boostrap an environment in the shortest number of steps we have grouped dependency packages under named


### PR DESCRIPTION
# Description

Removed the --upgrade option from bootstrap.py. This is now the default behavior.

Fixes #2984

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran bootstrap.py without --upgrade option, and verified that it called pip --upgrade on all packages. Pinned packages were skipped.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
