### PR TITLE
Modify expected output

### DIFF
--- a/volttrontesting/platform/dbutils/test_sqlitefuncts.py
+++ b/volttrontesting/platform/dbutils/test_sqlitefuncts.py
@@ -394,7 +394,9 @@ def test_create_aggregate_store(get_sqlitefuncts):
     assert expected_new_agg_table in get_tables()
 
     actual_indexes = get_indexes(expected_new_agg_table)
-    assert actual_indexes == expected_indexes
+    for idx, val in enumerate(actual_indexes):
+        assert val.startswith(expected_indexes[idx]) 
+    # assert actual_indexes == expected_indexes
 
 
 @pytest.mark.sqlitefuncts

--- a/volttrontesting/platform/dbutils/test_sqlitefuncts.py
+++ b/volttrontesting/platform/dbutils/test_sqlitefuncts.py
@@ -386,7 +386,7 @@ def test_create_aggregate_store(get_sqlitefuncts):
     agg_type = "AVG"
     agg_time_period = "1984"
     expected_new_agg_table = "AVG_1984"
-    expected_indexes = ["0|idx_AVG_1984|0|c|0", "1|sqlite_autoindex_AVG_1984_1|1|u|0"]
+    expected_indexes = ['0|idx_AVG_1984|0', '1|sqlite_autoindex_AVG_1984_1|1']
 
     result = sqlitefuncts.create_aggregate_store(agg_type, agg_time_period)
 


### PR DESCRIPTION
# Description

The expected output for `test_create_aggregate_store` could vary because the [PRAGMA  index_list](https://www.sqlite.org/pragma.html#pragma_index_list) statement is producing different outputs depending on what machine is being used to run the test.

I ran this test on Centos 7.0 and saw that `test_create_aggregate_store` failed because the actual output did not match the expected output. This test makes a PRAGMA statement to get a list of indexes and then compares that list to the expected list. When this test is run on Ubutntu, the PRAGMA statement returns `["0|idx_AVG_1984|0|c|0", "1|sqlite_autoindex_AVG_1984_1|1|u|0"]`, but on Centos 7.0, it returns `['0|idx_AVG_1984|0', '1|sqlite_autoindex_AVG_1984_1|1']`. To ensure that tests can run on both flavors of Linux, this PR modifies the assertion test in `test_create_aggregate_store`. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Python 3.8.10
* Centos 7.0

```
pytest -s test_sqlitefuncts.py

# expected output

53 passed, 2 skipped in 48.30s

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
