### PR TITLE
Revert "Pip fix"

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -137,7 +137,7 @@ def update(operation, verbose=None, offline=False, optional_requirements=[], rab
     # option_requirements contains wheel as first entry
 
     # Build option_requirements separately to pass install options
-    build_option = '--build-option' if wheeling else '--config-settings'
+    build_option = '--build-option' if wheeling else '--install-option'
 
     for requirement, options in option_requirements:
         args = []


### PR DESCRIPTION
Reverts VOLTTRON/volttron#3094

This doesn't work with python 3.10 because inside the virtual environment created by bootstrap.py the default pip version is the older 22.0.2 and when install is done within this virtual environment pip commands fail with no such option "--config-settings"