### PR TITLE
Tests/fix test global settings

### DIFF
--- a/services/core/PlatformDriverAgent/tests/test_global_settings.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_settings.py
@@ -44,7 +44,7 @@ import pytest
 import gevent
 
 from volttron.platform import get_services_core
-from volttron.platform.agent.known_identities import CONFIGURATION_STORE, PLATFORM_DRIVER
+from volttron.platform.agent.known_identities import PLATFORM_DRIVER
 from volttron.platform.vip.agent import Agent
 from volttron.platform.messaging import topics
 
@@ -66,6 +66,7 @@ class _subscriber_agent(Agent):
         self.publish_results.add(topic)
 
 
+# def subscriber_agent(request, volttron_instance):
 @pytest.fixture(scope="module")
 def subscriber_agent(request, volttron_instance):
 
@@ -73,12 +74,9 @@ def subscriber_agent(request, volttron_instance):
 
     agent.vip.pubsub.subscribe(peer='pubsub', prefix=topics.DRIVER_TOPIC_BASE, callback=agent.add_result).get()
 
-    def cleanup():
-        agent.core.stop()
+    yield agent
 
-    request.addfinalizer(cleanup)
-    return agent
-
+    agent.core.stop()
 
 fake_device_config = """
 {{
@@ -149,60 +147,48 @@ breadth_set = set(['devices/Float/fake', 'devices/FloatNoDefault/fake'])
 
 
 @pytest.fixture(scope="module")
-def config_store_connection(request, volttron_instance):
-    capabilities = [{'edit_config_store': {'identity': PLATFORM_DRIVER}}]
-    connection = volttron_instance.build_connection(peer=CONFIGURATION_STORE, capabilities=capabilities)
+def test_agent(volttron_instance):
+    """
+    Build a test_agent, PlatformDriverAgent
+    """
+
+    # Build a test agent
+    md_agent = volttron_instance.build_agent(identity="test_md_agent")
     gevent.sleep(1)
-    # Reset platform driver config store
-    connection.call("manage_delete_store", PLATFORM_DRIVER)
 
-    # Start the platform driver agent which would in turn start the fake driver
-    #  using the configs created above
+    if volttron_instance.auth_enabled:
+        capabilities = {"edit_config_store": {"identity": PLATFORM_DRIVER}}
+        volttron_instance.add_capabilities(md_agent.core.publickey, capabilities)
+
+    # Clean out platform driver configurations
+    # wait for it to return before adding new config
+    md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
+
+    # Add a fake.csv to the config store
+    md_agent.vip.rpc.call("config.store", "manage_store", PLATFORM_DRIVER, "fake.csv", registry_config_string, config_type="csv").get()
+    
+    # install the PlatformDriver
     platform_uuid = volttron_instance.install_agent(
-        agent_dir=get_services_core("PlatformDriverAgent"),
-        config_file={},
-        start=True)
-    print("agent id: ", platform_uuid)
-    gevent.sleep(2)  # wait for the agent to start and start the devices
+        agent_dir=get_services_core("PlatformDriverAgent"), config_file={}, start=True
+    )
 
-    def stop_agent():
-        volttron_instance.stop_agent(platform_uuid)
-        volttron_instance.remove_agent(platform_uuid)
-        connection.kill()
+    gevent.sleep(10)  # wait for the agent to start and start the devices
 
-    request.addfinalizer(stop_agent)
+    yield md_agent
 
-    return connection
+    volttron_instance.stop_agent(platform_uuid)
+    md_agent.core.stop()
 
-
-@pytest.fixture(scope="function")
-def config_store(request, config_store_connection):
-    # Always have fake.csv ready to go.
-    print("Adding fake.csv into store")
-    config_store_connection.call("manage_store", PLATFORM_DRIVER, "fake.csv", registry_config_string, config_type="csv")
-
-    def cleanup():
-        # Reset platform driver config store
-        print("Wiping out store.")
-        config_store_connection.call("manage_delete_store", PLATFORM_DRIVER)
-        gevent.sleep(0.1)
-
-    request.addfinalizer(cleanup)
-
-    return config_store_connection
-
-
-def setup_config(config_store, config_name, config_string, **kwargs):
+def setup_config(test_agent, config_name, config_string, **kwargs):
     config = config_string.format(**kwargs)
     print("Adding", config_name, "to store")
-    config_store.call("manage_store", PLATFORM_DRIVER, config_name, config, config_type="json")
+    test_agent.vip.rpc.call("config.store", "manage_store", PLATFORM_DRIVER, config_name, config, config_type="json").get()
 
 
 @pytest.mark.driver
-def test_default_publish(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config_default)
-    setup_config(config_store, "devices/fake", fake_device_config)
-
+def test_default_publish(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config_default)
+    setup_config(test_agent, "devices/fake", fake_device_config)
     subscriber_agent.reset_results()
 
     # Give it enough time to publish at least once.
@@ -212,15 +198,14 @@ def test_default_publish(config_store, subscriber_agent):
 
     assert results == depth_all_set
 
-
 @pytest.mark.driver
-def test_default_global_off(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_global_off(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
-    setup_config(config_store, "devices/fake", fake_device_config)
+    setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
 
@@ -233,13 +218,13 @@ def test_default_global_off(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_global_breadth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_global_breadth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="true",
                  depth_all="false",
                  breadth="false",
                  depth="false")
-    setup_config(config_store, "devices/fake", fake_device_config)
+    setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
 
@@ -252,13 +237,13 @@ def test_default_global_breadth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_global_depth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_global_depth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="true",
                  breadth="false",
                  depth="false")
-    setup_config(config_store, "devices/fake", fake_device_config)
+    setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
 
@@ -271,13 +256,13 @@ def test_default_global_depth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_global_depth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_global_depth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="true")
-    setup_config(config_store, "devices/fake", fake_device_config)
+    setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
 
@@ -290,13 +275,13 @@ def test_default_global_depth(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_global_breadth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_global_breadth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="true",
                  depth="false")
-    setup_config(config_store, "devices/fake", fake_device_config)
+    setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
 
@@ -309,14 +294,14 @@ def test_default_global_breadth(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_override,
                  breadth_all="true",
                  depth_all="true",
                  breadth="true",
@@ -333,14 +318,14 @@ def test_default_override_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_breadth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_breadth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_override,
                  breadth_all="true",
                  depth_all="false",
                  breadth="false",
@@ -357,14 +342,14 @@ def test_default_override_breadth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_depth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_depth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_override,
                  breadth_all="false",
                  depth_all="true",
                  breadth="false",
@@ -381,14 +366,14 @@ def test_default_override_depth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_depth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_depth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_override,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
@@ -405,14 +390,14 @@ def test_default_override_depth(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_breadth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_breadth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_override,
                  breadth_all="false",
                  depth_all="false",
                  breadth="true",
@@ -429,14 +414,14 @@ def test_default_override_breadth(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_single_breadth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_single_breadth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_single_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
                  override_param='"publish_breadth_first_all": true')
 
     subscriber_agent.reset_results()
@@ -450,14 +435,14 @@ def test_default_override_single_breadth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_single_depth_all(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_single_depth_all(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_single_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
                  override_param='"publish_depth_first_all": true')
 
     subscriber_agent.reset_results()
@@ -471,14 +456,14 @@ def test_default_override_single_depth_all(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_single_depth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_single_depth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_single_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
                  override_param='"publish_depth_first": true')
 
     subscriber_agent.reset_results()
@@ -492,14 +477,14 @@ def test_default_override_single_depth(config_store, subscriber_agent):
 
 
 @pytest.mark.driver
-def test_default_override_single_breadth(config_store, subscriber_agent):
-    setup_config(config_store, "config", platform_driver_config,
+def test_default_override_single_breadth(test_agent, subscriber_agent):
+    setup_config(test_agent, "config", platform_driver_config,
                  breadth_all="false",
                  depth_all="false",
                  breadth="false",
                  depth="false")
 
-    setup_config(config_store, "devices/fake", fake_device_config_single_override,
+    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
                  override_param='"publish_breadth_first": true')
 
     subscriber_agent.reset_results()

--- a/services/core/PlatformDriverAgent/tests/test_global_settings.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_settings.py
@@ -70,13 +70,18 @@ class _subscriber_agent(Agent):
 @pytest.fixture(scope="module")
 def subscriber_agent(request, volttron_instance):
 
-    agent = volttron_instance.build_agent(identity='subscriber_agent', agent_class=_subscriber_agent)
+    agent = volttron_instance.build_agent(
+        identity="subscriber_agent", agent_class=_subscriber_agent
+    )
 
-    agent.vip.pubsub.subscribe(peer='pubsub', prefix=topics.DRIVER_TOPIC_BASE, callback=agent.add_result).get()
+    agent.vip.pubsub.subscribe(
+        peer="pubsub", prefix=topics.DRIVER_TOPIC_BASE, callback=agent.add_result
+    ).get()
 
     yield agent
 
     agent.core.stop()
+
 
 fake_device_config = """
 {{
@@ -140,10 +145,10 @@ Float,Float,F,-100 to 300,TRUE,50,float,CO2 Reading 0.00-2000.0 ppm
 FloatNoDefault,FloatNoDefault,F,-100 to 300,TRUE,,float,CO2 Reading 0.00-2000.0 ppm
 """
 
-depth_all_set = set(['devices/fake/all'])
-breadth_all_set = set(['devices/all/fake'])
-depth_set = set(['devices/fake/Float', 'devices/fake/FloatNoDefault'])
-breadth_set = set(['devices/Float/fake', 'devices/FloatNoDefault/fake'])
+depth_all_set = set(["devices/fake/all"])
+breadth_all_set = set(["devices/all/fake"])
+depth_set = set(["devices/fake/Float", "devices/fake/FloatNoDefault"])
+breadth_set = set(["devices/Float/fake", "devices/FloatNoDefault/fake"])
 
 
 @pytest.fixture(scope="module")
@@ -165,8 +170,15 @@ def test_agent(volttron_instance):
     md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
 
     # Add a fake.csv to the config store
-    md_agent.vip.rpc.call("config.store", "manage_store", PLATFORM_DRIVER, "fake.csv", registry_config_string, config_type="csv").get()
-    
+    md_agent.vip.rpc.call(
+        "config.store",
+        "manage_store",
+        PLATFORM_DRIVER,
+        "fake.csv",
+        registry_config_string,
+        config_type="csv",
+    ).get()
+
     # install the PlatformDriver
     platform_uuid = volttron_instance.install_agent(
         agent_dir=get_services_core("PlatformDriverAgent"), config_file={}, start=True
@@ -179,10 +191,18 @@ def test_agent(volttron_instance):
     volttron_instance.stop_agent(platform_uuid)
     md_agent.core.stop()
 
+
 def setup_config(test_agent, config_name, config_string, **kwargs):
     config = config_string.format(**kwargs)
     print("Adding", config_name, "to store")
-    test_agent.vip.rpc.call("config.store", "manage_store", PLATFORM_DRIVER, config_name, config, config_type="json").get()
+    test_agent.vip.rpc.call(
+        "config.store",
+        "manage_store",
+        PLATFORM_DRIVER,
+        config_name,
+        config,
+        config_type="json",
+    ).get()
 
 
 @pytest.mark.driver
@@ -198,13 +218,18 @@ def test_default_publish(test_agent, subscriber_agent):
 
     assert results == depth_all_set
 
+
 @pytest.mark.driver
 def test_default_global_off(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
     setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
@@ -219,11 +244,15 @@ def test_default_global_off(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_global_breadth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="true",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="true",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
     setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
@@ -238,11 +267,15 @@ def test_default_global_breadth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_global_depth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="true",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="true",
+        breadth="false",
+        depth="false",
+    )
     setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
@@ -257,11 +290,15 @@ def test_default_global_depth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_global_depth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="true")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="true",
+    )
     setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
@@ -276,11 +313,15 @@ def test_default_global_depth(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_global_breadth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="true",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="true",
+        depth="false",
+    )
     setup_config(test_agent, "devices/fake", fake_device_config)
 
     subscriber_agent.reset_results()
@@ -295,17 +336,25 @@ def test_default_global_breadth(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_override,
-                 breadth_all="true",
-                 depth_all="true",
-                 breadth="true",
-                 depth="true")
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_override,
+        breadth_all="true",
+        depth_all="true",
+        breadth="true",
+        depth="true",
+    )
 
     subscriber_agent.reset_results()
 
@@ -319,17 +368,25 @@ def test_default_override_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_breadth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_override,
-                 breadth_all="true",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_override,
+        breadth_all="true",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
     subscriber_agent.reset_results()
 
@@ -343,17 +400,25 @@ def test_default_override_breadth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_depth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_override,
-                 breadth_all="false",
-                 depth_all="true",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_override,
+        breadth_all="false",
+        depth_all="true",
+        breadth="false",
+        depth="false",
+    )
 
     subscriber_agent.reset_results()
 
@@ -367,17 +432,25 @@ def test_default_override_depth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_depth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_override,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="true")
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_override,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="true",
+    )
 
     subscriber_agent.reset_results()
 
@@ -391,17 +464,25 @@ def test_default_override_depth(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_breadth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_override,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="true",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_override,
+        breadth_all="false",
+        depth_all="false",
+        breadth="true",
+        depth="false",
+    )
 
     subscriber_agent.reset_results()
 
@@ -415,14 +496,22 @@ def test_default_override_breadth(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_single_breadth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
-                 override_param='"publish_breadth_first_all": true')
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_single_override,
+        override_param='"publish_breadth_first_all": true',
+    )
 
     subscriber_agent.reset_results()
 
@@ -436,14 +525,22 @@ def test_default_override_single_breadth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_single_depth_all(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
-                 override_param='"publish_depth_first_all": true')
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_single_override,
+        override_param='"publish_depth_first_all": true',
+    )
 
     subscriber_agent.reset_results()
 
@@ -457,14 +554,22 @@ def test_default_override_single_depth_all(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_single_depth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
-                 override_param='"publish_depth_first": true')
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_single_override,
+        override_param='"publish_depth_first": true',
+    )
 
     subscriber_agent.reset_results()
 
@@ -478,14 +583,22 @@ def test_default_override_single_depth(test_agent, subscriber_agent):
 
 @pytest.mark.driver
 def test_default_override_single_breadth(test_agent, subscriber_agent):
-    setup_config(test_agent, "config", platform_driver_config,
-                 breadth_all="false",
-                 depth_all="false",
-                 breadth="false",
-                 depth="false")
+    setup_config(
+        test_agent,
+        "config",
+        platform_driver_config,
+        breadth_all="false",
+        depth_all="false",
+        breadth="false",
+        depth="false",
+    )
 
-    setup_config(test_agent, "devices/fake", fake_device_config_single_override,
-                 override_param='"publish_breadth_first": true')
+    setup_config(
+        test_agent,
+        "devices/fake",
+        fake_device_config_single_override,
+        override_param='"publish_breadth_first": true',
+    )
 
     subscriber_agent.reset_results()
 


### PR DESCRIPTION
# Description

The config store test fixture does not work as expected. I've replaced it using a test agent that makes RPC calls to the config store. Similar to the solution in #3013. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Centos 7.0, Python 3.8.10

```
pytest test_global_settings.py

= 30 passed, 15 skipped in 244.94s (0:04:04) =
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
