### PR TITLE
Dnp3 driver pr

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/__init__.py
@@ -1,0 +1,1 @@
+from .udd_dnp3 import *

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/dnp3-driver.md
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/dnp3-driver.md
@@ -1,0 +1,75 @@
+
+# DNP3 Driver
+
+
+VOLTTRON's DNP3 driver enables the use of [DNP3 Distributed Network Protocol](https://en.wikipedia.org/wiki/DNP3)
+communications, reading and writing points via a DNP3 Outstation.
+
+In order to use a DNP3 driver to read and write point data, a server component (i.e., Outstation) must also
+be configured and running. 
+
+
+### Requirements
+
+The DNP3 driver requires the [dnp3-python](https://github.com/VOLTTRON/dnp3-python) package, a wrapper on Pydnp3 package.
+This package can be installed in an activated environment with:
+
+
+    pip install dnp3-python
+
+
+### Driver Configuration
+
+There are arguments for the "driver_config" section of the DNP3 driver configuration file.
+
+Here is a sample DNP3 driver configuration file:
+
+```json
+{
+    "driver_config": {"master_ip": "0.0.0.0", "outstation_ip": "127.0.0.1",
+        "master_id": 2, "outstation_id": 1,
+        "port":  20000},
+    "registry_config":"config://udd-Dnp3.csv",
+        "driver_type": "udd_dnp3",
+    "interval": 5,
+    "timezone": "UTC",
+    "campus": "campus-vm",
+    "building": "building-vm",
+    "unit": "Dnp3",
+        "publish_depth_first_all": true,
+    "heart_beat_point": "random_bool"
+}
+```
+A sample data dictionary is available in ``services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.config``.
+
+### DNP3 Registry Configuration File
+
+The driver's registry configuration file, a [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) file,
+specifies which DNP3 points the driver will read and/or write. Each row configures a single DNP3 point.
+
+The following columns are required for each row:
+- **Volttron Point Name** - The name used by the VOLTTRON platform and agents to refer to the point.
+- **Group** - The point's DNP3 group number.
+- **Variation** - THe permit negotiated exchange of data formatted, i.e., data type.
+- **Index** - The point's index number within its DNP3 data type (which is derived from its DNP3 group number).
+- **Scaling** - A factor by which to multiply point values.
+- **Units** - Point value units.
+- **Writable** - TRUE or FALSE, indicating whether the point can be written by the driver (FALSE = read-only).
+
+Consult the **DNP3 data dictionary** for a point's Group and Index values. Point
+definitions in the data dictionary are by agreement between the DNP3 Outstation and Master.
+The VOLTTRON DNP3Agent loads the data dictionary of point definitions from the JSON file
+at "point_definitions_path" in the DNP3Agent's config file.
+
+A sample data dictionary is available in ``services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.csv``.
+
+
+Point definitions in the DNP3 driver's registry should look something like this:
+
+| Point Name         | Volttron Point     | Group | Variation | Index | Scaling | Units |Writable| Notes|
+|:-------------------|:-------------------|:------|:----------|:------|:--------|:------| :---  |:-----|
+| AnalogInput_index0 | AnalogInput_index0 | 30    | 6         | 0     | 1       | NA    | FALSE |Double Analogue input without status|
+| AnalogInput_index1 | AnalogInput_index1 | 30    | 6         | 1     | 1       | NA    | FALSE |Double Analogue input without status|
+| BinaryInput_index0 | BinaryInput_index0 | 1     | 2         | 0     | 1       | NA    | FALSE |Double Analogue input without status|
+| BinaryInput_index1 | BinaryInput_index1 | 1     | 2         | 1     | 1       | NA    | FALSE |Double Analogue input without status|
+

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/driver_wrapper.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/driver_wrapper.py
@@ -1,0 +1,840 @@
+# -*- coding: utf-8 -*- {{{
+# vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
+#
+# Copyright 2020, Battelle Memorial Institute.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This material was prepared as an account of work sponsored by an agency of
+# the United States Government. Neither the United States Government nor the
+# United States Department of Energy, nor Battelle, nor any of their
+# employees, nor any jurisdiction or organization that has cooperated in the
+# development of these materials, makes any warranty, express or
+# implied, or assumes any legal liability or responsibility for the accuracy,
+# completeness, or usefulness or any information, apparatus, product,
+# software, or process disclosed, or represents that its use would not infringe
+# privately owned rights. Reference herein to any specific commercial product,
+# process, or service by trade name, trademark, manufacturer, or otherwise
+# does not necessarily constitute or imply its endorsement, recommendation, or
+# favoring by the United States Government or any agency thereof, or
+# Battelle Memorial Institute. The views and opinions of authors expressed
+# herein do not necessarily state or reflect those of the
+# United States Government or any agency thereof.
+#
+# PACIFIC NORTHWEST NATIONAL LABORATORY operated by
+# BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY
+# under Contract DE-AC05-76RL01830
+# }}}
+import abc
+import random
+import datetime
+import math
+from math import pi
+
+from platform_driver.interfaces import BaseInterface, BaseRegister, BasicRevert
+# from ...platform_driver.interfaces import BaseInterface, BaseRegister, BasicRevert
+from csv import DictReader
+from io import StringIO
+import logging
+import sys
+
+import requests
+
+from typing import List, Type, Dict, Union, Optional, TypeVar
+from time import sleep
+
+stdout_stream = logging.StreamHandler(sys.stdout)
+stdout_stream.setFormatter(logging.Formatter('%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s'))
+
+_log = logging.getLogger(__name__)
+# _log = logging.getLogger("data_retrieval_demo")
+_log.addHandler(stdout_stream)
+_log.setLevel(logging.DEBUG)
+_log.setLevel(logging.WARNING)
+
+# TODO: parse to python_type based on literal. i.e., locate("int")("1") -> int(1)
+# Design the data type validation logic (recommend but not enforce?)
+type_mapping = {"string": str,
+                "int": int,
+                "integer": int,
+                "float": float,
+                "bool": bool,
+                "boolean": bool}
+
+# Type alias
+RegisterValue = Union[int, str, float, bool]
+Register = TypeVar("Register", bound=BaseRegister)
+
+
+class WrapperRegister(BaseRegister):
+    """
+    Template Register, host boilerplate code
+    """
+
+    # TODO: do we need to separate read-only and writable register? How a writable register looks like?
+    # TODO: e.g., How the set-value pass to the register class?
+    # TODO: (Mimic what happen to get_register_value method, we might need a controller method.
+    def __init__(self, driver_config: dict, point_name: str, data_type: RegisterValue, units: str, read_only: bool,
+                 default_value=None, description='', csv_config={}, *args, **kwargs):
+        """
+        Parameters  # TODO: clean this up,
+        ----------
+        config_dict: associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+
+        read_only: associated with `Writable` in driver-config.csv
+        point_name: associated with `Volttron Point Name` in driver-config.csv
+        units: associated with `Units` in driver-config.csv
+        reg_type: ?? # TODO: clean this up,
+        default_value: ?? # TODO: clean this up,
+        description: ?? # TODO: clean this up,
+
+        Associated with Point Name,Volttron Point Name,Units,Units Details,Writable,Starting Value,Type,Notes
+            read_only = regDef['Writable'].lower() != 'true'
+            point_name = regDef['Volttron Point Name']
+            description = regDef.get('Notes', '')
+            units = regDef['Units']
+            default_value = regDef.get("Starting Value", 'sin').strip()
+        """
+        super().__init__("byte", read_only, point_name, units, description='')
+        self._value: str = ""
+        self.driver_config: dict = driver_config
+
+        self.point_name: str = point_name
+        self.data_type_str: str = data_type  # "byte" or "bit"
+        self.units: Optional[str] = units
+        self.read_only: bool = read_only
+        self.default_value: Optional[RegisterValue] = default_value
+        self.description: str = description
+        self.csv_config: list = csv_config
+
+    @property
+    def value(self):
+        self._value = self.get_register_value()  # pre-requite methods
+        return self._value
+
+    @value.setter
+    def value(self, x: RegisterValue):
+        if self.read_only:
+            raise RuntimeError(  # TODO: Is RuntimeError necessary
+                "Trying to write to a point configured read only: " + self.point_name)  # TODO: clean up
+        self._value = x
+
+    @abc.abstractmethod
+    def get_register_value(self, **kwargs) -> RegisterValue:
+        """
+        Override this to get register value
+        Examples 1 retrieve:
+            def get_register_value():
+                some_url: str = self.config_dict.get("url")
+                return self.get_restAPI_value(url=some_url)
+            def get_restAPI_value(url=some_url)
+                ...
+        Returns
+        -------
+
+        """
+
+    @abc.abstractmethod
+    def set_register_value(self, value, **kwargs) -> Optional[RegisterValue]:  # TODO: need an example/redesign for this
+        pass
+    #     """
+    #     Override this to set register value. (Only for writable==True/read_only==False)
+    #     Examples:
+    #         def set_register_value():
+    #             some_temperature: int = get_comfortable_temperature(...)
+    #             self.value(some_temperature)
+    #         def get_comfortable_temperature(**kwargs) -> int:
+    #             ...
+    #     Returns
+    #     -------
+    #
+    #     """
+
+
+# alias
+ImplementedRegister = Union[WrapperRegister, Type[WrapperRegister]]
+
+
+class DriverConfig:
+    """
+    For validate driver configuration, e.g., driver-config.csv
+    """
+
+    def __init__(self, csv_config: List[dict]):
+        self.csv_config: List[dict] = csv_config
+        """
+
+        Parameters
+        ----------
+        csv_config
+
+        Returns
+        -------
+        Examples:
+            [{'Point Name': 'Heartbeat', 'Volttron Point Name': 'Heartbeat', 'Units': 'On/Off',
+            'Units Details': 'On/Off', 'Writable': 'TRUE', 'Starting Value': '0', 'Type': 'boolean',
+            'Notes': 'Point for heartbeat toggle'},
+            {'Point Name': 'Catfact', 'Volttron Point Name': 'Catfact', 'Units': 'No cat fact',
+            'Units Details': 'No cat fact', 'Writable': 'TRUE', 'Starting Value': 'No cat fact', 'Type': 'str',
+            'Notes': 'Cat fact extract from REST API'}]
+        """
+
+    @staticmethod
+    def _validate_header(point_config: dict):
+        """
+        Require the header include the following keys
+        "PointName", "DataType", "Units", "ReadOnly", "DefaultValue", "Description"
+        (or allow parsing with minimal effort)
+        "PointName" <- "Point Name", "point name", "point-name", but not "point names" or "the point name"
+        Parameters
+        ----------
+        point_config
+
+        Returns
+        -------
+
+        """
+
+        def _to_alpha_lower(key: str):
+            return ''.join([x.lower() for x in key if x.isalpha()])
+
+        new_dict = {_to_alpha_lower(k): v for k, v in point_config.items()}
+        new_keys = new_dict.keys()
+
+        standardized_valid_names = ["Volttron Point Name", "Data Type", "Units", "Writable", "Default Value", "Notes"]
+        for valid_name in standardized_valid_names:
+            if valid_name.lower() not in new_keys:
+                raise ValueError(f"`{valid_name}` is not in the config")
+        return new_dict
+
+    def key_validate(self) -> List[dict]:
+        """
+
+        Returns
+            EXAMPLE:
+            {'pointname': 'Heartbeat',
+            'datatype': 'boolean',
+            'units': 'On/Off',
+            'readonly': 'TRUE',
+            'defaultvalue': '0',
+            'description': 'Point for heartbeat toggle',
+            'volttronpointname': 'Heartbeat',
+            'unitsdetails': 'On/Off'}
+        -------
+
+        """
+        key_validate_csv = [self._validate_header(point_config) for point_config in self.csv_config]
+        return key_validate_csv
+
+
+class WrapperInterface(BasicRevert, BaseInterface):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.point_map: Dict[str, ImplementedRegister] = {}  # {register.point_name: register}
+        self.register_types: List[
+            ImplementedRegister] = []  # TODO: add sanity check for restister_types, e.g., count == register counts
+
+        self.csv_config = None  # TODO: try to get this value, potentially from def configure. get inspiration from modbus_tk testing
+        self.driver_config_in_json_config = None  # TODO: try to get this value, potentially from def configure
+
+        # TODO: clean up this public interface
+        # from *.csv configure file "driver_config": {...}
+        # self.driver_config: dict = {}
+
+    def configure(self, driver_config_in_json_config: dict, csv_config: List[
+        dict]):  # TODO: ask driver.py, BaseInterface.configure to update signature when evoking
+        """
+        Used by driver.py
+            def get_interface(self, driver_type, config_dict, config_string):
+                interface.configure(config_dict, config_string)
+
+        Parameters  # TODO: follow BaseInterface.configure signatures. But the names are wrong.
+        ----------
+        driver_config_in_json_config: associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+        csv_config: associated with the whole driver-config.csv file
+            Examples:
+            [{'Point Name': 'Heartbeat', 'Volttron Point Name': 'Heartbeat', 'Units': 'On/Off',
+            'Units Details': 'On/Off', 'Writable': 'TRUE', 'Starting Value': '0', 'Type': 'boolean',
+            'Notes': 'Point for heartbeat toggle'},
+            {'Point Name': 'Catfact', 'Volttron Point Name': 'Catfact', 'Units': 'No cat fact',
+            'Units Details': 'No cat fact', 'Writable': 'TRUE', 'Starting Value': 'No cat fact', 'Type': 'str',
+            'Notes': 'Cat fact extract from REST API'}]
+
+        """
+        # print("========================================== csv_config, ", csv_config)
+        # print("========================================== driver_config_in_json_config, ", driver_config_in_json_config)
+        self.csv_config = csv_config
+        self.driver_config_in_json_config = driver_config_in_json_config
+
+        # TODO configuration validation, i.e., self.config_check(...)
+        # self.config_check
+        self.parse_config(csv_config, driver_config_in_json_config)
+
+    @staticmethod
+    @abc.abstractmethod
+    def pass_register_types(csv_config: dict, driver_config_in_json_config: List[dict],
+                            register_type_list: List[ImplementedRegister] = None) -> List[ImplementedRegister]:
+        """
+        For ingesting the register types list
+        Will be used by concrete Interface class inherit this template
+
+        Parameters
+        ----------
+        driver_config_in_json_config: associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+        csv_config: associated with the whole driver-config.csv file
+            Examples:
+            [{'Point Name': 'Heartbeat', 'Volttron Point Name': 'Heartbeat', 'Units': 'On/Off',
+            'Units Details': 'On/Off', 'Writable': 'TRUE', 'Starting Value': '0', 'Type': 'boolean',
+            'Notes': 'Point for heartbeat toggle'},
+            {'Point Name': 'Catfact', 'Volttron Point Name': 'Catfact', 'Units': 'No cat fact',
+            'Units Details': 'No cat fact', 'Writable': 'TRUE', 'Starting Value': 'No cat fact', 'Type': 'str',
+            'Notes': 'Cat fact extract from REST API'}]
+        register_type_list:
+            Example:
+            [RestAPIRegister, RestAPIRegister, RestAPIRegister, RandomBoolRegister]
+        """
+        pass
+        return register_type_list
+
+    def parse_config(self, csv_config, driver_config_in_json_config):  # TODO: this configDict is from *.csv not .config
+        # print("========================================== csv_config, ", csv_config)
+        # print("========================================== driver_config_in_json_config, ", driver_config_in_json_config)
+
+        # driver_config: DriverConfig = DriverConfig(csv_config)
+        # valid_csv_config = DriverConfig(csv_config).key_validate()
+        # print("========================================== valid_csv_config, ", valid_csv_config)
+
+        if csv_config is None:  # TODO: leave it now. Later for central data check
+            return
+
+        register_types: List[ImplementedRegister] = self.pass_register_types(csv_config, driver_config_in_json_config)
+        valid_csv_config = csv_config  # TODO: Design the config check (No config check for now.)
+        for reg_def, register_type_iter in zip(valid_csv_config, register_types):
+            # Skip lines that have no address yet. # TODO: understand why
+            if not reg_def['Point Name']:
+                continue
+
+            point_name = reg_def['Volttron Point Name']
+            type_name = reg_def.get("Data Type", 'string')
+            reg_type = type_mapping.get(type_name, str)
+            units = reg_def['Units']
+            read_only = reg_def['Writable'].lower() != 'true'  # TODO: watch out for this is opposite logic
+
+            description = reg_def.get('Notes', '')
+
+            # default_value = reg_def.get("defaultvalue", 'sin').strip()
+            default_value = reg_def.get(
+                "Default Value")  # TODO: redesign default value logic, e.g., beable to map to real python type
+            if not default_value:
+                default_value = None
+
+            # register_type = FakeRegister if not point_name.startswith('Cat') else CatfactRegister  # TODO: change this
+            register_type = register_type_iter  # TODO: Inconventional, document this.
+
+            # print("========================================== point_name, ", point_name)
+            # print("========================================== reg_type, ", reg_type)
+            # print("========================================== units, ", units)
+            # print("========================================== read_only, ", read_only)
+            # print("========================================== default_value, ", default_value)
+            # print("========================================== description, ", description)
+            # print("========================================== reg_def, ", reg_def)
+            # Note: the following is to init a register_type object, e.g., WrapperRegister
+            try:
+                # register: WrapperRegister = register_type(driver_config=driver_config_in_json_config,
+                #                                           point_name=point_name,
+                #                                           data_type=reg_type,  # TODO: make it more clear in documentation
+                #                                           units=units,
+                #                                           read_only=read_only,
+                #                                           default_value=default_value,
+                #                                           description=description,
+                #                                           csv_config=csv_config,
+                #                                           reg_def=reg_def)
+
+                register: WrapperRegister = self.create_register(driver_config=driver_config_in_json_config,
+                                                                 point_name=point_name,
+                                                                 data_type=reg_type,
+                                                                 # TODO: make it more clear in documentation
+                                                                 units=units,
+                                                                 read_only=read_only,
+                                                                 default_value=default_value,
+                                                                 description=description,
+                                                                 csv_config=csv_config,
+                                                                 reg_def=reg_def,
+                                                                 register_type=register_type)
+                if default_value is not None:
+                    self.set_default(point_name, register.value)
+
+                self.insert_register(register)
+            except Exception as e:
+                print(e)
+
+
+
+    def create_register(self, driver_config,
+                        point_name,
+                        data_type,
+                        units,
+                        read_only,
+                        default_value,
+                        description,
+                        csv_config,
+                        reg_def,
+                        register_type, *args, **kwargs) -> ImplementedRegister:
+        pass
+        """
+        Factory method to init (WrapperRegister) register object
+        
+        :param register_type: the class name of the to-be-created register, e.g., WrapperRegister
+        :param driver_config_in_json_config: json config file, 
+        :param csv_config: csv config file, Dict[str, str]
+        
+        """
+        register: WrapperRegister = register_type(driver_config=driver_config,
+                                                  point_name=point_name,
+                                                  data_type=data_type,  # TODO: make it more clear in documentation
+                                                  units=units,
+                                                  read_only=read_only,
+                                                  default_value=default_value,
+                                                  description=description,
+                                                  csv_config=csv_config,
+                                                  reg_def=reg_def)
+        return register
+
+    def insert_register(self, register: WrapperRegister):
+        """
+        Inserts a register into the :py:class:`Interface`.
+
+        :param register: Register to add to the interface.
+        :type register: :py:class:`BaseRegister`
+        """
+        register_point: str = register.point_name
+        self.point_map[register_point] = register
+
+        register_type = register.get_register_type()
+        self.registers[register_type].append(register)
+
+    def get_point(self, point_name, **kwargs) -> RegisterValue:
+        """
+        Override BasicInvert method
+        Note: this method should be evoked by vip agent
+        EXAMPLE:
+            rs = a.vip.rpc.call("platform.driver", "get_point",
+              "campus-vm/building-vm/Dnp3",
+               "AnalogInput_index0").get()
+        """
+        register: WrapperRegister = self.get_register_by_name(point_name)
+        val = self.get_reg_point(register)
+        return val
+
+    # def _set_point(self, point_name: str,
+    #                value_to_set: RegisterValue):  # TODO: this method has some problem. Understand the logic: overall + example
+
+    def set_point(self, point_name, value):
+        """
+        Override/Restate BasicInvert method for convenience
+        Note: this method should be evoked by vip agent
+        EXAMPLE:
+            rs = a.vip.rpc.call("platform.driver", "set_point",
+              "campus-vm/building-vm/Dnp3",
+               "AnalogInput_index0", 0.543).get()
+        """
+        # result = self._set_point(point_name, value)
+        # self._tracker.mark_dirty_point(point_name)
+        return super().set_point(point_name, value)
+
+    def _set_point(self, point_name, value, **kwargs):
+        """
+        Parameters
+        ----------
+        point_name
+        value
+
+        Returns
+        -------
+
+        """
+        # value_to_set = value
+        register: ImplementedRegister = self.get_register_by_name(point_name)
+
+        # response = self.set_reg_point_w_verification(value_to_set=value, register=register)
+        response = self.set_reg_point_async_w_verification(value_to_set=value, register=register)
+        return response
+
+    @staticmethod
+    def get_reg_point(register: ImplementedRegister):
+        """
+        Core logic for get_point
+        """
+        return register.value
+
+    @staticmethod
+    def set_reg_point(register: ImplementedRegister, value_to_set: RegisterValue):
+        """
+        Core logic for set_point, i.e., _set_point without verification
+        Note: Can be used for vip-agent-mock testing
+        """
+        set_pt_response = register.set_register_value(value=value_to_set)
+        return set_pt_response
+
+    @classmethod
+    def set_reg_point_w_verification(cls, value_to_set: RegisterValue, register: ImplementedRegister,
+                                     relax_verification=True):
+        """
+        Core logic for set_point, i.e., _set_point with verification
+        Note: Can be used for vip-agent-mock testing
+        """
+        # Note: leave register method to verify, e.g., check writability.
+
+        # set point workflow
+        set_pt_response = cls.set_reg_point(register=register, value_to_set=value_to_set)
+
+        # verify with get_point
+        get_pt_response = cls.get_reg_point(register)
+
+        success_flag_strict = (get_pt_response == value_to_set)
+        success_flag_relax = (str(get_pt_response) == str(value_to_set))
+        if relax_verification:
+            success_flag = success_flag_relax
+        else:
+            success_flag = success_flag_strict
+
+        response = {"success_flag": success_flag,
+                    "value_to_set": value_to_set,
+                    "set_pt_response": set_pt_response,
+                    "get_pt_response": get_pt_response}
+        if not success_flag:
+            _log.warning(f"Set value failed, {response}")
+        return response
+
+    @classmethod
+    def set_reg_point_async_w_verification(cls, value_to_set: RegisterValue, register: ImplementedRegister,
+                                           relax_verification=True):
+        """
+        Counterpart of set_reg_point_w_verification for asynchronous workflow with delay and retry.
+        """
+
+        # set point workflow
+        set_pt_response = cls.set_reg_point(register=register, value_to_set=value_to_set)
+
+        # verify with get_point
+        get_pt_response = cls.get_reg_point(register)
+
+        def check_success_flag():
+            _success_flag_strict = (get_pt_response == value_to_set)
+            _success_flag_relax = (str(get_pt_response) == str(value_to_set))
+            if relax_verification:
+                _success_flag = _success_flag_relax
+            else:
+                _success_flag = _success_flag_strict
+            return _success_flag
+
+        # note: only delay and retry the read/get logic NOT the send/set logic
+        # note: hard-coded delay time and number of retry. Use small delay, large retry number strategy.
+        # For local instances, 2 sec should be sufficient.
+        retry_delay = 0.2
+        retry_max = 20
+        retry_count = 0
+        success_flag = check_success_flag()
+        while not success_flag and retry_count < retry_max:
+            sleep(retry_delay)
+            retry_count += 1
+
+            get_pt_response = cls.get_reg_point(register)
+
+            success_flag = check_success_flag()
+
+        response = {"success_flag": success_flag,
+                    "value_to_set": value_to_set,
+                    "set_pt_response": set_pt_response,
+                    "get_pt_response": get_pt_response}
+        if not success_flag:
+            _log.warning(f"Set value failed, {response}")
+        return response
+
+    def _scrape_all(self) -> Dict[str, any]:
+        result: Dict[str, RegisterValue] = {}  # Dict[register.point_name, register.value]
+        read_registers = self.get_registers_by_type(reg_type="byte",
+                                                    read_only=True)  # TODO: Parameterize the "byte" hard-code here
+        write_registers = self.get_registers_by_type(reg_type="byte", read_only=False)
+        all_registers: List[ImplementedRegister] = read_registers + write_registers
+        for register in all_registers:
+            result[register.point_name] = register.value
+        return result
+
+    def get_register_by_name(self, name: str) -> WrapperRegister:
+        """
+        Get a register by it's point name.
+
+        :param name: Point name of register.
+        :type name: str
+        :return: An instance of BaseRegister
+        :rtype: :py:class:`BaseRegister`
+        """
+        try:
+            return self.point_map[name]
+        except KeyError:
+            raise DriverInterfaceError("Point not configured on device: " + name)
+
+
+class WrapperInterfaceNew:
+    """
+    Use composition instead of inheritance
+    """
+
+    def __init__(self, *args, **kwargs):
+        # self.basic_revert = BasicRevert(**kwargs)
+        # self.basic_interface = BaseInterface(**kwargs)
+        self.basic_revert = BasicRevert()
+        self.basic_interface = BaseInterface()
+        self._tracker = self.basic_revert._tracker
+
+        self.point_map: Dict[str, ImplementedRegister] = {}  # {register.point_name: register}
+        self.register_types: List[
+            ImplementedRegister] = []  # TODO: add sanity check for restister_types, e.g., count == register counts
+
+        self.csv_config = None  # TODO: try to get this value, potentially from def configure. get inspiration from modbus_tk testing
+        self.driver_config_in_json_config = None  # TODO: try to get this value, potentially from def configure
+
+    def configure(self, driver_config_in_json_config: dict, csv_config: List[
+        dict]):  # TODO: ask driver.py, BaseInterface.configure to update signature when evoking
+        """
+        Used by driver.py
+            def get_interface(self, driver_type, config_dict, config_string):
+                interface.configure(config_dict, config_string)
+
+        Parameters  # TODO: follow BaseInterface.configure signatures. But the names are wrong.
+        ----------
+        driver_config_in_json_config: associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+        csv_config: associated with the whole driver-config.csv file
+            Examples:
+            [{'Point Name': 'Heartbeat', 'Volttron Point Name': 'Heartbeat', 'Units': 'On/Off',
+            'Units Details': 'On/Off', 'Writable': 'TRUE', 'Starting Value': '0', 'Type': 'boolean',
+            'Notes': 'Point for heartbeat toggle'},
+            {'Point Name': 'Catfact', 'Volttron Point Name': 'Catfact', 'Units': 'No cat fact',
+            'Units Details': 'No cat fact', 'Writable': 'TRUE', 'Starting Value': 'No cat fact', 'Type': 'str',
+            'Notes': 'Cat fact extract from REST API'}]
+
+        """
+        # print("========================================== csv_config, ", csv_config)
+        # print("========================================== driver_config_in_json_config, ", driver_config_in_json_config)
+        self.csv_config = csv_config
+        self.driver_config_in_json_config = driver_config_in_json_config
+
+        # TODO configuration validation, i.e., self.config_check(...)
+        # self.config_check
+        self.parse_config(csv_config, driver_config_in_json_config)
+
+    def parse_config(self, csv_config, driver_config_in_json_config,
+                     register_type_list):  # TODO: this configDict is from *.csv not .config
+        # print("========================================== csv_config, ", csv_config)
+        # print("========================================== driver_config_in_json_config, ", driver_config_in_json_config)
+
+        # driver_config: DriverConfig = DriverConfig(csv_config)
+        # valid_csv_config = DriverConfig(csv_config).key_validate()
+        # print("========================================== valid_csv_config, ", valid_csv_config)
+
+        if csv_config is None:  # TODO: leave it now. Later for central data check
+            return
+
+        # register_types: List[ImplementedRegister] = register_type_list
+        register_types: List[ImplementedRegister] = self.pass_register_types(csv_config, driver_config_in_json_config)
+        valid_csv_config = csv_config  # TODO: Design the config check (No config check for now.)
+        for reg_def, register_type_iter in zip(valid_csv_config, register_types):
+            # Skip lines that have no address yet. # TODO: understand why
+            if not reg_def['Point Name']:
+                continue
+
+            point_name = reg_def['Volttron Point Name']
+            type_name = reg_def.get("Data Type", 'string')
+            reg_type = type_mapping.get(type_name, str)
+            units = reg_def['Units']
+            read_only = reg_def['Writable'].lower() != 'true'  # TODO: watch out for this is opposite logic
+
+            description = reg_def.get('Notes', '')
+
+            # default_value = reg_def.get("defaultvalue", 'sin').strip()
+            default_value = reg_def.get(
+                "Default Value")  # TODO: redesign default value logic, e.g., beable to map to real python type
+            if not default_value:
+                default_value = None
+
+            # register_type = FakeRegister if not point_name.startswith('Cat') else CatfactRegister  # TODO: change this
+            register_type = register_type_iter  # TODO: Inconventional, document this.
+
+            # print("========================================== point_name, ", point_name)
+            # print("========================================== reg_type, ", reg_type)
+            # print("========================================== units, ", units)
+            # print("========================================== read_only, ", read_only)
+            # print("========================================== default_value, ", default_value)
+            # print("========================================== description, ", description)
+            # print("========================================== reg_def, ", reg_def)
+            # Note: the following is to init a register_type object, e.g., WrapperRegister
+            try:
+                register: WrapperRegister = self.create_register(driver_config=driver_config_in_json_config,
+                                                                 point_name=point_name,
+                                                                 data_type=reg_type,
+                                                                 # TODO: make it more clear in documentation
+                                                                 units=units,
+                                                                 read_only=read_only,
+                                                                 default_value=default_value,
+                                                                 description=description,
+                                                                 csv_config=csv_config,
+                                                                 reg_def=reg_def,
+                                                                 register_type=register_type)
+
+                if default_value:
+                    self.basic_revert.set_default(point_name, register.value)
+
+                self.insert_register(register)
+
+            except Exception as e:
+                print(e)
+
+    @staticmethod
+    @abc.abstractmethod
+    def pass_register_types(csv_config: dict, driver_config_in_json_config: List[dict],
+                            register_type_list: List[ImplementedRegister] = None) -> List[ImplementedRegister]:
+        """
+        For ingesting the register types list
+        Will be used by concrete Interface class inherit this template
+
+        Parameters
+        ----------
+        driver_config_in_json_config: associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+        csv_config: associated with the whole driver-config.csv file
+            Examples:
+            [{'Point Name': 'Heartbeat', 'Volttron Point Name': 'Heartbeat', 'Units': 'On/Off',
+            'Units Details': 'On/Off', 'Writable': 'TRUE', 'Starting Value': '0', 'Type': 'boolean',
+            'Notes': 'Point for heartbeat toggle'},
+            {'Point Name': 'Catfact', 'Volttron Point Name': 'Catfact', 'Units': 'No cat fact',
+            'Units Details': 'No cat fact', 'Writable': 'TRUE', 'Starting Value': 'No cat fact', 'Type': 'str',
+            'Notes': 'Cat fact extract from REST API'}]
+        register_type_list:
+            Example:
+            [RestAPIRegister, RestAPIRegister, RestAPIRegister, RandomBoolRegister]
+        """
+        pass
+        return register_type_list
+
+    def create_register(self, driver_config,
+                        point_name,
+                        data_type,
+                        units,
+                        read_only,
+                        default_value,
+                        description,
+                        csv_config,
+                        reg_def,
+                        register_type, *args, **kwargs) -> ImplementedRegister:
+        pass
+        """
+        Factory method to init (WrapperRegister) register object
+
+        :param register_type: the class name of the to-be-created register, e.g., WrapperRegister
+        :param driver_config_in_json_config: json config file, 
+        :param csv_config: csv config file, Dict[str, str]
+
+        """
+        register: WrapperRegister = register_type(driver_config=driver_config,
+                                                  point_name=point_name,
+                                                  data_type=data_type,  # TODO: make it more clear in documentation
+                                                  units=units,
+                                                  read_only=read_only,
+                                                  default_value=default_value,
+                                                  description=description,
+                                                  csv_config=csv_config,
+                                                  reg_def=reg_def)
+        return register
+
+    def insert_register(self, register: WrapperRegister):
+        """
+        Inserts a register into the :py:class:`Interface`.
+
+        :param register: Register to add to the interface.
+        :type register: :py:class:`BaseRegister`
+        """
+        register_point: str = register.point_name
+        self.point_map[register_point] = register
+
+        register_type = register.get_register_type()
+        self.basic_interface.registers[register_type].append(register)
+
+    def get_point(self, point_name, **kwargs) -> RegisterValue:
+        register: WrapperRegister = self.get_register_by_name(point_name)
+        # val: RegisterValue = register.get_register_value()
+
+        # return "testing_value"
+        return register.value
+
+    def get_register_by_name(self, name: str) -> Register:
+        return self.basic_interface.get_register_by_name(name)
+
+    def set_point(self, point_name, value):
+        """
+        Implementation of :py:meth:`BaseInterface.set_point`
+
+        Passes arguments through to :py:meth:`BasicRevert._set_point`
+        """
+        # return self.basic_revert.set_point(point_name, value)
+        result = self._set_point(point_name, value)
+        self._tracker.mark_dirty_point(point_name)
+        return result
+
+    def _set_point(self, point_name, value, **kwargs):
+        """
+        Parameters
+        ----------
+        point_name
+        value
+
+        Returns
+        -------
+
+        """
+        value_to_set = value
+        register: ImplementedRegister = self.get_register_by_name(point_name)
+        # Note: leave register method to verify, e.g., check writability.
+        # register.value(value_to_set)
+        # value_response: RegisterValue = register.value
+
+        set_pt_response = register.set_register_value(value=value_to_set)
+        # verify with get_point
+        get_pt_response = self.get_point(point_name=point_name)
+
+        success_flag_strict = (get_pt_response == value_to_set)
+        success_flag_relax = (str(get_pt_response) == str(value_to_set))
+        success_flag = success_flag_relax
+
+        response = {"success_flag": success_flag,
+                    "value_to_set": value_to_set,
+                    "set_pt_response": set_pt_response,
+                    "get_pt_response": get_pt_response}
+        if not success_flag:
+            _log.warning(f"Set value failed, {response}")
+        return response
+
+    def scrape_all(self):
+        """
+        Implementation of :py:meth:`BaseInterface.scrape_all`
+        """
+        return self.basic_revert.scrape_all()
+
+
+class DriverInterfaceError(Exception):
+    pass

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.config
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.config
@@ -1,0 +1,14 @@
+{
+    "driver_config": {"master_ip": "0.0.0.0", "outstation_ip": "127.0.0.1",
+        "master_id": 2, "outstation_id": 1,
+        "port":  20000},
+    "registry_config":"config://udd-Dnp3.csv",
+		"driver_type": "udd_dnp3",
+    "interval": 5,
+    "timezone": "UTC",
+    "campus": "campus-vm",
+    "building": "building-vm",
+    "unit": "Dnp3",
+		"publish_depth_first_all": true,
+    "heart_beat_point": "random_bool"
+}

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.csv
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples/udd-Dnp3.csv
@@ -1,0 +1,17 @@
+Point Name,Volttron Point Name,Group,Variation,Index,Scaling,Units,Writable,Notes
+AnalogInput_index0,AnalogInput_index0,30,6,0,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index1,AnalogInput_index1,30,6,1,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index2,AnalogInput_index2,30,6,2,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index3,AnalogInput_index3,30,6,3,1,NA,FALSE,Double Analogue input without status
+BinaryInput_index0,BinaryInput_index0,1,2,0,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index1,BinaryInput_index1,1,2,1,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index2,BinaryInput_index2,1,2,2,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index3,BinaryInput_index3,1,2,3,1,NA,FALSE,Single bit binary input with status
+AnalogOutput_index0,AnalogOutput_index0,40,4,0,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index1,AnalogOutput_index1,40,4,1,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index2,AnalogOutput_index2,40,4,2,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index3,AnalogOutput_index3,40,4,3,1,NA,TRUE,Double-precision floating point with flags
+BinaryOutput_index0,BinaryOutput_index0,10,2,0,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index1,BinaryOutput_index1,10,2,1,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index2,BinaryOutput_index2,10,2,2,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index3,BinaryOutput_index3,10,2,3,1,NA,TRUE,Binary Output with flags

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/__init__.py
@@ -1,0 +1,1 @@
+from services.core.PlatformDriverAgent.platform_driver.interfaces import udd_dnp3

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py
@@ -1,0 +1,504 @@
+import pytest
+import gevent
+import logging
+import time
+import csv
+import json
+from pathlib import Path
+import random
+
+from services.core.PlatformDriverAgent.platform_driver.interfaces. \
+    udd_dnp3 import UserDevelopRegisterDnp3
+from pydnp3 import opendnp3
+from services.core.PlatformDriverAgent.platform_driver.interfaces. \
+    udd_dnp3.udd_dnp3 import Interface as DNP3Interface
+
+from dnp3_python.dnp3station.master_new import MyMasterNew
+from dnp3_python.dnp3station.outstation_new import MyOutStationNew
+
+import os
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestDummy:
+    """
+    Dummy test to check pytest setup
+    """
+
+    def test_dummy(self):
+        print("I am a silly dummy test.")
+
+
+@pytest.fixture(
+    scope="module"
+)
+def outstation_app(request):
+    """
+    outstation using default configuration (including default database)
+    Note: since outstation cannot shut down gracefully,
+    outstation_app fixture need to in "module" scope to prevent interrupting pytest during outstation shut-down
+    """
+    # Note: allow parsing argument to fixture change port number using `request.param`
+    try:
+        port = request.param
+    except AttributeError:
+        port = 20000
+    outstation_appl = MyOutStationNew(port=port)  # Note: using default port 20000
+    outstation_appl.start()
+    # time.sleep(3)
+    yield outstation_appl
+    # clean-up
+    outstation_appl.shutdown()
+
+
+@pytest.fixture(
+    # scope="module"
+)
+def master_app(request):
+    """
+    master station using default configuration
+    Note: outstation needs to exist first to make connection.
+    """
+
+    # Note: allow parsing argument to fixture change port number using `request.param`
+    try:
+        port = request.param
+    except AttributeError:
+        port = 20000
+    # Note: using default port 20000,
+    # Note: using small "stale_if_longer_than" to force update
+    master_appl = MyMasterNew(port=port, stale_if_longer_than=0.1)
+    master_appl.start()
+    # Note: add delay to prevent conflict
+    # (there is a delay when master shutdown. And all master shares the same config)
+    time.sleep(1)
+    yield master_appl
+    # clean-up
+    master_appl.shutdown()
+    time.sleep(1)
+
+
+class TestStation:
+    """
+    Testing the underlying pydnp3 package station-related fuctions.
+    """
+
+    def test_station_init(self, master_app, outstation_app):
+        # master_app = MyMasterNew()
+        # master_app.start()
+        driver_wrapper_init_arg = {'driver_config': {}, 'point_name': "", 'data_type': "", 'units': "", 'read_only': ""}
+        UserDevelopRegisterDnp3(master_application=master_app, reg_def={},
+                                **driver_wrapper_init_arg)
+
+    def test_station_get_val_analog_input_float(self, master_app, outstation_app):
+
+        # outstation update with values
+        analog_input_val = [1.2454, 33453.23, 45.21]
+        for i, val_update in enumerate(analog_input_val):
+            outstation_app.apply_update(opendnp3.Analog(value=val_update,
+                                                        flags=opendnp3.Flags(24),
+                                                        time=opendnp3.DNPTime(3094)),
+                                        index=i)
+        # Note: group=30, variation=6 is AnalogInputFloat
+        for i, val_update in enumerate(analog_input_val):
+            val_get = master_app.get_val_by_group_variation_index(group=30, variation=6, index=i)
+            # print(f"===val_update {val_update}, val_get {val_get}")
+            assert val_get == val_update
+
+        time.sleep(1)  # add delay buffer to pass the "stale_if_longer_than" checking statge
+
+        # outstation update with random values
+        analog_input_val_random = [random.random() for i in range(3)]
+        for i, val_update in enumerate(analog_input_val_random):
+            outstation_app.apply_update(opendnp3.Analog(value=val_update),
+                                        index=i)
+        # Note: group=30, variation=6 is AnalogInputFloat
+        for i, val_update in enumerate(analog_input_val_random):
+            val_get = master_app.get_val_by_group_variation_index(group=30, variation=6, index=i)
+            # print(f"===val_update {val_update}, val_get {val_get}")
+            assert val_get == val_update
+
+    def test_station_set_val_analog_input_float(self, master_app, outstation_app):
+
+        # outstation update with values
+        analog_output_val = [1.2454, 33453.23, 45.21]
+        for i, val_to_set in enumerate(analog_output_val):
+            master_app.send_direct_point_command(group=40, variation=4, index=i,
+                                                 val_to_set=val_to_set)
+        # Note: group=40, variation=4 is AnalogOutFloat
+        for i, val_to_set in enumerate(analog_output_val):
+            val_get = master_app.get_val_by_group_variation_index(group=40, variation=4, index=i)
+            # print(f"===val_update {val_update}, val_get {val_get}")
+            assert val_get == val_to_set
+
+        time.sleep(1)  # add delay buffer to pass the "stale_if_longer_than" checking statge
+
+        # outstation update with random values
+        analog_output_val_random = [random.random() for i in range(3)]
+        for i, val_to_set in enumerate(analog_output_val_random):
+            master_app.send_direct_point_command(group=40, variation=4, index=i,
+                                                 val_to_set=val_to_set)
+        # Note: group=40, variation=4 is AnalogOutFloat
+        for i, val_to_set in enumerate(analog_output_val_random):
+            val_get = master_app.get_val_by_group_variation_index(group=40, variation=4, index=i)
+            # print(f"===val_update {val_update}, val_get {val_get}")
+            assert val_get == val_to_set
+
+
+@pytest.fixture
+def dnp3_inherit_init_args(csv_config, driver_config_in_json_config):
+    """
+    args required for parent class init (i.e., class WrapperRegister)
+    """
+    args = {'driver_config': driver_config_in_json_config,
+            'point_name': "",
+            'data_type': "",
+            'units': "",
+            'read_only': ""}
+    return args
+
+
+@pytest.fixture
+def driver_config_in_json_config():
+    """
+    associated with `driver_config` in driver-config.config (json-like file)
+                    user inputs are put here, e.g., IP address, url, etc.
+    """
+    json_path = Path("./testing_data/udd-Dnp3.config")
+    json_path = Path(TEST_DIR, json_path)
+    with open(json_path) as json_f:
+        driver_config = json.load(json_f)
+    k = "driver_config"
+    return {k: driver_config.get(k)}
+
+
+@pytest.fixture
+def csv_config():
+    """
+    associated with the whole driver-config.csv file
+    """
+    csv_path = Path("./testing_data/udd-Dnp3.csv")
+    csv_path = Path(TEST_DIR, csv_path)
+    with open(csv_path) as f:
+        reader = csv.DictReader(f, delimiter=',')
+        csv_config = [row for row in reader]
+
+    return csv_config
+
+
+@pytest.fixture
+def reg_def_dummy():
+    """
+    register definition, row of csv config file
+    """
+    # reg_def = {'Point Name': 'AnalogInput_index0', 'Volttron Point Name': 'AnalogInput_index0',
+    #            'Group': '30', 'Variation': '6', 'Index': '0', 'Scaling': '1', 'Units': 'NA',
+    #            'Writable': 'FALSE', 'Notes': 'Double Analogue input without status'}
+    reg_def = {'Point Name': 'pn', 'Volttron Point Name': 'pn',
+               'Group': 'int', 'Variation': 'int', 'Index': 'int', 'Scaling': '1', 'Units': 'NA',
+               'Writable': 'NA', 'Notes': ''}
+    return reg_def
+
+
+class TestDNPRegister:
+    """
+    Tests for UserDevelopRegisterDnp3 class
+
+    init
+
+    get_register_value
+        analog input float
+        analog input int
+        binary input
+    """
+
+    def test_init(self, master_app, csv_config, dnp3_inherit_init_args):
+        for reg_def in csv_config:
+            UserDevelopRegisterDnp3(master_application=master_app,
+                                    reg_def=reg_def,
+                                    **dnp3_inherit_init_args
+                                    )
+
+    def test_get_register_value_analog_float(self, outstation_app, master_app, csv_config,
+                                             dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        analog_input_val = [445.33, 1123.56, 98.456] + [random.random() for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 30, variation = 6 is AnalogInputFloat
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(analog_input_val)):
+            reg_def["Group"] = "30"
+            reg_def["Variation"] = "6"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # outstation update values
+        for i, val_update in enumerate(analog_input_val):
+            outstation_app.apply_update(opendnp3.Analog(value=val_update), index=i)
+
+        # verify: driver read value
+        for i, (val_update, csv_row) in enumerate(zip(analog_input_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_update
+
+    def test_get_register_value_analog_int(self, outstation_app, master_app, csv_config,
+                                           dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        analog_input_val = [345, 1123, 98] + [random.randint(1, 100) for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 30, variation = 1 is AnalogInputInt32
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(analog_input_val)):
+            reg_def["Group"] = "30"
+            reg_def["Variation"] = "1"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # outstation update values
+        for i, val_update in enumerate(analog_input_val):
+            outstation_app.apply_update(opendnp3.Analog(value=val_update), index=i)
+
+        # verify: driver read value
+        for i, (val_update, csv_row) in enumerate(zip(analog_input_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_update
+
+    def test_get_register_value_binary(self, outstation_app, master_app, csv_config,
+                                       dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        binary_input_val = [True, False, True] + [random.choice([True, False]) for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 1, variation = 2 is BinaryInput
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(binary_input_val)):
+            reg_def["Group"] = "1"
+            reg_def["Variation"] = "2"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # outstation update values
+        for i, val_update in enumerate(binary_input_val):
+            outstation_app.apply_update(opendnp3.Binary(value=val_update), index=i)
+
+        # verify: driver read value
+        for i, (val_update, csv_row) in enumerate(zip(binary_input_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print(f"=========== i {i}, val_get {val_get}, val_update {val_update}")
+            assert val_get == val_update
+
+
+class TestDNP3RegisterControlWorkflow:
+
+    def test_set_register_value_analog_float(self, outstation_app, master_app, csv_config,
+                                             dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        # Note: group=40, variation=4 is AnalogOutputDoubleFloat
+        output_val = [343.23, 23.1109, 58.2] + [random.random() for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 1, variation = 2 is BinaryInput
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(output_val)):
+            reg_def["Group"] = "40"
+            reg_def["Variation"] = "4"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # master set values
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            dnp3_register.set_register_value(value=val_set)
+
+        # verify: driver read value
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_set
+
+    def test_set_register_value_analog_int(self, outstation_app, master_app, csv_config,
+                                           dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        # Note: group=40, variation=4 is AnalogOutputDoubleFloat
+        output_val = [45343, 344, 221] + [random.randint(1, 1000) for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 1, variation = 2 is BinaryInput
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(output_val)):
+            reg_def["Group"] = "40"
+            reg_def["Variation"] = "1"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # master set values
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            dnp3_register.set_register_value(value=val_set)
+
+        # verify: driver read value
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_set
+
+    def test_set_register_value_binary(self, outstation_app, master_app, csv_config,
+                                       dnp3_inherit_init_args, reg_def_dummy):
+
+        # dummy test variable
+        # Note: group=40, variation=4 is AnalogOutputDoubleFloat
+        output_val = [True, False, True] + [random.choice([True, False]) for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 1, variation = 2 is BinaryInput
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(output_val)):
+            reg_def["Group"] = "10"
+            reg_def["Variation"] = "2"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # master set values
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            dnp3_register.set_register_value(value=val_set)
+
+        # verify: driver read value
+        for i, (val_set, csv_row) in enumerate(zip(output_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            val_get = dnp3_register.get_register_value()
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_set
+
+
+class TestDNP3InterfaceNaive:
+
+    def test_init(self):
+        pass
+        dnp3_interface = DNP3Interface()
+
+    def test_get_reg_point(self, outstation_app, master_app, csv_config,
+                           dnp3_inherit_init_args, reg_def_dummy):
+        # dummy test variable
+        analog_input_val = [445.33, 1123.56, 98.456] + [random.random() for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 30, variation = 6 is AnalogInputFloat
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(analog_input_val)):
+            reg_def["Group"] = "30"
+            reg_def["Variation"] = "6"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        # outstation update values
+        for i, val_update in enumerate(analog_input_val):
+            outstation_app.apply_update(opendnp3.Analog(value=val_update), index=i)
+
+        # verify: driver read value
+        dnp3_interface = DNP3Interface()
+        for i, (val_update, csv_row) in enumerate(zip(analog_input_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+
+            val_get = dnp3_interface.get_reg_point(register=dnp3_register)
+            # print("======== dnp3_register.value", dnp3_register.value)
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_update
+
+    def test_set_reg_point(self, outstation_app, master_app, csv_config,
+                           dnp3_inherit_init_args, reg_def_dummy):
+        # dummy test variable
+        analog_output_val = [445.33, 1123.56, 98.456] + [random.random() for i in range(3)]
+
+        # dummy reg_def (csv config row)
+        # Note: group = 30, variation = 6 is AnalogInputFloat
+        reg_def = reg_def_dummy
+        reg_defs = []
+        for i in range(len(analog_output_val)):
+            reg_def["Group"] = "40"
+            reg_def["Variation"] = "4"
+            reg_def["Index"] = str(i)
+            reg_defs.append(reg_def.copy())  # Note: Python gotcha, mutable don't evaluate til the end of the loop.
+
+        dnp3_interface = DNP3Interface()
+
+        # dnp3_interface update values
+        for i, (val_update, csv_row) in enumerate(zip(analog_output_val, reg_defs)):
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+            dnp3_interface.set_reg_point(register=dnp3_register, value_to_set=val_update)
+
+        # verify: driver read value
+
+        for i, (val_update, csv_row) in enumerate(zip(analog_output_val, reg_defs)):
+            # print(f"====== reg_defs {reg_defs}, analog_input_val {analog_input_val}")
+            dnp3_register = UserDevelopRegisterDnp3(master_application=master_app,
+                                                    reg_def=csv_row,
+                                                    **dnp3_inherit_init_args
+                                                    )
+
+            val_get = dnp3_interface.get_reg_point(register=dnp3_register)
+            # print("======== dnp3_register.value", dnp3_register.value)
+            # print("===========val_get, val_update", val_get, val_update)
+            assert val_get == val_update

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py
@@ -1,0 +1,202 @@
+import pytest
+import gevent
+import logging
+import time
+import random
+
+from volttron.platform import get_services_core, jsonapi
+
+from volttron.platform.agent.known_identities import PLATFORM_DRIVER
+
+from pydnp3 import opendnp3
+
+from dnp3_python.dnp3station.outstation_new import MyOutStationNew
+from pathlib import Path
+
+import sys
+import os
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+# TODO: add IP, port pool to avoid conflict
+
+
+class TestDummy:
+    """
+    Dummy test to check pytest setup
+    """
+
+    def test_dummy(self):
+        print("I am a silly dummy test.")
+
+
+@pytest.fixture(
+    scope="class"
+)
+def outstation_app_p20000():
+    """
+    outstation using default configuration (including default database)
+    Note: since outstation cannot shut down gracefully,
+    outstation_app fixture need to in "module" scope to prevent interrupting pytest during outstation shut-down
+    """
+    port = 20000
+    outstation_appl = MyOutStationNew(port=port)  # Note: using default port 20000
+    outstation_appl.start()
+    time.sleep(2)
+    yield outstation_appl
+
+    outstation_appl.shutdown()
+
+
+@pytest.mark.skip(reason="only for debugging purpose")
+class TestDummyAgentFixture:
+    """
+    Dummy test to check VOLTTRON agent (carry on test VOLTTRON instance) setup
+    """
+
+    def test_agent_dummy(self, dnp3_tester_agent):
+        print("I am a fixture agent dummy test.")
+
+
+class TestDnp3DriverRPC:
+
+    def test_interface_get_point(
+            self,
+            dnp3_tester_agent,
+            outstation_app_p20000,
+    ):
+        val_update = 7.124 + random.random()
+        outstation_app_p20000.apply_update(opendnp3.Analog(value=val_update,
+                                                           flags=opendnp3.Flags(24),
+                                                           time=opendnp3.DNPTime(3094)),
+                                           index=0)
+
+        time.sleep(2)
+
+        res_val = dnp3_tester_agent.vip.rpc.call("platform.driver", "get_point",
+                                                 "campus-vm/building-vm/Dnp3-port30000",
+                                                 "AnalogInput_index0").get(timeout=5)
+
+        print(f"======res_val {res_val}")
+        assert res_val == val_update
+
+    def test_interface_set_point(
+            self,
+            dnp3_tester_agent,
+            outstation_app_p20000,
+    ):
+        val_set = 8.342 + random.random()
+
+        res_val = dnp3_tester_agent.vip.rpc.call("platform.driver", "set_point",
+                                                 "campus-vm/building-vm/Dnp3-port30000",
+                                                 "AnalogOutput_index0", val_set).get(timeout=5)
+
+        # print(f"======res_val {res_val}")
+        # Expected output
+        # {'success_flag': True, 'value_to_set': 8.342, 'set_pt_response': None, 'get_pt_response': 8.342}
+        try:
+            assert res_val.get("success_flag")
+        except AssertionError:
+            print(f"======res_val {res_val}")
+
+    @pytest.mark.skip(reason="TODO")
+    def test_scrape_all(self, ):
+        """
+        Issue a get_point RPC call for the device and return the result.
+
+        @param agent: The test Agent.
+        @param device_name: The driver name, by default: 'devices/device_name'.
+        @return: The dictionary mapping point names to their actual values from
+        the RPC call.
+        """
+        # return agent.vip.rpc.call(PLATFORM_DRIVER, 'scrape_all', device_name) \
+        #     .get(timeout=10)
+
+    @pytest.mark.skip(reason="TODO")
+    def test_revert_all(self, ):
+        """
+        Issue a get_point RPC call for the device and return the result.
+
+        @param agent: The test Agent.
+        @param device_name: The driver name, by default: 'devices/device_name'.
+        @return: Return value from the RPC call.
+        """
+        # return agent.vip.rpc.call(PLATFORM_DRIVER, 'revert_device',
+        #                           device_name).get(timeout=10)
+
+    @pytest.mark.skip(reason="TODO")
+    def test_revert_point(self, ):
+        """
+        Issue a get_point RPC call for the named point and return the result.
+
+        @param agent: The test Agent.
+        @param device_name: The driver name, by default: 'devices/device_name'.
+        @param point_name: The name of the point to query.
+        @return: Return value from the RPC call.
+        """
+        # return agent.vip.rpc.call(PLATFORM_DRIVER, 'revert_point',
+        #                           device_name, point_name).get(timeout=10)
+
+
+@pytest.fixture(scope="module")
+# @pytest.fixture
+def dnp3_tester_agent(request, volttron_instance):
+    """
+    Build PlatformDriverAgent, add modbus driver & csv configurations
+    """
+
+    # Build platform driver agent
+    tester_agent = volttron_instance.build_agent(identity="test_dnp3_agent")
+    capabilities = {'edit_config_store': {'identity': PLATFORM_DRIVER}}
+    volttron_instance.add_capabilities(tester_agent.core.publickey, capabilities)
+
+    # Clean out platform driver configurations
+    # wait for it to return before adding new config
+    tester_agent.vip.rpc.call(peer='config.store',
+                              method='manage_delete_store',
+                              identity=PLATFORM_DRIVER).get()
+
+    json_config_path = Path("./testing_data/udd-Dnp3.config")
+    json_config_path = Path(TEST_DIR, json_config_path)
+    with open(json_config_path, "r") as f:
+        json_str_p20000 = f.read()
+
+    csv_config_path = Path("./testing_data/udd-Dnp3.csv")
+    csv_config_path = Path(TEST_DIR, csv_config_path)
+    with open(csv_config_path, "r") as f:
+        csv_str = f.read()
+
+    tester_agent.vip.rpc.call(peer='config.store',
+                              method='manage_store',
+                              identity=PLATFORM_DRIVER,
+                              config_name="udd-Dnp3.csv",
+                              raw_contents=csv_str,
+                              config_type='csv'
+                              ).get(timeout=5)
+
+    tester_agent.vip.rpc.call('config.store',
+                              method='manage_store',
+                              identity=PLATFORM_DRIVER,
+                              config_name="devices/campus-vm/building-vm/Dnp3-port30000",
+                              raw_contents=json_str_p20000,
+                              config_type='json'
+                              ).get(timeout=5)
+
+    platform_uuid = volttron_instance.install_agent(
+        agent_dir=get_services_core("PlatformDriverAgent"),
+        config_file={},
+        start=True)
+
+    # gevent.sleep(10)  # wait for the agent to start and start the devices
+    # time.sleep(10)  # wait for the agent to start and start the devices
+
+    def stop():
+        """
+        Stop platform driver agent
+        """
+        volttron_instance.stop_agent(platform_uuid)
+        tester_agent.core.stop()
+
+    yield tester_agent
+    request.addfinalizer(stop)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/testing_data/udd-Dnp3.config
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/testing_data/udd-Dnp3.config
@@ -1,0 +1,14 @@
+{
+    "driver_config": {"master_ip": "0.0.0.0", "outstation_ip": "127.0.0.1",
+        "master_id": 2, "outstation_id": 1,
+        "port":  20000},
+    "registry_config":"config://udd-Dnp3.csv",
+		"driver_type": "udd_dnp3",
+    "interval": 5,
+    "timezone": "UTC",
+    "campus": "campus-vm",
+    "building": "building-vm",
+    "unit": "Dnp3",
+		"publish_depth_first_all": true,
+    "heart_beat_point": "random_bool"
+}

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/testing_data/udd-Dnp3.csv
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/testing_data/udd-Dnp3.csv
@@ -1,0 +1,17 @@
+Point Name,Volttron Point Name,Group,Variation,Index,Scaling,Units,Writable,Notes
+AnalogInput_index0,AnalogInput_index0,30,6,0,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index1,AnalogInput_index1,30,6,1,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index2,AnalogInput_index2,30,6,2,1,NA,FALSE,Double Analogue input without status
+AnalogInput_index3,AnalogInput_index3,30,6,3,1,NA,FALSE,Double Analogue input without status
+BinaryInput_index0,BinaryInput_index0,1,2,0,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index1,BinaryInput_index1,1,2,1,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index2,BinaryInput_index2,1,2,2,1,NA,FALSE,Single bit binary input with status
+BinaryInput_index3,BinaryInput_index3,1,2,3,1,NA,FALSE,Single bit binary input with status
+AnalogOutput_index0,AnalogOutput_index0,40,4,0,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index1,AnalogOutput_index1,40,4,1,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index2,AnalogOutput_index2,40,4,2,1,NA,TRUE,Double-precision floating point with flags
+AnalogOutput_index3,AnalogOutput_index3,40,4,3,1,NA,TRUE,Double-precision floating point with flags
+BinaryOutput_index0,BinaryOutput_index0,10,2,0,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index1,BinaryOutput_index1,10,2,1,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index2,BinaryOutput_index2,10,2,2,1,NA,TRUE,Binary Output with flags
+BinaryOutput_index3,BinaryOutput_index3,10,2,3,1,NA,TRUE,Binary Output with flags

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/udd_dnp3.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/udd_dnp3.py
@@ -1,0 +1,236 @@
+# from platform_driver.interfaces.driver_wrapper import WrapperInterface, WrapperRegister
+# from platform_driver.interfaces.driver_wrapper import ImplementedRegister, RegisterValue
+from .driver_wrapper import WrapperInterface, WrapperRegister
+from .driver_wrapper import ImplementedRegister, RegisterValue
+from typing import List, Optional, Dict
+# import numpy as np
+import random
+import requests
+
+from dnp3_python.dnp3station.master_new import MyMasterNew
+
+from .driver_wrapper import WrapperInterfaceNew
+
+# TODO-developer: Your code here
+# Add dependency as needed, and update in requirements
+import json
+
+import logging
+import random
+import sys
+
+from datetime import datetime
+
+
+stdout_stream = logging.StreamHandler(sys.stdout)
+stdout_stream.setFormatter(logging.Formatter('%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s'))
+
+_log = logging.getLogger(__name__)
+# _log = logging.getLogger("data_retrieval_demo")
+_log.addHandler(stdout_stream)
+_log.setLevel(logging.DEBUG)
+_log.setLevel(logging.WARNING)
+_log.setLevel(logging.ERROR)
+
+
+# try:
+#     from pydnp3 import opendnp3
+#     # from .dnp3_python.master_new import MyMasterNew
+#     from .pydnp3.src.dnp3_python.master_new import MyMasterNew
+#     # from .dnp3_python.outstation_new import MyOutStationNew
+# except ImportError as e:
+#     _log.error(e)
+
+
+# TODO-developer: Your code here
+# Change the classname "UserDevelopRegister" as needed
+class UserDevelopRegisterDnp3(WrapperRegister):
+    # TODO-developer: Your code here
+    def __init__(self, master_application, reg_def, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # self.master_application = kwargs['master_application']
+        # self.reg_def = kwargs['reg_def']
+        self.master_application = master_application
+        self.reg_def = reg_def
+
+    def get_register_value(self) -> RegisterValue:
+        # TODO-developer: Your code here
+        # Implemet get-register-value logic here
+        # Note: Keep the method name as it is including the signatures.
+        # Use a helper method if needed.
+
+        # EXAMPLE:
+        # def get_register_value(self) -> RegisterValue:
+        #    return _get_register_value_helper(url=self.driver_config.get("url"))
+        # def _get_register_value_helper(self, url: str):
+        #    ...
+
+        #         print("silly implementation")
+        # the url will be in the config file
+
+        try:
+            reg_def = self.reg_def
+            group = int(reg_def.get("Group"))
+            variation = int(reg_def.get("Variation"))
+            index = int(reg_def.get("Index"))
+            val = self._get_outstation_pt(self.master_application, group, variation, index)
+            # val = str(val)
+
+            if val is not None:
+                return val
+            else:
+                _log.warning("udd_dnp3 driver (master) couldn't collect data from the outstation.")
+                raise ValueError(f"Returned invalid dnp3 data point {val}")  # do not publish invalid values
+        except Exception as e:
+            # print(f"!!!!!!!!!!!!!!!!!!!!{e}")
+            _log.error(e)
+
+            raise Exception(e)
+
+    @staticmethod
+    def _get_outstation_pt(master_application, group, variation, index) -> RegisterValue:
+        """
+        Core logic to retrieve register value by polling a dnp3 outstation
+        Note: using def get_db_by_group_variation_index
+        Returns
+        -------
+
+        """
+        return_point_value = master_application.get_val_by_group_variation_index(group=group,
+                                                                                 variation=variation,
+                                                                                 index=index)
+        return return_point_value
+
+    def set_register_value(self, value, **kwargs) -> Optional[RegisterValue]:
+        """
+        TODO: docstring
+        """
+        try:
+            reg_def = self.reg_def
+            group = int(reg_def.get("Group"))
+            variation = int(reg_def.get("Variation"))
+            index = int(reg_def.get("Index"))
+
+            val: Optional[RegisterValue]
+            self._set_outstation_pt(self.master_application, group, variation, index, set_value=value)
+            val = None
+
+            return val
+        except Exception as e:
+            # print(f"!!!!!!!!!!!!!!!!!!!!{e}")
+            _log.error(e)
+            _log.warning("udd_dnp3 driver (master) couldn't set value for the outstation.")
+
+    @staticmethod
+    def _set_outstation_pt(master_application, group, variation, index, set_value) -> None:
+        """
+        Core logic to send point operate command to outstation
+        Note: using def send_direct_point_command
+        Returns None
+        -------
+
+        """
+        master_application.send_direct_point_command(group=group, variation=variation, index=index,
+                                                     val_to_set=set_value)
+
+
+class Interface(WrapperInterface):
+    # TODO-developer: Your code here
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.master_application = None
+
+    # TODO-developer: Your code here
+    # Register type configuration
+    @staticmethod
+    def pass_register_types(csv_config: dict, driver_config_in_json_config: List[dict],
+                            register_type_list: List[ImplementedRegister] = None):
+        """
+        Note: based on the config.csv file.
+        By default, assuming register points are dnp3-register type + (optional) heartbeat register
+        """
+        return [UserDevelopRegisterDnp3] * len(csv_config)
+
+    @staticmethod
+    def _create_master_station(driver_config: dict):
+        """
+        init a master station and later pass to registers
+
+        Note: rely on XX.config json file convention, e.g.,
+        "driver_config":
+            {"master_ip": "0.0.0.0",
+            "outstation_ip": "127.0.0.1",
+            "master_id": 2,
+            "outstation_id": 1,
+            "port":  20000},
+
+        Returns
+        -------
+
+        """
+        # driver_config: dict = self.driver_config
+        # print(f"=============driver_config {driver_config}")
+
+        master_application = MyMasterNew(
+            masterstation_ip_str=driver_config.get("master_ip"),
+            outstation_ip_str=driver_config.get("outstation_ip"),
+            port=driver_config.get("port"),
+            masterstation_id_int=driver_config.get("master_id"),
+            outstation_id_int=driver_config.get("outstation_id"),
+        )
+        # master_application.start()
+        # self.master_application = master_application
+        return master_application
+
+    def create_register(self, driver_config,
+                        point_name,
+                        data_type,
+                        units,
+                        read_only,
+                        default_value,
+                        description,
+                        csv_config,
+                        reg_def,
+                        register_type, *args, **kwargs):
+        def get_master_station():
+            # Note: this a closure, since parameter driver_config is required.
+            # (at current state) only create_register workflow should use it.
+            if self.master_application:
+                return self.master_application
+            else:
+                self.master_application = self._create_master_station(driver_config)
+                return self.master_application
+
+        master = get_master_station()
+        master.start()
+
+        register = UserDevelopRegisterDnp3(
+            driver_config=driver_config,
+            point_name=point_name,
+            data_type=data_type,  # TODO: make it more clear in documentation
+            units=units,
+            read_only=read_only,
+            default_value=default_value,
+            description=description,
+            csv_config=csv_config,
+            reg_def=reg_def,
+            master_application=master
+        )
+        return register
+
+    @staticmethod
+    def get_reg_point(register: ImplementedRegister):
+        """
+        Core logic for get_point
+        Note: Can be used for vip-agent-mock testing
+        """
+        return register.get_register_value()
+
+    @staticmethod
+    def set_reg_point(register: ImplementedRegister, value_to_set: RegisterValue):
+        """
+        Core logic for set_point, i.e., _set_point without verification
+        Note: Can be used for vip-agent-mock testing
+        """
+        set_pt_response = register.set_register_value(value=value_to_set)
+        return set_pt_response


### PR DESCRIPTION
# Description

This PR improved DNP3 driver associated with issue #314 #1676 #1695.
- Refactored and repackaged underlying pydnp3 and allow pip install. (Currently on test-pypi: https://test.pypi.org/project/dnp3-python/)
- Extended unit-tests and integration test: close-loop testing with volttron-instance and outstation. 
- With example configuration at services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/examples
- With READEME

Fixes #314 #1676 #1695

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

at root_path
run `pytest services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests`

**Note: the test failed for** 
                    pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
                    dict(messagebus='zmq', auth_enabled=False),

```
(volttron) kefei@ubuntu-20-ws ~/project/volttron (dnp3-driver-pr) $ pytest services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests
===================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.8.10, pytest-7.1.3, pluggy-1.0.0 -- /home/kefei/project/volttron/env/bin/python3
cachedir: .pytest_cache
rootdir: /home/kefei/project/volttron, configfile: pytest.ini
collected 27 items                                                                                                                                                                                                            

services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDummy::test_dummy PASSED                                                                                           [  3%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestStation::test_station_init PASSED                                                                                  [  7%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestStation::test_station_get_val_analog_input_float PASSED                                                            [ 11%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestStation::test_station_set_val_analog_input_float PASSED                                                            [ 14%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNPRegister::test_init PASSED                                                                                      [ 18%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNPRegister::test_get_register_value_analog_float PASSED                                                           [ 22%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNPRegister::test_get_register_value_analog_int PASSED                                                             [ 25%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNPRegister::test_get_register_value_binary PASSED                                                                 [ 29%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3RegisterControlWorkflow::test_set_register_value_analog_float PASSED                                           [ 33%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3RegisterControlWorkflow::test_set_register_value_analog_int PASSED                                             [ 37%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3RegisterControlWorkflow::test_set_register_value_binary PASSED                                                 [ 40%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3InterfaceNaive::test_init PASSED                                                                               [ 44%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3InterfaceNaive::test_get_reg_point PASSED                                                                      [ 48%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver.py::TestDNP3InterfaceNaive::test_set_reg_point PASSED                                                                      [ 51%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDummy::test_dummy PASSED                                                                      [ 55%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDummyAgentFixture::test_agent_dummy[volttron_instance0] SKIPPED (only for debugging purpose)  [ 59%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_get_point[volttron_instance0] PASSED                            [ 62%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_set_point[volttron_instance0] PASSED                            [ 66%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDummyAgentFixture::test_agent_dummy[volttron_instance1] SKIPPED (RabbitMQ is not setup an...) [ 70%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_get_point[volttron_instance1] SKIPPED (RabbitMQ is not setu...) [ 74%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_set_point[volttron_instance1] SKIPPED (RabbitMQ is not setu...) [ 77%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDummyAgentFixture::test_agent_dummy[volttron_instance2] SKIPPED (only for debugging purpose)  [ 81%]ms(1667232773883) INFO    manager - Exiting thread (0)

services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_get_point[volttron_instance2] ERROR                             [ 85%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_interface_set_point[volttron_instance2] ERROR                             [ 88%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_scrape_all SKIPPED (TODO)                                                 [ 92%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_revert_all SKIPPED (TODO)                                                 [ 96%]
services/core/PlatformDriverAgent/platform_driver/interfaces/udd_dnp3/tests/test_dnp3_driver_integration_volttron.py::TestDnp3DriverRPC::test_revert_point SKIPPED (TODO)                                               [100%]
```

