### PR TITLE
Updaed yaml.load(file) to yaml.safe_load(file).

### DIFF
--- a/services/core/DNP3Agent/dnp3/mesa/conversion.py
+++ b/services/core/DNP3Agent/dnp3/mesa/conversion.py
@@ -1,4 +1,4 @@
 import sys, yaml, json
 
-y=yaml.load(sys.stdin.read())
+y=yaml.safe_load(sys.stdin.read())
 print(json.dumps(y))

--- a/services/core/DNP3Agent/dnp3/mesa/functions.py
+++ b/services/core/DNP3Agent/dnp3/mesa/functions.py
@@ -110,7 +110,7 @@ class FunctionDefinitions(collections.abc.Mapping):
             self._functions = {}
             try:
                 with open(fdef_path, 'r') as f:
-                    self.load_functions(yaml.load(f)['functions'])
+                    self.load_functions(yaml.safe_load(f)['functions'])
             except Exception as err:
                 raise ValueError('Problem parsing {}. Error={}'.format(fdef_path, err))
         _log.debug('Loaded {} FunctionDefinitions'.format(len(self._functions.keys())))

--- a/services/core/DNP3Agent/tests/test_mesa_agent.py
+++ b/services/core/DNP3Agent/tests/test_mesa_agent.py
@@ -103,7 +103,7 @@ def add_definitions_to_config_store(test_agent):
     test_agent.vip.rpc.call('config.store', 'manage_store', MESA_AGENT_ID,
                             'mesa_points.config', points_json, config_type='raw')
     with open(FUNCTION_DEFINITIONS_PATH, 'r') as f:
-        functions_json = yaml.load(f.read())
+        functions_json = yaml.safe_load(f.read())
     test_agent.vip.rpc.call('config.store', 'manage_store', MESA_AGENT_ID,
                             'mesa_functions.config', functions_json, config_type='raw')
 

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/config_cmd.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/config_cmd.py
@@ -79,7 +79,7 @@ class ConfigCmd (cmd.Cmd):
         yaml_file = "{0}/{1}".format(self._directories['map_dir'], file_name)
         if file_name and os.stat(yaml_file).st_size:
             with open("{0}/maps.yaml".format(self._directories['map_dir'])) as yaml_file:
-                device_type_maps = yaml.load(yaml_file)
+                device_type_maps = yaml.safe_load(yaml_file)
         return device_type_maps
 
     def _sh(self, shell_command):

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/maps/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/maps/__init__.py
@@ -329,7 +329,7 @@ class Catalog(Mapping):
                 yaml_path = os.path.dirname(__file__) + '/' + yaml_path
 
             with open(yaml_path, 'rb') as yaml_file:
-                for map in yaml.load(yaml_file):
+                for map in yaml.safe_load(yaml_file):
                     map = dict((k.lower(), v) for k, v in map.items())
                     Catalog._data[map['name']] = Map(file=map.get('file', ''),
                                                      map_dir=os.path.dirname(__file__),

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -232,7 +232,7 @@ def configure_logging(conf_path):
                 return (conf_path, 'PyYAML must be installed before '
                         'loading logging configuration from a YAML file.')
             try:
-                conf_dict = yaml.load(conf_file)
+                conf_dict = yaml.safe_load(conf_file)
             except yaml.YAMLError as exc:
                 return conf_path, exc
     try:


### PR DESCRIPTION
# Description

Replaces yaml.load(file) with yaml.safe_load(file). This is necessary for yaml 6.0 compatability, and also closes a possible code injection possiblity.

Fixes # 3100

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 

# How Has This Been Tested?

Tests for the modbus_tk driver have been run manually, and work after the change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
