### PR TITLE
Fixed hardcoded value for table_catalog to use the database name (dbn…

### DIFF
--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -45,6 +45,7 @@ For method details please refer to base class
 """
 class PostgreSqlFuncts(DbDriver):
     def __init__(self, connect_params, table_names):
+        self.db_name = connect_params.get('dbname')
         if table_names:
             self.data_table = table_names['data_table']
             self.topics_table = table_names['topics_table']
@@ -147,7 +148,7 @@ class PostgreSqlFuncts(DbDriver):
 
     def setup_historian_tables(self):
         rows = self.select(f"""SELECT table_name FROM information_schema.tables
-                            WHERE table_catalog = 'test_historian' and table_schema = 'public' 
+                            WHERE table_catalog = '{self.db_name}' and table_schema = 'public' 
                             AND table_name = '{self.data_table}'""")
         if rows:
             _log.debug("Found table {}. Historian table exists".format(


### PR DESCRIPTION
…ame) in the config file

# Description

The table_catalog is hardcoded in setup_historian_tables in the postgresqlfuncts.py file. This change adds a line of code to grab the database name from the configuration file, and use that name in setup_historian_tables.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change is currently running on the campus installation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules
