### PR TITLE
Add skip test logic when pika not installed

### DIFF
--- a/volttrontesting/platform/test_basehistorian.py
+++ b/volttrontesting/platform/test_basehistorian.py
@@ -13,7 +13,12 @@ from volttron.platform.vip.agent.results import AsyncResult
 from volttron.platform.vip.agent.subsystems.query import Query
 from volttrontesting.utils.utils import AgentMock
 from time import sleep
-from volttrontesting.platform.test_instance_setup import create_vcfg_vhome
+
+from volttron.platform import is_rabbitmq_available
+if is_rabbitmq_available():
+    from volttrontesting.platform.test_instance_setup import create_vcfg_vhome
+else:
+    pytest.skip("Pika is not installed", allow_module_level=True)
 
 
 class QueryHelper:

--- a/volttrontesting/platform/test_instance_setup.py
+++ b/volttrontesting/platform/test_instance_setup.py
@@ -8,11 +8,17 @@ from volttron.platform import is_rabbitmq_available
 from volttron.platform.instance_setup import _is_agent_installed
 from volttron.utils import get_hostname
 from volttron.platform.agent.utils import is_volttron_running
-from volttrontesting.fixtures.rmq_test_setup import create_rmq_volttron_setup
+from volttron.platform import is_rabbitmq_available
+
+RMQ_TIMEOUT = 600
+HAS_RMQ = is_rabbitmq_available()
+if HAS_RMQ:
+    from volttrontesting.fixtures.rmq_test_setup import create_rmq_volttron_setup
+else:
+    pytest.skip("Pika is not installed", allow_module_level=True)
+
 from volttrontesting.utils.platformwrapper import create_volttron_home
 
-HAS_RMQ = is_rabbitmq_available()
-RMQ_TIMEOUT = 600
 
 '''
 Example variables to be used during each of the tests, depending on the prompts that will be asked

--- a/volttrontesting/services/historian/test_multiplatform.py
+++ b/volttrontesting/services/historian/test_multiplatform.py
@@ -57,7 +57,13 @@ from volttrontesting.utils.utils import get_rand_vip, get_hostname_and_random_po
 from volttrontesting.utils.platformwrapper import PlatformWrapper
 from volttrontesting.fixtures.volttron_platform_fixtures import get_rand_vip, \
     get_rand_ip_and_port
-from volttron.utils.rmq_setup import start_rabbit, stop_rabbit
+
+from volttron.platform import is_rabbitmq_available
+if is_rabbitmq_available():
+    from volttron.utils.rmq_setup import start_rabbit, stop_rabbit
+else:
+    pytest.skip("Pika is not installed", allow_module_level=True)
+
 from volttron.platform.agent.utils import execute_command
 
 


### PR DESCRIPTION
# Description

Some tests require RMQ to be installed which in turn requires pika. When running these tests, `pytest` will mark those tests as 'ERROR'. If a volttron platform does not install RMQ, then running tests should not result in 'ERROR'; instead, those tests should be skipped following the example in this [previous PR](https://github.com/VOLTTRON/volttron/pull/3003).


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


```
pytest -m vc
pytest -m vcp
pytest -m zmq
pytest -m driver
``` 

**Test Configuration**:
Ubuntu 18.04
Python 3.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
