### PR TITLE
Renamed secure mode to agent isolation mode - fix for #3035

### DIFF
--- a/docs/source/agent-framework/historian-agents/sql-historian/sql-historian.rst
+++ b/docs/source/agent-framework/historian-agents/sql-historian/sql-historian.rst
@@ -76,11 +76,16 @@ or
 Sqlite3 Specifics
 -----------------
 
-An Sqlite Historian provides a convenient solution for under powered systems. The database is a parameter to a location on the file system; 'database' should be a non-empty string.
-By default, the location is relative to the agent's installation directory, however it will respect a rooted or relative path to the database.
+An Sqlite Historian provides a convenient solution for under powered systems. The database is a parameter to a location
+on the file system; 'database' should be a non-empty string.
+By default, the location is relative to the agent's installation directory, however it will respect a rooted or
+relative path to the database.
 
-If 'database' does not have a rooted or relative path, the location of the database depends on whether the volttron platform is in secure mode. For more information on secure mode, see :ref:`Running-Agents-as-Unix-User`.
-In secure mode, the location will be under <install_dir>/<agent name>.agent-data directory because this will be the only directory in which the agent will have write-access.
+If 'database' does not have a rooted or relative path, the location of the database depends on whether the volttron
+platform is in agent isolation mode. For more information on agent isolation mode,
+see :ref:`Running-Agents-as-Unix-User`.
+In agent isolation mode, the location will be under <install_dir>/<agent name>.agent-data directory because this
+will be the only directory in which the agent will have write-access.
 In regular mode, the location will be under <install_dir>/data for backward compatibility.
 
 The following is a minimal configuration file that uses a relative path to the database.

--- a/docs/source/deploying-volttron/platform-configuration.rst
+++ b/docs/source/deploying-volttron/platform-configuration.rst
@@ -161,7 +161,7 @@ Optional Arguments
   - **--list-agents** - Display a list of configurable agents (Listener, Platform Driver, Platform Historian, VOLTTRON
     Central, VOLTTRON Central Platform)
   - **--agent AGENT [AGENT ...]** - Configure listed agents
-  - **--secure-agent-users** - Require that agents run as their own Unix users (this requires running
+  - **--agent-isolation-mode** - Require that agents run as their own Unix users (this requires running
     `scripts/secure_user_permissions.sh` as `sudo`)
 
 RabbitMQ Arguments

--- a/docs/source/deploying-volttron/secure-deployment-considerations.rst
+++ b/docs/source/deploying-volttron/secure-deployment-considerations.rst
@@ -177,5 +177,5 @@ that agent user such that agent has write access only to its own agent-data fold
 prevents agents from accidentally or intentionally editing/deleting other volttron process or other agents' files or
 system files outside of VOLTTRON_HOME
 
-For more information, refer to :ref:`Running-Agents-as-Unique-Unix-User`.
+For more information, refer to :ref:`Agent Isolation Mode: Running Users as unique Unix user<Agent-Isolation-Mode>`.
 

--- a/docs/source/platform-features/control/platform-commands.rst
+++ b/docs/source/platform-features/control/platform-commands.rst
@@ -113,12 +113,12 @@ Agent Options
   instance
 - **--agent-monitor-frequency AGENT_MONITOR_FREQUENCY** - How often should the platform check for crashed agents
   and attempt to restart. Units=seconds. Default=600
-- **--secure-agent-users SECURE_AGENT_USERS** - Require that agents run with their own users (this requires running
+- **--agent-isolation-mode AGENT_ISOLATION_MODE** - Require that agents run with their own users (this requires running
   scripts/secure_user_permissions.sh as sudo)
 
 .. warning::
 
-   Certain options alter some basic behaviors of the platform, such as `--secure-agent-users` which causes the platform
+   Certain options alter some basic behaviors of the platform, such as `--agent-isolation-mode` which causes the platform
    to run each agent using its own Unix user to spawn the process.  Please view the documentation for each feature to
    understand its implications before choosing to run the platform in that fashion.
 
@@ -338,7 +338,7 @@ vcfg Optional Arguments
 
      vcfg --rabbitmq single|federation|shovel [rabbitmq config file]
 
-- **--secure-agent-users**  Require that agents run with their own users (this requires running
+- **--agent-isolation-mode**  Require that agents run with their own users (this requires running
   scripts/secure_user_permissions.sh as sudo)
 
   .. warning::

--- a/docs/source/platform-features/security/agent-isolation-mode.rst
+++ b/docs/source/platform-features/security/agent-isolation-mode.rst
@@ -1,8 +1,8 @@
-.. _Running-Agents-as-Unique-Unix-User:
+.. _Agent-Isolation-Mode:
 
-============================
-Running Agents as Unix Users
-============================
+====================
+Agent Isolation Mode
+====================
 
 This VOLTTRON feature will cause the platform to create a new, unique Unix user(agent users) on the host machine for
 each agent installed on the platform.  This user will have restricted permissions for the file system, and will be used
@@ -19,9 +19,9 @@ VOLTTRON platform.
 All files and folder created by the VOLTTRON process in this mode would not have any access to others by default.
 Permission for Unix group others would be provided to specific files and folder based on VOLTTRON process requirement.
 
-It is recommended that you use a new :term:`VOLTTRON_HOME` to run VOLTTRON in secure mode.  Converting a existing
-VOLTTRON instance to secure mode is also possible but would involve some manual changes.  Please see the section
-`Porting existing volttron home to secure mode`_.
+It is recommended that you use a new :term:`VOLTTRON_HOME` to run VOLTTRON in agent isolation mode.  Converting a existing
+VOLTTRON instance to agent isolation mode is also possible but would involve some manual changes.  Please see the section
+`Porting existing volttron home to agent isolation mode`_.
 
 .. note::
 
@@ -86,13 +86,13 @@ Setup agents to run using unique users
 Creating new Agents
 ===================
 
-In this secure mode, agents will only have read write access to the agent-data directory under the agent install
+In agent isolation mode, agents will only have read write access to the agent-data directory under the agent install
 directory - `VOLTTRON_HOME/agents/<agent_uuid>/<agent_name>/<agent_name>.agent-data`. Attempting to write in any other
 folder under `VOLTTRON_HOME` **will result in permission errors**.
 
 
-Changes to existing agents in secure mode
-=========================================
+Changes to existing agents in agent isolation mode
+==================================================
 
 Due to the above change, **SQL historian has been modified to create its database by default under its agent-data
 directory** if no path is given in the config file.  If providing a path to the database in the config file, please
@@ -100,17 +100,18 @@ provide a directory where agent will have write access.  This can be an external
 (`recorded in VOLTTRON_HOME/agents/<agent-uuid>/USER_ID`) has *read, write, and execute* access.
 
 
-Porting existing VOLTTRON home to secure mode
-=============================================
+Porting existing VOLTTRON home to agent isolation mode
+======================================================
 
 When running `scripts/secure_users_permissions.sh` you will be prompted for a `VOLTTRON_HOME` directory.  If this
 directory exists and contains a volttron config file, the script will update the file locations and permissions of
 existing VOLTTRON files including installed directories.  However this step has the following limitations:
 
-#. **You will NOT be able to revert to insecure mode once the changes are done.** - Once setup is complete, changing the
-   config file manually to make parameter `secure-agent-users` to `False`, may result inconsistent VOLTTRON behavior
+#. **You will NOT be able to revert from agent isolation mode once the changes are done.** - Once setup is complete,
+   changing the config file manually to make parameter `agent-isolation-mode` to `False`, may result inconsistent
+   VOLTTRON behavior
 #. The VOLTTRON process and all agents have to be restarted to take effect
-#. **Agents can only to write to its own agent-data dir.** - If your agents writes to any directory outside
+#. **Agents can only write to its own agent-data dir.** - If your agents writes to any directory outside
    `$VOLTTRON_HOME/agents/<agent-uuid>/<agent-name>/agent-name.agent-data` move existing files and update the agent
    configuration such that the agent writes to the `agent-name.agent-data` dir.  For example, if you have a
    `SQLHistorian` which writes a `.sqlite` file to a subdirectory under `VOLTTRON_HOME` that is not

--- a/docs/source/platform-features/security/volttron-security.rst
+++ b/docs/source/platform-features/security/volttron-security.rst
@@ -29,5 +29,5 @@ Additional documentation related to VIP authentication and authorization is avai
 
    key-stores
    known-hosts-file
-   running-agent-as-unique-user
+   agent-isolation-mode
    non-auth-mode

--- a/scripts/secure_stop_agent.sh
+++ b/scripts/secure_stop_agent.sh
@@ -29,7 +29,7 @@ stop_process_and_wait(){
 user=$1
 pid=$2
 
-#  Verify script is run as root or using sudo because agents will be running as root in secure mode
+#  Verify script is run as root or using sudo because agents will be running as root in agent isolation mode
 if [ -z "$UID" ] || [ $UID -ne 0 ]; then
   echo "Script should be run as root user or as sudo <path to this script>/secure_stop_agent.sh"
   exit

--- a/scripts/secure_user_permissions.sh
+++ b/scripts/secure_user_permissions.sh
@@ -47,7 +47,7 @@ if [ ! -d $volttron_home ]; then
 else
     echo -n "
 **WARNING** You are using a existing directory as volttron home."
-    echo -n " You will NOT be able to revert to insecure mode once the changes \
+    echo -n " You will NOT be able to revert out of agent isolation mode once the changes \
 are done. Changing the config file manually might result inconsistent \
 volttron behavior. If you would like to continue please note the following,
        1. This script will manually restrict permissions for existing files and directory.
@@ -58,7 +58,7 @@ move existing files and update configuration such that agent writes to agent-nam
        4. If you have agents that **connect to remote RMQ instances** the script will attempt to move the \
 remote instance signed certificate into corresponding agent's agent-data directory
 "
-    echo -n "Would you like to transition this existing VOLTTRON_HOME to secure mode (Y/N)"
+    echo -n "Would you like to transition this existing VOLTTRON_HOME to agent isolation mode (Y/N)"
     read continue
     if [ $continue == "Y" ] || [ $continue == "y" ]; then
 
@@ -185,7 +185,7 @@ remote instance signed certificate into corresponding agent's agent-data directo
                 chown ${volttron_user} $data_dir/$file_name
             done
         fi
-        echo "####Completed volttron home permission changes and file organization for secure mode"
+        echo "####Completed volttron home permission changes and file organization for agent isolation mode"
         echo  " "
 
     else
@@ -194,18 +194,18 @@ remote instance signed certificate into corresponding agent's agent-data directo
 fi
 
 if [ -f $volttron_home/config ]; then
-    line=`grep secure-agent-users $volttron_home/config`
+    line=`grep agent-isolation-mode $volttron_home/config`
     if [ -z "$line" ]; then
         # append to end of file
-        echo "entry for secure-agent-users does not exists. appending to end of file"
-        echo "secure-agent-users = True" >> $volttron_home/config
+        echo "entry for agent-isolation-mode does not exists. appending to end of file"
+        echo "agent-isolation-mode = True" >> $volttron_home/config
     else
         # replace false to true
-        sed -i 's/secure-agent-users = False/secure-agent-users = True/' $volttron_home/config
+        sed -i 's/agent-isolation-mode = False/agent-isolation-mode = True/' $volttron_home/config
     fi
 else
     echo "[volttron]" > $volttron_home/config
-    echo "secure-agent-users = True" >> $volttron_home/config
+    echo "agent-isolation-mode = True" >> $volttron_home/config
     chown $volttron_user $volttron_home/config
 fi
 
@@ -237,13 +237,13 @@ while true; do
                 if [ $continue == "N" ] || [ $continue == "n" ]; then
                     # write instance-name to config file
                     echo "instance-name = $name" >> $volttron_home/config
-                    echo "Volttron secure mode setup is complete"
+                    echo "Volttron agent isolation mode setup is complete"
                     exit 0
                 else
                     name=""
                 fi
             else
-                echo "Volttron secure mode setup is complete"
+                echo "Volttron agent isolation mode setup is complete"
                 exit 0
             fi
         else
@@ -275,4 +275,4 @@ echo "$volttron_user ALL= NOPASSWD: /usr/sbin/userdel volttron_[1-9]*" | sudo ED
 # allow user to run all non-sudo commands for all volttron agent users
 echo "$volttron_user ALL=(%volttron_$name) NOPASSWD: ALL" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
 echo "Permissions set for $volttron_user"
-echo "Volttron secure mode setup is complete"
+echo "Volttron agent isolation mode setup is complete"

--- a/scripts/secure_user_permissions.sh
+++ b/scripts/secure_user_permissions.sh
@@ -268,7 +268,7 @@ done
 echo "$volttron_user ALL= NOPASSWD: /usr/sbin/groupadd volttron_$name" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
 echo "$volttron_user ALL= NOPASSWD: /usr/sbin/usermod -a -G volttron_$name $USER" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
 echo "$volttron_user ALL= NOPASSWD: /usr/sbin/useradd volttron_[1-9]* -r -G volttron_$name" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
-echo "$volttron_user ALL= NOPASSWD: $source_dir/scripts/secure_stop_agent.sh volttron_[1-9]* [1-9]*" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
+echo "$volttron_user ALL= NOPASSWD: $source_dir/scripts/stop_agent_running_in_isolation.sh volttron_[1-9]* [1-9]*" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name
 
 # TODO want delete only users with pattern of particular group
 echo "$volttron_user ALL= NOPASSWD: /usr/sbin/userdel volttron_[1-9]*" | sudo EDITOR='tee -a' visudo -f /etc/sudoers.d/volttron_$name

--- a/scripts/stop_agent_running_in_isolation.sh
+++ b/scripts/stop_agent_running_in_isolation.sh
@@ -31,7 +31,7 @@ pid=$2
 
 #  Verify script is run as root or using sudo because agents will be running as root in agent isolation mode
 if [ -z "$UID" ] || [ $UID -ne 0 ]; then
-  echo "Script should be run as root user or as sudo <path to this script>/secure_stop_agent.sh"
+  echo "Script should be run as root user or as sudo <path to this script>/stop_agent_running_in_isolation.sh"
   exit
 fi
 
@@ -40,7 +40,7 @@ fi
 re='volttron_[0-9]+'
 if ! [[ $user =~ $re ]]; then
     echo "Invalid user $user"
-    echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
+    echo "Usage: <path>/stop_agent_running_in_isolation.sh <user name of requester> <pid of agent to be stopped>"
     exit 1
 fi
 
@@ -48,7 +48,7 @@ fi
 re='^[0-9]+$'
 if [ -z "$pid" ] || ! [[ $pid =~ $re ]]; then
     echo "Invalid process id..."
-    echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
+    echo "Usage: <path>/stop_agent_running_in_isolation.sh <user name of requester> <pid of agent to be stopped>"
     exit 2
 fi
 
@@ -59,7 +59,7 @@ exit_code="$?"
 # If exit code is not 0 for the ps command then no such pid exists
 if [ $exit_code -ne 0 ]; then
     echo "Invalid process id $pid. Process id does not correspond to any valid agent process"
-    echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
+    echo "Usage: <path>/stop_agent_running_in_isolation.sh <user name of requester> <pid of agent to be stopped>"
     exit 3
 fi
 
@@ -70,7 +70,7 @@ fi
 re="^sudo -E -u $user /.+/python.* -m .+"
 if [[ ! $command =~ $re ]]; then
     echo "Invalid process id. pid does not correspond to a volttron agent owned by user $user"
-    echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
+    echo "Usage: <path>/stop_agent_running_in_isolation.sh <user name of requester> <pid of agent to be stopped>"
     exit 4
 fi
 
@@ -80,7 +80,7 @@ exit_code="$?"
 # If exit code is not 0 for the ps command then no such pid exists
 if [ $exit_code -ne 0 ]; then
     echo "Invalid process id $pid. Process id does not have valid child process"
-    echo "Usage: <path>/secure_stop_agent.sh <user name of requester> <pid of agent to be stopped>"
+    echo "Usage: <path>/stop_agent_running_in_isolation.sh <user name of requester> <pid of agent to be stopped>"
     exit 5
 fi
 

--- a/services/ops/TopicWatcher/tests/test_topic_watcher.py
+++ b/services/ops/TopicWatcher/tests/test_topic_watcher.py
@@ -76,18 +76,17 @@ def agent(request, volttron_instance):
         vip_identity=PLATFORM_TOPIC_WATCHER
     )
     gevent.sleep(2)
-    if volttron_instance.secure_agent_users:
+    if volttron_instance.agent_isolation_mode:
         db_path = os.path.join(volttron_instance.volttron_home, 'agents',
                                alert_uuid, 'topic_watcheragent-' + agent_version,
                                'topic-watcheragent-' + agent_version + '.agent-data',
                                'alert_log.sqlite')
     else:
-        # agent keeps the same path in insecure mode for backward compatibility
         db_path = os.path.join(volttron_instance.volttron_home, 'agents',
                                alert_uuid, 'topic_watcheragent-' + agent_version,
                                'alert_log.sqlite')
 
-    print ("DB PATH: {}".format(db_path))
+    print("DB PATH: {}".format(db_path))
     db_connection = sqlite3.connect(
         db_path,
         detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)

--- a/volttron/platform/agent/base_historian.py
+++ b/volttron/platform/agent/base_historian.py
@@ -1754,7 +1754,7 @@ class BackupDatabase:
 
         _log.debug(f"Setting up backup DB. {os.getcwd()}")
         # we want to create it in the agent-data directory since agent will not have write access to any other
-        # directory in secure mode
+        # directory in agent isolation mode
         if os.path.exists(os.path.join(os.getcwd(), os.path.basename(os.getcwd()) + ".agent-data")):
             backup_db = os.path.join(os.getcwd(), os.path.basename(os.getcwd()) + ".agent-data", 'backup.sqlite')
         else:   

--- a/volttron/platform/agent/utils.py
+++ b/volttron/platform/agent/utils.py
@@ -261,12 +261,12 @@ def is_web_enabled():
 
 
 def is_secure_mode():
-    """Returns True if running in secure mode, False otherwise"""
-    string_value = os.environ.get('SECURE_AGENT_USERS')
+    """Returns True if running in agent isolation mode, False otherwise"""
+    string_value = os.environ.get('AGENT_ISOLATION_MODE')
     _log.debug("value from env {}".format(string_value))
     if not string_value:
         config = load_platform_config()
-        string_value = config.get('secure-agent-users', 'False')
+        string_value = config.get('agent-isolation-mode', 'False')
         _log.debug("value from config {}".format(string_value))
 
     if string_value == "True":

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -237,7 +237,7 @@ class SecureExecutionEnvironment:
 
     def stop(self):
         if self.process.poll() is None:
-            cmd = ["sudo", update_volttron_script_path("scripts/secure_stop_agent.sh"), self.agent_user, str(self.process.pid)]
+            cmd = ["sudo", update_volttron_script_path("scripts/stop_agent_running_in_isolation.sh"), self.agent_user, str(self.process.pid)]
             _log.debug("In aip secureexecutionenv {}".format(cmd))
             process = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
             stdout, stderr = process.communicate()

--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -397,8 +397,8 @@ class AIPplatform:
                 os.makedirs(path)
                 os.chmod(path, 0o755)
         # Create certificates directory and its subdirectory at start of platform
-        # so if volttron is run in secure mode, the first agent install would already have
-        # the directories ready. In secure mode, agents will be run as separate user and will
+        # so if volttron is run in agent isolation mode, the first agent install would already have
+        # the directories ready. In agent isolation mode, agents will be run as separate user and will
         # not have access to create these directories
         Certs()
 
@@ -970,7 +970,7 @@ class AIPplatform:
                 _log.info("No existing volttron agent user was found at {} due "
                           "to {}".format(user_id_path, err))
 
-                # May be switched from normal to secure mode with existing agents. To handle this case
+                # May be switched from normal to agent isolation mode with existing agents. To handle this case
                 # create users and also set permissions again for existing files
                 agent_user = self.add_agent_user(name, agent_dir)
                 self.set_agent_user_permissions(agent_user,
@@ -979,7 +979,7 @@ class AIPplatform:
 
                 # additionally give permissions to contents of agent-data dir.
                 # This is needed only for agents installed before switching to
-                # secure mode. Agents installed in secure mode will own files
+                # agent isolation mode. Agents installed in agent isolation mode will own files
                 # in agent-data dir
                 # Moved this to the top so that "agent-data" directory gets
                 # created in the beginning

--- a/volttron/platform/auth/auth_protocols/auth_rmq.py
+++ b/volttron/platform/auth/auth_protocols/auth_rmq.py
@@ -170,7 +170,7 @@ class RMQConnectionAPI:
         permissions = self.rmq_mgmt.get_default_permissions(self.params.rmq_user)
 
         if self.ssl_auth:
-            # This could fail with permission error when running in secure mode
+            # This could fail with permission error when running in agent isolation mode
             # and agent was installed when volttron was running on ZMQ instance
             # and then switched to RMQ instance. In that case
             # vctl certs create-ssl-keypair should be used to create a cert/key pair

--- a/volttron/platform/auth/certs.py
+++ b/volttron/platform/auth/certs.py
@@ -696,7 +696,7 @@ class Certs:
 
     def create_requests_ca_bundle(self, agent_remote_cert_dir):
         # if this is called by agent there will be an agent specific
-        # remote cert dir in secure mode
+        # remote cert dir in agent isolation mode
         bundle_file = os.path.join(agent_remote_cert_dir, "requests_ca_bundle")
 
         with open(bundle_file, 'wb') as fp:
@@ -723,7 +723,7 @@ class Certs:
 
     def save_remote_cert(self, name, cert_string, remote_cert_dir=None):
         if remote_cert_dir:
-            # agent has its own remote cert dir in secure mode
+            # agent has its own remote cert dir in agent isolation mode
             cert_file = os.path.join(remote_cert_dir, name + ".crt")
         else:
             # default platform remote cert dir

--- a/volttron/platform/instance_setup.py
+++ b/volttron/platform/instance_setup.py
@@ -155,7 +155,7 @@ def _is_bound_already(address):
     return already_bound
 
 
-def fail_if_instance_running(args):
+def fail_if_instance_running():
 
     home = get_home()
 
@@ -1093,7 +1093,7 @@ def main():
     group.add_argument('--agent', nargs='+',
                         help='configure listed agents')
 
-    group.add_argument('--secure-agent-users', action='store_true', dest='secure_agent_users',
+    group.add_argument('--agent-isolation-mode', action='store_true', dest='agent_isolation_mode',
                        help='Require that agents run with their own users (this requires running '
                             'scripts/secure_user_permissions.sh as sudo)')
 
@@ -1111,7 +1111,7 @@ def main():
         set_home(args.vhome)
         prompt_vhome = False
     # if not args.rabbitmq or args.rabbitmq[0] in ["single"]:
-    fail_if_instance_running(args)
+    fail_if_instance_running()
     fail_if_not_in_src_root()
     if use_active in n:
         atexit.register(_cleanup_on_exit)
@@ -1121,8 +1121,8 @@ def main():
     if args.list_agents:
         print("Agents available to configure:{}".format(agent_list))
 
-    elif args.secure_agent_users:
-        config_opts['secure-agent-users'] = args.secure_agent_users
+    elif args.agent_isolation_mode:
+        config_opts['agent-isolation-mode'] = args.agent_isolation_mode
         _update_config_file()
     elif args.is_rabbitmq:
         process_rmq_inputs(vars(args))

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -673,11 +673,11 @@ def start_volttron_process(opts):
             _log.error('{}: {}'.format(*error))
             sys.exit(1)
 
-    if opts.secure_agent_users == "True":
-        _log.info("VOLTTRON starting in secure mode")
+    if opts.agent_isolation_mode == "True":
+        _log.info("VOLTTRON starting in agent isolation mode")
         os.umask(0o007)
     else:
-        opts.secure_agent_users = 'False'
+        opts.agent_isolation_mode = 'False'
 
     opts.publish_address = config.expandall(opts.publish_address)
     opts.subscribe_address = config.expandall(opts.subscribe_address)
@@ -702,7 +702,7 @@ def start_volttron_process(opts):
     # and opts.web_ssl_cert
 
     os.environ['MESSAGEBUS'] = opts.message_bus
-    os.environ['SECURE_AGENT_USERS'] = opts.secure_agent_users
+    os.environ['AGENT_ISOLATION_MODE'] = opts.agent_isolation_mode
     os.environ['AUTH_ENABLED'] = opts.allow_auth
     opts.allow_auth = False if opts.allow_auth == 'False' else True
     if opts.instance_name is None:
@@ -779,10 +779,10 @@ def start_volttron_process(opts):
     opts.aip = aip.AIPplatform(opts)
     opts.aip.setup()
 
-    # Check for secure mode/permissions on VOLTTRON_HOME directory
+    # Check for agent isolation mode/permissions on VOLTTRON_HOME directory
     mode = os.stat(opts.volttron_home).st_mode
     if mode & (stat.S_IWGRP | stat.S_IWOTH):
-        _log.warning('insecure mode on directory: %s', opts.volttron_home)
+        _log.warning('insecure access control on directory: %s', opts.volttron_home)
     
     # Initialize public and secret keys for Non-auth.
     publickey = None
@@ -796,7 +796,7 @@ def start_volttron_process(opts):
             _log.warning('key store is invalid; connections may fail')
         st = os.stat(keystore.filename)
         if st.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
-            _log.warning('insecure mode on key file')
+            _log.warning('insecure access restriction on key file')
         publickey = decode_key(keystore.public)
         if publickey:
             # Authorize the platform key:
@@ -1314,7 +1314,7 @@ def main(argv=sys.argv):
         help='How often should the platform check for crashed agents and '
              'attempt to restart. Units=seconds. Default=600')
     agents.add_argument(
-        '--secure-agent-users', default=False,
+        '--agent-isolation-mode', default=False,
         help='Require that agents run with their own users (this requires '
              'running scripts/secure_user_permissions.sh as sudo)')
 

--- a/volttron/platform/store.py
+++ b/volttron/platform/store.py
@@ -129,8 +129,8 @@ class ConfigStoreService(Agent):
         _log.info("Initializing configuration store service.")
 
         try:
-            # explicitly provide access to others. Needed for secure mode.
-            # Agents needs access to its own store file in this dir
+            # explicitly provide access to others. Needed for agent isolation mode.
+            # Agents need access to its own store file in this dir
             os.makedirs(self.store_path)
             os.chmod(self.store_path, 0o755)
         except OSError as e:

--- a/volttron/platform/upgrade/rename_config_for_agent_isolation.py
+++ b/volttron/platform/upgrade/rename_config_for_agent_isolation.py
@@ -35,30 +35,32 @@
 # BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY
 # under Contract DE-AC05-76RL01830
 # }}}
-
+import os.path
 import sys
-from gevent import monkey as curious_george
-curious_george.patch_all(thread=False, select=False)
 
-from . import update_auth_file
-from . import move_sqlite_files
-from . import rename_config_for_agent_isolation
+from volttron.platform.instance_setup import fail_if_instance_running
+from volttron.platform import get_home
+
+
+def rename_config():
+    """Check if configuration 'secure-agent-users' configuration exists and if so rename to
+       agent-isolation-mode"""
+    config_path = os.path.join(get_home(), "config")
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            data = f.read()
+        data = data.replace('secure-agent-users', 'agent-isolation-mode')
+        with open(config_path, 'w') as f:
+            f.write(data)
 
 
 def main():
-    # Upgrade auth file to function with dynamic rpc authorizations
-    update_auth_file.main()
-    print("")
-    # Moves backup cache of historian (backup.sqlite files) into corresponding agent-data directory so that
-    # historian agents other than sqlitehistorian, can be upgraded to latest version using
-    # vctl install --force without losing cache data. vctl install --force will backup and restore
-    # contents of <agent-install-dir>/<agentname-version>/<agentname-version>.agent-data directory
-    # If using sqlite historian manually backup and restore sqlite historian's db before upgrading to historian version
-    # 4.0.0 or later
-    move_sqlite_files.main()
-    print("")
-    # In VOLTTRON 8.2 - secure-agent-user config has been renamed to agent-isolation-mode
-    rename_config_for_agent_isolation.main()
+    """Check if configuration 'secure-agent-users' configuration exists and if so rename to
+       agent-isolation-mode"""
+    fail_if_instance_running()
+    rename_config()
+    print("Checked for secure-agent-users configuration")
+
 
 def _main():
     """ Wrapper for main function"""
@@ -66,6 +68,7 @@ def _main():
         sys.exit(main())
     except KeyboardInterrupt:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     _main()

--- a/volttron/platform/vip/agent/utils.py
+++ b/volttron/platform/vip/agent/utils.py
@@ -62,11 +62,11 @@ def get_known_host_serverkey(vip_address):
 def get_server_keys():
     try:
         # attempt to read server's keys. Should be used only by multiplatform connection and tests
-        # If agents such as forwarder attempt this in secure mode this will throw access violation exception
+        # If agents such as forwarder attempt this in agent isolation mode this will throw access violation exception
         ks = KeyStore()
     except IOError as e:
         raise RuntimeError("Exception accessing server keystore. Agents must use agent's public and private key"
-                           "to build dynamic agents when running in secure mode. Exception:{}".format(e))
+                           "to build dynamic agents when running in agent isolation mode. Exception:{}".format(e))
 
     return ks.public, ks.secret
 

--- a/volttrontesting/fixtures/rmq_test_setup.py
+++ b/volttrontesting/fixtures/rmq_test_setup.py
@@ -114,7 +114,7 @@ class RabbitTestConfig:
 
 
 def create_rmq_volttron_setup(vhome=None, ssl_auth=False, env=None,
-                              instance_name=None, secure_agent_users=False) -> RabbitTestConfig:
+                              instance_name=None, agent_isolation_mode=False) -> RabbitTestConfig:
     """
         Set-up rabbitmq broker for volttron testing:
             - Install config and rabbitmq_config.yml in VOLTTRON_HOME
@@ -130,7 +130,7 @@ def create_rmq_volttron_setup(vhome=None, ssl_auth=False, env=None,
     else:
         vhome = get_home()
 
-    if secure_agent_users:
+    if agent_isolation_mode:
         os.umask(0o007)
 
     # Build default config file object, which we will then update to fit the

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -40,11 +40,11 @@ def print_log(volttron_home):
 
 def build_wrapper(vip_address: str, should_start: bool = True, messagebus: str = 'zmq',
                   remote_platform_ca: Optional[str] = None,
-                  instance_name: Optional[str] = None, secure_agent_users: bool = False, **kwargs):
+                  instance_name: Optional[str] = None, agent_isolation_mode: bool = False, **kwargs):
     wrapper = PlatformWrapper(ssl_auth=kwargs.pop('ssl_auth', False),
                               messagebus=messagebus,
                               instance_name=instance_name,
-                              secure_agent_users=secure_agent_users,
+                              agent_isolation_mode=agent_isolation_mode,
                               remote_platform_ca=remote_platform_ca,
                               auth_enabled=kwargs.pop('auth_enabled', True))
     if should_start:

--- a/volttrontesting/platform/security/test_aip_security.py
+++ b/volttrontesting/platform/security/test_aip_security.py
@@ -49,7 +49,7 @@ def secure_volttron_instance(request):
                             instance_name=request.param['instance_name'],
                             messagebus=request.param['messagebus'],
                             ssl_auth=request.param['ssl_auth'],
-                            secure_agent_users=True)
+                            agent_isolation_mode=True)
 
     gevent.sleep(3)
 
@@ -148,9 +148,9 @@ def publish(publish_agent, topic, header, message):
 @pytest.mark.secure
 def test_agent_rpc(secure_volttron_instance, security_agent, query_agent):
     """
-    Test agent running in secure mode can make RPC calls without any errors
+    Test agent running in agent isolation mode can make RPC calls without any errors
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     """if multiple copies of an agent can be installed successfully"""
@@ -185,9 +185,9 @@ def test_agent_rpc(secure_volttron_instance, security_agent, query_agent):
 def test_agent_pubsub(secure_volttron_instance, security_agent,
                       query_agent):
     """
-    Test agent running in secure mode can publish and subscribe to message bus without any errors
+    Test agent running in agent isolation mode can publish and subscribe to message bus without any errors
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     query_agent.vip.rpc.call("security_agent", "can_publish_to_pubsub")
@@ -215,7 +215,7 @@ def test_install_dir_permissions(secure_volttron_instance, security_agent, query
     Test to make sure agent user only has read and execute permissions for all sub folders of agent install directory
     except <agent>.agent-data directory. Agent user should have rwx to agent-data directory
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     assert secure_volttron_instance.is_agent_running(security_agent)
@@ -231,7 +231,7 @@ def test_install_dir_file_permissions(secure_volttron_instance, security_agent, 
     <agent>.agent-data directory. Agent user will be the owner of files in agent-data directory and hence we
     need not check files in this dir
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     results = query_agent.vip.rpc.call("security_agent", "verify_install_dir_file_permissions").get(timeout=5)
@@ -248,7 +248,7 @@ def test_vhome_dir_permissions(secure_volttron_instance, security_agent, query_a
         - vhome
         - vhome/certificates and its subfolders
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     assert secure_volttron_instance.is_agent_running(security_agent)
@@ -270,7 +270,7 @@ def test_vhome_file_permissions(secure_volttron_instance, security_agent, query_
         - vhome/certificates/private/<agent_vip_id>.<instance_name>.pem
 
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     assert secure_volttron_instance.is_agent_running(security_agent)
@@ -313,7 +313,7 @@ def test_config_store_access(secure_volttron_instance, security_agent, query_age
         - vhome/certificates/certs/<agent_vip_id>.<instance_name>.crt
         - vhome/certificates/private/<agent_vip_id>.<instance_name>.pem
     :param secure_volttron_instance: secure volttron instance
-    :param security_agent: Test agent which runs secure mode as a user other than platform user
+    :param security_agent: Test agent which runs agent isolation mode as a user other than platform user
     :param query_agent: Fake agent to do rpc calls to test agent
     """
     assert secure_volttron_instance.is_agent_running(security_agent)

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -188,7 +188,7 @@ def create_volttron_home() -> str:
     :return: str: the temp directory
     """
     volttron_home = tempfile.mkdtemp()
-    # This is needed to run tests with volttron's secure mode. Without this
+    # This is needed to run tests with volttron's agent isolation mode. Without this
     # default permissions for folders under /tmp directory doesn't not have read or execute for group or others
     os.chmod(volttron_home, 0o755)
     # Move volttron_home to be one level below the mkdir so that
@@ -224,7 +224,7 @@ def with_os_environ(update_env: dict):
 
 class PlatformWrapper:
     def __init__(self, messagebus=None, ssl_auth=False, instance_name=None,
-                 secure_agent_users=False, remote_platform_ca=None, auth_enabled=True):
+                 agent_isolation_mode=False, remote_platform_ca=None, auth_enabled=True):
         """ Initializes a new VOLTTRON instance
 
         Creates a temporary VOLTTRON_HOME directory with a packaged directory
@@ -317,7 +317,7 @@ class PlatformWrapper:
             self.ssl_auth = ssl_auth
             self.auth_enabled = auth_enabled
 
-        self.secure_agent_users = secure_agent_users
+        self.agent_isolation_mode = agent_isolation_mode
         if self.ssl_auth:
             certsdir = os.path.join(self.volttron_home, 'certificates')
 
@@ -350,7 +350,7 @@ class PlatformWrapper:
                                                                      ssl_auth=self.ssl_auth,
                                                                      env=self.env,
                                                                      instance_name=self.instance_name,
-                                                                     secure_agent_users=secure_agent_users)
+                                                                     agent_isolation_mode=agent_isolation_mode)
             if self.ssl_auth:
                 self.certsobj = Certs(os.path.join(self.volttron_home, "certificates"))
 
@@ -676,7 +676,7 @@ class PlatformWrapper:
         #                    key_file=certs.private_key_file(f"client{x}"))
         #     ns['client_certs'].append(cert_ns)
 
-        return ns
+        # return ns
 
     def startup_platform(self, vip_address, auth_dict=None,
                          mode=UNRESTRICTED, bind_web_address=None,
@@ -830,7 +830,7 @@ class PlatformWrapper:
                          'bind_web_address': bind_web_address,
                          'volttron_central_address': volttron_central_address,
                          'volttron_central_serverkey': volttron_central_serverkey,
-                         'secure_agent_users': self.secure_agent_users,
+                         'agent_isolation_mode': self.agent_isolation_mode,
                          'platform_name': None,
                          'log': self.log_path,
                          'log_config': None,
@@ -874,9 +874,9 @@ class PlatformWrapper:
             if self.messagebus:
                 parser.set('volttron', 'message-bus',
                            self.messagebus)
-            if self.secure_agent_users:
-                parser.set('volttron', 'secure-agent-users',
-                           str(self.secure_agent_users))
+            if self.agent_isolation_mode:
+                parser.set('volttron', 'agent-isolation-mode',
+                           str(self.agent_isolation_mode))
             if self.auth_enabled is not None:
                 parser.set('volttron', 'allow-auth',
                            str(self.auth_enabled))


### PR DESCRIPTION
Fixes issue #3035 

Fixes:
Updated config parameter name to agent-isolation-mode
Updated all code variables from secure_agent_users to agent_isolation_mode
Updated all documents to use agent isolation mode instead of secure mode. 
Updated volttron-upgrade command to look for "secure-agent-users" parameter in volttron config and replace it with "agent-isolation-mode" if param exists
Tested by run pytests, setup script and upgrade script. Build rst docs locally to verify links to renamed documents