### PR TITLE
Fix for config store security issue #3097

### DIFF
--- a/deprecated/OldDnp3/OldDnp3Driver/PlatformDriverAgent/tests/test_dnp3_driver.py
+++ b/deprecated/OldDnp3/OldDnp3Driver/PlatformDriverAgent/tests/test_dnp3_driver.py
@@ -80,7 +80,7 @@ def agent(request, volttron_instance):
     test_agent = volttron_instance.build_agent()
 
     def update_config(agent_id, name, value, cfg_type):
-        test_agent.vip.rpc.call('config.store', 'manage_store', agent_id, name, value, config_type=cfg_type)
+        test_agent.vip.rpc.call('config.store', 'set_config', agent_id, name, value, config_type=cfg_type)
 
     capabilities = {'edit_config_store': {'identity': PLATFORM_DRIVER}}
     volttron_instance.add_capabilities(test_agent.core.publickey, capabilities)
@@ -95,7 +95,7 @@ def agent(request, volttron_instance):
 
     # Build and start PlatformDriverAgent
 
-    test_agent.vip.rpc.call('config.store', 'manage_delete_store', PLATFORM_DRIVER)
+    test_agent.vip.rpc.call('config.store', 'delete_store', PLATFORM_DRIVER)
 
     platform_uuid = volttron_instance.install_agent(agent_dir=get_services_core("PlatformDriverAgent"),
                                                   config_file={},

--- a/docs/source/platform-features/config-store/agent-configuration-store.rst
+++ b/docs/source/platform-features/config-store/agent-configuration-store.rst
@@ -312,36 +312,66 @@ Platform RPC Methods
 --------------------
 
 
-Methods for Agents
-^^^^^^^^^^^^^^^^^^
+**set_config(identity, config_name, contents, config_type="raw", trigger_callback=True, send_update=True)** -
+Change/create a configuration on the platform for an agent with the specified identity. Requires the
+authorization capability 'edit_config_store'. By default agents have access to edit only their own config store entries.
 
-Agent methods that change configurations do not trigger any callbacks unless trigger_callback is True.
+**manage_store(identity, config_name, contents, config_type="raw", trigger_callback=True, send_update=True)** -
+Deprecated method. Please use set_config instead. Will be removed in VOLTTRON version 10.
+Change/create a configuration on the platform for an agent with the specified identity. Requires the
+authorization capability 'edit_config_store'. By default agents have access to edit only their own config store entries.
 
-**set_config(config_name, contents, trigger_callback=False)** - Change/create a configuration file on the platform.
+**delete_config(identity, config_name, trigger_callback=True, send_update=True)** - Delete a configuration for an
+agent with the specified identity. Requires the authorization capability 'edit_config_store'. By default agents have
+access to edit only their own config store entries.
 
-**get_configs()** - Get all of the configurations for an Agent.
+**manage_delete_config(identity, config_name, trigger_callback=True, send_update=True)** -
+Deprecated method. Please use delete_config instead. Will be removed in VOLTTRON version 10.
+Delete a configuration for an agent with the specified identity. Requires the authorization capability
+'edit_config_store'. By default agents have access to edit only their own config store entries.
 
-**delete_config(config_name, trigger_callback=False)** - Delete a configuration.
-
-
-Methods for Management
-^^^^^^^^^^^^^^^^^^^^^^
-
-**manage_store_config(identity, config_name, contents, config_type="raw")** - Change/create a configuration on the
-platform for an agent with the specified identity
-
-**manage_delete_config(identity, config_name)** - Delete a configuration for an agent with the specified identity.
+**delete_store(identity)** - Delete all configurations for an agent with the specified identity. Requires the
+authorization capability 'edit_config_store'. By default agents have access to edit only their own config store entries.
 Calls the agent's update_config with the action `DELETE_ALL` and no configuration name.
 
-**manage_delete_store(identity)** - Delete all configurations for a :term:`VIP Identity`.
+**manage_delete_store(identity)** -
+Deprecated method. Please use delete_store instead. Will be removed in VOLTTRON version 10.
+Delete all configurations for an agent with the specified identity. Requires the
+authorization capability 'edit_config_store'. By default agents have access to edit only their own config store entries.
+Calls the agent's update_config with the action `DELETE_ALL` and no configuration name.
 
-**manage_list_config(identity)** - Get a list of configurations for an agent with the specified identity.
+**list_configs(identity)** - Get a list of configurations for an agent with the specified identity.
 
-**manage_get_config(identity, config_name, raw=True)** - Get the contents of a configuration file.  If raw is set to
+**manage_list_configs(identity)** -
+Deprecated method. Please use list_configs instead. Will be removed in VOLTTRON version 10.
+Get a list of configurations for an agent with the specified identity.
+
+**list_stores()** - Get a list of all the agents with configurations.
+
+**manage_list_stores()** -
+Deprecated method. Please use list_stores instead. Will be removed in VOLTTRON version 10.
+Get a list of all the agents with configurations.
+
+
+**get_config(identity, config_name, raw=True)** - Get the contents of a configuration file.  If raw is set to
 `True` this function will return the original file, otherwise it will return the parsed representation of the file.
 
-**manage_list_stores()** - Get a list of all the agents with configurations.
+**manage_get_config(identity, config_name, raw=True)** -
+Deprecated method. Please use get_config instead. Will be removed in VOLTTRON version 10.
+Get the contents of a configuration file.  If raw is set to `True` this function will return the original file,
+otherwise it will return the parsed representation of the file.
 
+**initialize_configs(identity)** - Called by an Agent at startup to trigger initial configuration state push.
+Requires the authorization capability 'edit_config_store'. By default agents have access to edit only their own
+config store entries.
+
+**get_metadata(identity, config_name)** - Get the metadata of configuration named *config_name* of agent
+identified by *identity*. Returns the type(json, csv, raw) of the configuration, modified date and actual content
+
+**manage_get_metadata(identity, config_name)** -
+Deprecated method. Please use get_metadata instead. Will be removed in VOLTTRON version 10.
+Get the metadata of configuration named *config_name* of agent
+identified by *identity*. Returns the type(json, csv, raw) of the configuration, modified date and actual content
 
 Direct Call Methods
 ^^^^^^^^^^^^^^^^^^^

--- a/examples/ConfigActuation/tests/test_config_actuation.py
+++ b/examples/ConfigActuation/tests/test_config_actuation.py
@@ -157,7 +157,7 @@ def test_thing(publish_agent):
     assert value == 10.0
 
     publish_agent.vip.rpc.call(CONFIGURATION_STORE,
-                               "manage_store",
+                               "set_config",
                                "config_actuation",
                                "fakedriver",
                                jsonapi.dumps({"SampleWritableFloat1": 42.0}),

--- a/examples/ConfigActuation/update_config.py
+++ b/examples/ConfigActuation/update_config.py
@@ -97,21 +97,21 @@ def main():
     agent = build_agent(**get_keys())
 
     files = agent.vip.rpc.call(CONFIGURATION_STORE,
-                               'manage_list_configs',
+                               'list_configs',
                                vip_id).get(timeout=10)
 
     if filename not in files:
         config = {key: value}
     else:
         config = agent.vip.rpc.call(CONFIGURATION_STORE,
-                                    'manage_get',
+                                    'get_config',
                                     vip_id,
                                     filename).get(timeout=10)
         config = jsonapi.loads(config)
         config[key] = value
 
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_store',
+                       'set_config',
                        vip_id,
                        filename,
                        jsonapi.dumps(config),

--- a/requirements.py
+++ b/requirements.py
@@ -61,7 +61,8 @@ install_requires = ['gevent==21.12.0',
                     'tzlocal==2.1',
                     #'pyOpenSSL==19.0.0',
                     'cryptography==37.0.4',
-                    'watchdog-gevent==0.1.1']
+                    'watchdog-gevent==0.1.1',
+                    'deprecated==1.2.14']
 
 extras_require = {'crate': ['crate==0.27.1'],
                   'databases': ['mysql-connector-python==8.0.30',

--- a/scripts/extract_config_store.py
+++ b/scripts/extract_config_store.py
@@ -74,7 +74,7 @@ def get_configs(config_id, output_directory):
     event.wait()
 
     config_list = agent.vip.rpc.call(CONFIGURATION_STORE,
-                           'manage_list_configs',
+                           'list_configs',
                            config_id).get(timeout=10)
 
     if not config_list:
@@ -88,7 +88,7 @@ def get_configs(config_id, output_directory):
     for config in config_list:
         print("Retrieving configuration", config)
         raw_config = agent.vip.rpc.call(CONFIGURATION_STORE,
-                           'manage_get',
+                           'get_config',
                            config_id,
                            config, raw=True).get(timeout=10)
 

--- a/scripts/install_platform_driver_configs.py
+++ b/scripts/install_platform_driver_configs.py
@@ -89,13 +89,13 @@ def install_configs(input_directory, keep=False):
     if not keep:
         print("Deleting old Platform Driver store")
         agent.vip.rpc.call(CONFIGURATION_STORE,
-                           'manage_delete_store',
+                           'delete_store',
                            PLATFORM_DRIVER).get(timeout=10)
 
     with open("config") as f:
         print("Storing main configuration")
         agent.vip.rpc.call(CONFIGURATION_STORE,
-                           'manage_store',
+                           'set_config',
                            PLATFORM_DRIVER,
                            'config',
                            f.read(),
@@ -105,7 +105,7 @@ def install_configs(input_directory, keep=False):
         with open(name) as f:
             print("Storing configuration:", name)
             agent.vip.rpc.call(CONFIGURATION_STORE,
-                               'manage_store',
+                               'set_config',
                                PLATFORM_DRIVER,
                                name,
                                f.read(),
@@ -117,7 +117,7 @@ def install_configs(input_directory, keep=False):
             with open(name) as f:
                 print("Storing configuration:", name)
                 agent.vip.rpc.call(CONFIGURATION_STORE,
-                                   'manage_store',
+                                   'set_config',
                                    PLATFORM_DRIVER,
                                    name,
                                    f.read(),

--- a/services/contrib/InfluxdbHistorian/tests/test_influxdb_historian.py
+++ b/services/contrib/InfluxdbHistorian/tests/test_influxdb_historian.py
@@ -1332,7 +1332,7 @@ def test_update_config_store(volttron_instance, influxdb_client):
         publish_some_fake_data(publisher, 5)
 
         # Update config store
-        publisher.vip.rpc.call('config.store', 'manage_store', 'influxdb.historian', 'config',
+        publisher.vip.rpc.call('config.store', 'set_config', 'influxdb.historian', 'config',
                                jsonapi.dumps(updated_influxdb_config), config_type="json").get(timeout=10)
         publish_some_fake_data(publisher, 5)
 

--- a/services/core/DNP3Agent/tests/test_dnp3_agent.py
+++ b/services/core/DNP3Agent/tests/test_dnp3_agent.py
@@ -118,7 +118,7 @@ def add_definitions_to_config_store(test_agent):
     """Add PointDefinitions to the mesaagent's config store."""
     with open(POINT_DEFINITIONS_PATH, 'r') as f:
         points_json = jsonapi.loads(strip_comments(f.read()))
-    test_agent.vip.rpc.call('config.store', 'manage_store', DNP3_AGENT_ID,
+    test_agent.vip.rpc.call('config.store', 'set_config', DNP3_AGENT_ID,
                             'mesa_points.config', points_json, config_type='raw')
 
 

--- a/services/core/DNP3Agent/tests/test_mesa_agent.py
+++ b/services/core/DNP3Agent/tests/test_mesa_agent.py
@@ -100,11 +100,11 @@ def add_definitions_to_config_store(test_agent):
     """Add PointDefinitions and FunctionDefinitions to the mesaagent's config store."""
     with open(POINT_DEFINITIONS_PATH, 'r') as f:
         points_json = jsonapi.loads(strip_comments(f.read()))
-    test_agent.vip.rpc.call('config.store', 'manage_store', MESA_AGENT_ID,
+    test_agent.vip.rpc.call('config.store', 'set_config', MESA_AGENT_ID,
                             'mesa_points.config', points_json, config_type='raw')
     with open(FUNCTION_DEFINITIONS_PATH, 'r') as f:
         functions_json = yaml.safe_load(f.read())
-    test_agent.vip.rpc.call('config.store', 'manage_store', MESA_AGENT_ID,
+    test_agent.vip.rpc.call('config.store', 'set_config', MESA_AGENT_ID,
                             'mesa_functions.config', functions_json, config_type='raw')
 
 

--- a/services/core/IEEE2030_5Agent/tests/test_IEEE2030_5_agent.py
+++ b/services/core/IEEE2030_5Agent/tests/test_IEEE2030_5_agent.py
@@ -106,8 +106,8 @@ def agent(request, volttron_instance_module_web):
     capabilities = {'edit_config_store': {'identity': PLATFORM_DRIVER}}
     volttron_instance_module_web.add_capabilities(test_agent.core.publickey, capabilities)
     # Configure a IEEE 2030.5 device in the Platform Driver
-    test_agent.vip.rpc.call('config.store', 'manage_delete_store', PLATFORM_DRIVER).get(timeout=10)
-    test_agent.vip.rpc.call('config.store', 'manage_store', PLATFORM_DRIVER,
+    test_agent.vip.rpc.call('config.store', 'delete_store', PLATFORM_DRIVER).get(timeout=10)
+    test_agent.vip.rpc.call('config.store', 'set_config', PLATFORM_DRIVER,
                             'devices/{}'.format(DRIVER_NAME),
                             """{
                                 "driver_config": {
@@ -124,7 +124,7 @@ def agent(request, volttron_instance_module_web):
                                 "heart_beat_point": "Heartbeat"
                             }""",
                             'json').get(timeout=10)
-    test_agent.vip.rpc.call('config.store', 'manage_store', PLATFORM_DRIVER,
+    test_agent.vip.rpc.call('config.store', 'set_config', PLATFORM_DRIVER,
                             'IEEE2030_5.csv',
                             REGISTRY_CONFIG_STRING,
                             'csv').get(timeout=10)

--- a/services/core/IEEE2030_5Agent/tests/test_IEEE2030_5_driver.py
+++ b/services/core/IEEE2030_5Agent/tests/test_IEEE2030_5_driver.py
@@ -130,8 +130,8 @@ def agent(request, volttron_instance_module_web):
     test_agent = volttron_instance_module_web.build_agent()
 
     # Configure a IEEE 2030.5 device in the Platform Driver
-    test_agent.vip.rpc.call('config.store', 'manage_delete_store', 'platform.driver').get(timeout=10)
-    test_agent.vip.rpc.call('config.store', 'manage_store', 'platform.driver',
+    test_agent.vip.rpc.call('config.store', 'delete_store', 'platform.driver').get(timeout=10)
+    test_agent.vip.rpc.call('config.store', 'set_config', 'platform.driver',
                             'devices/{}'.format(DRIVER_NAME),
                             """{
                                 "driver_config": {
@@ -148,7 +148,7 @@ def agent(request, volttron_instance_module_web):
                                 "heart_beat_point": "Heartbeat"
                             }""",
                             'json').get(timeout=10)
-    test_agent.vip.rpc.call('config.store', 'manage_store', 'platform.driver',
+    test_agent.vip.rpc.call('config.store', 'set_config', 'platform.driver',
                             'IEEE2030_5.csv',
                             REGISTRY_CONFIG_STRING,
                             'csv').get(timeout=10)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/chargepoint/tests/test_chargepoint_driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/chargepoint/tests/test_chargepoint_driver.py
@@ -157,7 +157,7 @@ def agent(request, volttron_instance):
     md_agent = volttron_instance.build_agent()
     # Clean out platform driver configurations.
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           'platform.driver').get(timeout=10)
 
     driver1_config = DRIVER1_CONFIG_STRING % os.environ.get('CHARGEPOINT_PASSWORD', 'Must set a password')
@@ -166,21 +166,21 @@ def agent(request, volttron_instance):
 
     # Add test configurations.
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'devices/chargepoint1',
                           driver1_config,
                           'json').get(timeout=10)
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'devices/chargepoint2',
                           driver2_config,
                           'json').get(timeout=10)
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'chargepoint.csv',
                           REGISTRY_CONFIG_STRING,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/ecobee.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/ecobee.py
@@ -287,10 +287,10 @@ class Interface(BasicRevert, BaseInterface):
         :return: Fetch currently stored auth configuration info from config store, returns empty dict if none is
         present
         """
-        configs = self.vip.rpc.call(CONFIGURATION_STORE, "manage_list_configs", PLATFORM_DRIVER).get(timeout=3)
+        configs = self.vip.rpc.call(CONFIGURATION_STORE, "list_configs", PLATFORM_DRIVER).get(timeout=3)
         if self.auth_config_path in configs:
             return jsonapi.loads(self.vip.rpc.call(
-                CONFIGURATION_STORE, "manage_get", PLATFORM_DRIVER, self.auth_config_path).get(timeout=3))
+                CONFIGURATION_STORE, "get_config", PLATFORM_DRIVER, self.auth_config_path).get(timeout=3))
         else:
             _log.warning("No Ecobee auth file found in config store")
             return {}

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_battery_meter.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_battery_meter.py
@@ -282,12 +282,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           jsonapi.dumps(DRIVER_CONFIG),
@@ -295,14 +295,14 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           REGISTER_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_ion6200.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_ion6200.py
@@ -88,12 +88,12 @@ def ion_driver_agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/ion6200',
                           ION6200_DRIVER_CONFIG,
@@ -101,14 +101,14 @@ def ion_driver_agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'ion6200.csv',
                           ION6200_CSV_CONFIG,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'ion6200_map.csv',
                           ION6200_CSV_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_mixed_endian.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_mixed_endian.py
@@ -87,19 +87,19 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus',
                           ORIGINAL_DRIVER_CONFIG,
                           config_type='json')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           NEW_DRIVER_CONFIG,
@@ -107,21 +107,21 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus.csv',
                           ORIGINAL_REGISTRY_CONFIG,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           NEW_REGISTRY_CONFIG,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           NEW_REGISTER_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_modbus_tk_driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_modbus_tk_driver.py
@@ -111,19 +111,19 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           jsonapi.dumps(DRIVER_CONFIG),
                           config_type='json')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus',
                           jsonapi.dumps(OLD_VOLTTRON_DRIVER_CONFIG),
@@ -131,21 +131,21 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           REGISTER_MAP,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus.csv',
                           OLD_VOLTTRON_REGISTRY_CONFIG,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scale_reg.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scale_reg.py
@@ -58,12 +58,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           DRIVER_CONFIG_STRING,
@@ -71,22 +71,22 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           REGISTER_MAP,
                           config_type='csv')
 
     platform_uuid = volttron_instance.install_agent(agent_dir=get_services_core("PlatformDriverAgent"),
-                                                   config_file={},
-                                                   start=True)
+                                                    config_file={},
+                                                    start=True)
 
     gevent.sleep(10)  # wait for the agent to start and start the devices
 

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scale_reg_pow_10.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scale_reg_pow_10.py
@@ -58,12 +58,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           DRIVER_CONFIG_STRING,
@@ -71,14 +71,14 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           REGISTER_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scrape_all.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_scrape_all.py
@@ -101,19 +101,19 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus_tk',
                           jsonapi.dumps(DRIVER_CONFIG),
                           config_type='json')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus',
                           jsonapi.dumps(OLD_VOLTTRON_DRIVER_CONFIG),
@@ -121,21 +121,21 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus_tk_map.csv',
                           REGISTER_MAP,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus.csv',
                           OLD_VOLTTRON_REGISTRY_CONFIG,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_watts_on.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_watts_on.py
@@ -66,12 +66,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'devices/watts_on',
                           DRIVER_CONFIG_STRING,
@@ -79,14 +79,14 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'watts_on.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           'platform.driver',
                           'watts_on_map.csv',
                           REGISTRY_CONFIG_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_write_single_registers.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/tests/test_write_single_registers.py
@@ -56,12 +56,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/write_single_registers',
                           DRIVER_CONFIG_STRING,
@@ -69,14 +69,14 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'write_single_registers.csv',
                           REGISTRY_CONFIG_STRING,
                           config_type='csv')
 
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'write_single_registers_map.csv',
                           REGISTRY_CONFIG_MAP,

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/universal.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/universal.py
@@ -112,7 +112,7 @@ class Interface(BasicRevert, BaseInterface):
             which calls volttron/platform/store.py: def get_configs(self):
                 self.vip.rpc.call(identity, "config.initial_update" sets list of registry_configs
                 
-    scripts/install_platform_driver_configs.py calls 'manage_store' rpc, which is in volttron/platform/store.py
+    scripts/install_platform_driver_configs.py calls 'set_config' rpc, which is in volttron/platform/store.py
                     which calls process_raw_config(), which stores it as a dict.
                     process_raw_config() is also called by process_store() in store.py 
                     when the platform starts ( class ConfigStoreService):

--- a/services/core/PlatformDriverAgent/tests/test_bacnet.py
+++ b/services/core/PlatformDriverAgent/tests/test_bacnet.py
@@ -184,7 +184,7 @@ def config_store(config_store_connection):
 
     # registry config
     config_store_connection.call(
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         registry_config,
         registry_string,
@@ -201,7 +201,7 @@ def config_store(config_store_connection):
     }
 
     config_store_connection.call(
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         BACNET_DEVICE_TOPIC,
         driver_config,
@@ -210,5 +210,5 @@ def config_store(config_store_connection):
     yield config_store_connection
 
     print("Wiping out store.")
-    config_store_connection.call("manage_delete_store", PLATFORM_DRIVER)
+    config_store_connection.call("delete_store", PLATFORM_DRIVER)
     gevent.sleep(0.1)

--- a/services/core/PlatformDriverAgent/tests/test_device_groups.py
+++ b/services/core/PlatformDriverAgent/tests/test_device_groups.py
@@ -136,12 +136,12 @@ def test_agent(volttron_instance):
 
     # Clean out platform driver configurations
     # wait for it to return before adding new config
-    md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
+    md_agent.vip.rpc.call("config.store", "delete_store", PLATFORM_DRIVER).get()
 
     # Add a fake.csv to the config store
     md_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         "fake.csv",
         registry_config_string,
@@ -166,7 +166,7 @@ def setup_config(test_agent, config_name, config_string, **kwargs):
     print("Adding", config_name, "to store")
     test_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         config_name,
         config,
@@ -177,7 +177,7 @@ def setup_config(test_agent, config_name, config_string, **kwargs):
 def remove_config(test_agent, config_name):
     print("Removing", config_name, "from store")
     test_agent.vip.rpc.call(
-        "config.store", "manage_delete_config", PLATFORM_DRIVER, config_name
+        "config.store", "delete_config", PLATFORM_DRIVER, config_name
     ).get()
 
 

--- a/services/core/PlatformDriverAgent/tests/test_device_groups_p2.py
+++ b/services/core/PlatformDriverAgent/tests/test_device_groups_p2.py
@@ -195,12 +195,12 @@ def test_agent(volttron_instance):
 
     # Clean out platform driver configurations
     # wait for it to return before adding new config
-    md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
+    md_agent.vip.rpc.call("config.store", "delete_store", PLATFORM_DRIVER).get()
 
     # Add a fake.csv to the config store
     md_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         "fake.csv",
         registry_config_string,
@@ -225,7 +225,7 @@ def setup_config(test_agent, config_name, config_string, **kwargs):
     print("Adding", config_name, "to store")
     test_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         config_name,
         config,
@@ -236,5 +236,5 @@ def setup_config(test_agent, config_name, config_string, **kwargs):
 def remove_config(test_agent, config_name):
     print("Removing", config_name, "from store")
     test_agent.vip.rpc.call(
-        "config.store", "manage_delete_config", PLATFORM_DRIVER, config_name
+        "config.store", "delete_config", PLATFORM_DRIVER, config_name
     ).get()

--- a/services/core/PlatformDriverAgent/tests/test_eagle.py
+++ b/services/core/PlatformDriverAgent/tests/test_eagle.py
@@ -202,19 +202,19 @@ def agent(volttron_instance):
     volttron_instance.add_capabilities(agent.core.publickey, capabilities)
     # Clean out platform driver configurations.
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_delete_store',
+                       'delete_store',
                        PLATFORM_DRIVER).get(timeout=10)
 
     # Add test configurations.
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_store',
+                       'set_config',
                        PLATFORM_DRIVER,
                        "devices/campus/building/unit",
                        driver_config_string,
                        "json").get(timeout=10)
 
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_store',
+                       'set_config',
                        PLATFORM_DRIVER,
                        "eagle.json",
                        register_config_string,

--- a/services/core/PlatformDriverAgent/tests/test_ecobee_driver.py
+++ b/services/core/PlatformDriverAgent/tests/test_ecobee_driver.py
@@ -578,14 +578,14 @@ def test_scrape_all_trigger_refresh(mock_ecobee):
 #     }
 #     ecobee_driver_config = jsonapi.load(get_examples("configurations/drivers/ecobee.config"))
 #     ecobee_driver_config["interval"] = 3
-#     query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store", PLATFORM_DRIVER,
+#     query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config", PLATFORM_DRIVER,
 #                              "devices/campus/building/test_ecobee", driver_config)
 #
 #     with open("configurations/drivers/ecobee.csv") as registry_file:
 #         registry_string = registry_file.read()
 #     registry_path = re.search("(?!config:\/\/)[a-zA-z]+\.csv", ecobee_driver_config.get("registry_config"))
 #
-#     query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store", PLATFORM_DRIVER, registry_path, registry_string,
+#     query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config", PLATFORM_DRIVER, registry_path, registry_string,
 #                              config_type="csv")
 #
 #     ecobee_driver_config.update(driver_config)

--- a/services/core/PlatformDriverAgent/tests/test_global_override.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_override.py
@@ -88,12 +88,12 @@ def test_agent(volttron_instance):
 
     # Clean out platform driver configurations
     # wait for it to return before adding new config
-    md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
+    md_agent.vip.rpc.call("config.store", "delete_store", PLATFORM_DRIVER).get()
 
     # Add configuration for platform driver
     md_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         "config",
         jsonapi.dumps(PLATFORM_DRIVER_CONFIG),
@@ -108,7 +108,7 @@ def test_agent(volttron_instance):
         registry_config_string = f.read()
     md_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         "fake.csv",
         registry_config_string,
@@ -120,7 +120,7 @@ def test_agent(volttron_instance):
         config_name = f"devices/fakedriver{i}"
         md_agent.vip.rpc.call(
             "config.store",
-            "manage_store",
+            "set_config",
             PLATFORM_DRIVER,
             config_name,
             jsonapi.dumps(FAKE_DEVICE_CONFIG),
@@ -790,7 +790,7 @@ def test_override_pattern(test_agent):
     config_name = config_path.format(camel_device_path)
     test_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         config_name,
         jsonapi.dumps(FAKE_DEVICE_CONFIG),

--- a/services/core/PlatformDriverAgent/tests/test_global_settings.py
+++ b/services/core/PlatformDriverAgent/tests/test_global_settings.py
@@ -167,12 +167,12 @@ def test_agent(volttron_instance):
 
     # Clean out platform driver configurations
     # wait for it to return before adding new config
-    md_agent.vip.rpc.call("config.store", "manage_delete_store", PLATFORM_DRIVER).get()
+    md_agent.vip.rpc.call("config.store", "delete_store", PLATFORM_DRIVER).get()
 
     # Add a fake.csv to the config store
     md_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         "fake.csv",
         registry_config_string,
@@ -197,7 +197,7 @@ def setup_config(test_agent, config_name, config_string, **kwargs):
     print("Adding", config_name, "to store")
     test_agent.vip.rpc.call(
         "config.store",
-        "manage_store",
+        "set_config",
         PLATFORM_DRIVER,
         config_name,
         config,

--- a/services/core/PlatformDriverAgent/tests/test_modbus_driver.py
+++ b/services/core/PlatformDriverAgent/tests/test_modbus_driver.py
@@ -80,12 +80,12 @@ def agent(request, volttron_instance):
     # Clean out platform driver configurations
     # wait for it to return before adding new config
     md_agent.vip.rpc.call('config.store',
-                          'manage_delete_store',
+                          'delete_store',
                           PLATFORM_DRIVER).get()
 
     # Add driver configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'devices/modbus',
                           jsonapi.dumps(DRIVER_CONFIG),
@@ -93,7 +93,7 @@ def agent(request, volttron_instance):
 
     # Add csv configurations
     md_agent.vip.rpc.call('config.store',
-                          'manage_store',
+                          'set_config',
                           PLATFORM_DRIVER,
                           'modbus.csv',
                           REGISTRY_CONFIG_STRING,

--- a/services/core/PlatformDriverAgent/tests/test_rest_driver.py
+++ b/services/core/PlatformDriverAgent/tests/test_rest_driver.py
@@ -82,19 +82,19 @@ def agent(request, volttron_instance):
     capabilities = {'edit_config_store': {'identity': PLATFORM_DRIVER}}
     volttron_instance.add_capabilities(agent.core.publickey, capabilities)
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_delete_store',
+                       'delete_store',
                        PLATFORM_DRIVER).get(timeout=10)
 
     # Add test configurations.
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_store',
+                       'set_config',
                        PLATFORM_DRIVER,
                        "devices/campus/building/unit",
                        driver_config_dict_string,
                        "json").get(timeout=10)
 
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_store',
+                       'set_config',
                        PLATFORM_DRIVER,
                        "restful.csv",
                        restful_csv_string,

--- a/services/core/VolttronCentral/tests/test_vc_autoregister.py
+++ b/services/core/VolttronCentral/tests/test_vc_autoregister.py
@@ -32,12 +32,12 @@ def multi_messagebus_vc_vcp(volttron_multi_messagebus):
     # capabilities = {'edit_config_store': {'identity': VOLTTRON_CENTRAL_PLATFORM}}
     # vcp_instance.add_capabilities(vcp_instance.dynamic_agent.core.publickey, capabilities)
     vcp_instance.dynamic_agent.vip.rpc.call(CONFIGURATION_STORE,
-                                            "manage_store",
+                                            "set_config",
                                             VOLTTRON_CENTRAL_PLATFORM,
                                             "config",
                                             config,
                                             "json").get()
-    # "manage_store", opts.identity, opts.name, file_contents, config_type = opts.config_type
+    # "set_config", opts.identity, opts.name, file_contents, config_type = opts.config_type
     # Allows connections between platforms to be established.
     gevent.sleep(20)
     yield vcp_instance, vc_instance, vcp_uuid

--- a/services/core/VolttronCentralPlatform/tests/test_platform_agent_rpc.py
+++ b/services/core/VolttronCentralPlatform/tests/test_platform_agent_rpc.py
@@ -226,7 +226,7 @@ def test_can_change_topic_map(setup_platform, vc_agent):
 
     # now update the config store for vcp
     vc.vip.rpc.call(CONFIGURATION_STORE,
-                    'manage_store',
+                    'set_config',
                     VOLTTRON_CENTRAL_PLATFORM,
                     'config',
                     jsonapi.dumps(replace_map),
@@ -247,7 +247,7 @@ def test_can_change_topic_map(setup_platform, vc_agent):
 
     # now update the config store for vcp
     vc.vip.rpc.call(CONFIGURATION_STORE,
-                    'manage_store',
+                    'set_config',
                     VOLTTRON_CENTRAL_PLATFORM,
                     'config',
                     jsonapi.dumps(replace_map),

--- a/services/core/VolttronCentralPlatform/vcplatform/agent.py
+++ b/services/core/VolttronCentralPlatform/vcplatform/agent.py
@@ -812,21 +812,21 @@ class VolttronCentralPlatform(Agent):
     def store_agent_config(self, agent_identity, config_name, raw_contents,
                            config_type='raw'):
         _log.debug("Storeing configuration file: {}".format(config_name))
-        self.vip.rpc.call(CONFIGURATION_STORE, "manage_store", agent_identity,
+        self.vip.rpc.call(CONFIGURATION_STORE, "set_config", agent_identity,
                           config_name, raw_contents, config_type)
 
     def list_agent_configs(self, agent_identity):
-        return self.vip.rpc.call(CONFIGURATION_STORE, "manage_list_configs",
+        return self.vip.rpc.call(CONFIGURATION_STORE, "list_configs",
                                  agent_identity).get(timeout=5)
 
     def get_agent_config(self, agent_identity, config_name, raw=True):
-        data = self.vip.rpc.call(CONFIGURATION_STORE, "manage_get",
+        data = self.vip.rpc.call(CONFIGURATION_STORE, "get_config",
                                  agent_identity, config_name, raw).get(
             timeout=5)
         return data or ""
 
     def delete_agent_config(self, agent_identity, config_name):
-        data = self.vip.rpc.call(CONFIGURATION_STORE, "manage_delete_config",
+        data = self.vip.rpc.call(CONFIGURATION_STORE, "delete_config",
                                  agent_identity, config_name).get(
             timeout=5)
         return data or ""
@@ -977,7 +977,7 @@ class VolttronCentralPlatform(Agent):
         devices = defaultdict(dict)
         for platform_driver_id in self._platform_driver_ids:
             config_list = self.vip.rpc.call(CONFIGURATION_STORE,
-                                            'manage_list_configs',
+                                            'list_configs',
                                             platform_driver_id).get(timeout=5)
             _log.debug('Config list is: {}'.format(config_list))
 
@@ -987,7 +987,7 @@ class VolttronCentralPlatform(Agent):
                     continue
 
                 device_config = self.vip.rpc.call(CONFIGURATION_STORE,
-                                                  'manage_get',
+                                                  'get_config',
                                                   platform_driver_id,
                                                   cfg_name,
                                                   raw=False).get(timeout=5)
@@ -999,7 +999,7 @@ class VolttronCentralPlatform(Agent):
                     reg_cfg_name
                 ))
                 registry_config = self.vip.rpc.call(CONFIGURATION_STORE,
-                                                    'manage_get',
+                                                    'get_config',
                                                     platform_driver_id,
                                                     reg_cfg_name,
                                                     raw=False).get(timeout=5)

--- a/services/ops/ThresholdDetectionAgent/tests/test_threshold_detection.py
+++ b/services/ops/ThresholdDetectionAgent/tests/test_threshold_detection.py
@@ -109,7 +109,7 @@ class AlertWatcher(Agent):
 
     def reset_store(self):
         self.vip.rpc.call(CONFIGURATION_STORE,
-                          'manage_store',
+                          'set_config',
                           'platform.thresholddetection',
                           'config',
                           jsonapi.dumps(_test_config),
@@ -137,7 +137,7 @@ def threshold_tester_agent(volttron_instance):
 
     agent.reset_store()
     # agent.vip.rpc.call(CONFIGURATION_STORE,
-    #                    'manage_store',
+    #                    'set_config',
     #                    'platform.thresholddetection',
     #                    'config',
     #                    jsonapi.dumps(_test_config),
@@ -146,7 +146,7 @@ def threshold_tester_agent(volttron_instance):
     yield agent
 
     agent.vip.rpc.call(CONFIGURATION_STORE,
-                       'manage_delete_store',
+                       'delete_store',
                        'platform.thresholddetection').get()
     volttron_instance.remove_agent(threshold_detection_uuid)
 
@@ -211,7 +211,7 @@ def test_update_config(threshold_tester_agent):
     # threshold_tester_agent.vip.pubsub.publish('pubsub', topic="alerts/woot", headers={"foo": "bar"})
     # threshold_tester_agent.vip .config.set('config', updated_config, True)
     threshold_tester_agent.vip.rpc.call(CONFIGURATION_STORE,
-                                        'manage_store',
+                                        'set_config',
                                         'platform.thresholddetection',
                                         'config',
                                         jsonapi.dumps(updated_config),
@@ -254,7 +254,7 @@ def test_device_publish(threshold_tester_agent):
 
 def test_remove_from_config_store(threshold_tester_agent):
     threshold_tester_agent.vip.rpc.call(CONFIGURATION_STORE,
-                                        'manage_delete_config',
+                                        'delete_config',
                                         'platform.thresholddetection',
                                         'config').get()
     publish(threshold_tester_agent, _test_config, lambda x: x+1)

--- a/volttron/platform/auth/auth_entry.py
+++ b/volttron/platform/auth/auth_entry.py
@@ -39,7 +39,7 @@
 
 import logging
 import re
-from typing import Optional
+from typing import Optional, Union
 import uuid
 
 from volttron.platform.vip.socket import BASE64_ENCODED_CURVE_KEY_LEN
@@ -114,7 +114,7 @@ class AuthEntry(object):
             identity=None,
             groups=None,
             roles=None,
-            capabilities: Optional[dict] = None,
+            capabilities: Optional[Union[dict, str, list[Union[str, dict]]]] = None,
             rpc_method_authorizations=None,
             comments=None,
             enabled=True,
@@ -165,7 +165,7 @@ class AuthEntry(object):
         return List(String(elem) for elem in value)
 
     @staticmethod
-    def build_capabilities_field(value: Optional[dict]):
+    def build_capabilities_field(value: Union[dict, str, list[Union[str, dict]]]):
         # _log.debug("_build_capabilities {}".format(value))
 
         if not value:

--- a/volttron/platform/auth/auth_entry.py
+++ b/volttron/platform/auth/auth_entry.py
@@ -114,7 +114,7 @@ class AuthEntry(object):
             identity=None,
             groups=None,
             roles=None,
-            capabilities: Optional[Union[dict, str, list[Union[str, dict]]]] = None,
+            capabilities=None,
             rpc_method_authorizations=None,
             comments=None,
             enabled=True,
@@ -127,13 +127,10 @@ class AuthEntry(object):
         self.credentials = AuthEntry._build_field(credentials)
         self.groups = AuthEntry._build_field(groups) or []
         self.roles = AuthEntry._build_field(roles) or []
-        self.capabilities = (
-            AuthEntry.build_capabilities_field(capabilities) or {}
-        )
-        self.rpc_method_authorizations = (
-            AuthEntry.build_rpc_authorizations_field(rpc_method_authorizations)
-            or {}
-        )
+        self.capabilities = AuthEntry.build_capabilities_field(capabilities) or {}
+
+        self.rpc_method_authorizations = AuthEntry.build_rpc_authorizations_field(rpc_method_authorizations) or {}
+
         self.comments = AuthEntry._build_field(comments)
         if user_id is None:
             user_id = str(uuid.uuid4())
@@ -165,7 +162,7 @@ class AuthEntry(object):
         return List(String(elem) for elem in value)
 
     @staticmethod
-    def build_capabilities_field(value: Union[dict, str, list[Union[str, dict]]]):
+    def build_capabilities_field(value):
         # _log.debug("_build_capabilities {}".format(value))
 
         if not value:

--- a/volttron/platform/auth/auth_file.py
+++ b/volttron/platform/auth/auth_file.py
@@ -62,6 +62,7 @@ from volttron.platform.auth.auth_entry import AuthEntry, AuthEntryInvalid
 
 _log = logging.getLogger(__name__)
 
+
 class AuthFile(object):
     def __init__(self, auth_file=None):
         self.auth_data = {}
@@ -74,7 +75,7 @@ class AuthFile(object):
 
     @property
     def version(self):
-        return {"major": 1, "minor": 3}
+        return {"major": 1, "minor": 4}
 
     def _check_for_upgrade(self):
         auth_data = self._read()
@@ -268,6 +269,11 @@ class AuthFile(object):
             version["minor"] = 2
         if version["major"] == 1 and version["minor"] == 2:
             allow_list = upgrade_1_2_to_1_3(allow_list)
+            version["minor"] = 3
+        if version["major"] == 1 and version["minor"] == 3:
+            # on start a new entry for config.store should have got created automatically
+            # so just update version
+            version["minor"] = 4
 
         allow_entries, deny_entries = self._get_entries(allow_list, deny_list)
         self._write(allow_entries, deny_entries, groups, roles)

--- a/volttron/platform/control/control_config.py
+++ b/volttron/platform/control/control_config.py
@@ -57,7 +57,7 @@ def add_config_to_store(opts):
     file_contents = opts.infile.read()
 
     call(
-        "manage_store",
+        "set_config",
         opts.identity,
         opts.name,
         file_contents,
@@ -69,7 +69,7 @@ def delete_config_from_store(opts):
     opts.connection.peer = CONFIGURATION_STORE
     call = opts.connection.call
     if opts.delete_store:
-        call("manage_delete_store", opts.identity)
+        call("delete_store", opts.identity)
         return
 
     if opts.name is None:
@@ -79,7 +79,7 @@ def delete_config_from_store(opts):
         )
         return
 
-    call("manage_delete_config", opts.identity, opts.name)
+    call("delete_config", opts.identity, opts.name)
 
 
 def list_store(opts):
@@ -87,9 +87,9 @@ def list_store(opts):
     call = opts.connection.call
     results = []
     if opts.identity is None:
-        results = call("manage_list_stores")
+        results = call("list_stores")
     else:
-        results = call("manage_list_configs", opts.identity)
+        results = call("list_configs", opts.identity)
 
     for item in results:
         _stdout.write(item + "\n")
@@ -98,7 +98,7 @@ def list_store(opts):
 def get_config(opts):
     opts.connection.peer = CONFIGURATION_STORE
     call = opts.connection.call
-    results = call("manage_get", opts.identity, opts.name, raw=opts.raw)
+    results = call("get_config", opts.identity, opts.name, raw=opts.raw)
 
     if opts.raw:
         _stdout.write(results)
@@ -119,7 +119,7 @@ def edit_config(opts):
         raw_data = ""
     else:
         try:
-            results = call("manage_get_metadata", opts.identity, opts.name)
+            results = call("get_metadata", opts.identity, opts.name)
             config_type = results["type"]
             raw_data = results["data"]
         except RemoteError as e:
@@ -159,7 +159,7 @@ def edit_config(opts):
             return
 
         call(
-            "manage_store",
+            "set_config",
             opts.identity,
             opts.name,
             new_raw_data,

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -986,6 +986,14 @@ def start_volttron_process(opts):
                                           message_bus=opts.message_bus,
                                           enable_auth=opts.allow_auth)
 
+        if opts.allow_auth:
+            entry = AuthEntry(credentials=config_store.core.publickey,
+                              user_id=CONFIGURATION_STORE,
+                              identity=CONFIGURATION_STORE,
+                              capabilities='sync_agent_config',
+                              comments='Automatically added by platform on start')
+            AuthFile().add(entry, overwrite=True)
+
         # Launch additional services and wait for them to start before
         # auto-starting agents
         services = [
@@ -1277,12 +1285,13 @@ def setup_auth_service(opts, address, services):
     entry = AuthEntry(credentials=services[0].core.publickey,
                       user_id=CONTROL,
                       identity=CONTROL,
-                      capabilities=[{
-                          'edit_config_store': {
-                              'identity': '/.*/'
-                          }
-                      }, 'modify_rpc_method_allowance',
-                                    'allow_auth_modifications'],
+                      capabilities=[
+                          {
+                           'edit_config_store': {
+                              'identity': '/.*/'}
+                          },
+                          'modify_rpc_method_allowance',
+                          'allow_auth_modifications'],
                       comments='Automatically added by platform on start')
     AuthFile().add(entry, overwrite=True)
 

--- a/volttron/platform/store.py
+++ b/volttron/platform/store.py
@@ -271,7 +271,7 @@ class ConfigStoreService(Agent):
 
         return real_config
 
-    @RPC.allow('initialize_agent_config')
+    @RPC.allow('edit_config_store')
     @RPC.export
     def initialize_configs(self, identity):
         """

--- a/volttron/platform/store.py
+++ b/volttron/platform/store.py
@@ -44,8 +44,8 @@ import os.path
 import errno
 from csv import DictReader
 from io import StringIO
-
 import gevent
+from deprecated import deprecated
 
 from volttron.platform import jsonapi
 from gevent.lock import Semaphore
@@ -162,6 +162,18 @@ class ConfigStoreService(Agent):
 
     @RPC.export
     @RPC.allow('edit_config_store')
+    @deprecated(reason="Use set_config")
+    def manage_store(self, identity, config_name, raw_contents, config_type="raw", trigger_callback=True,
+                     send_update=True):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Please use set_config instead
+        """
+        contents = process_raw_config(raw_contents, config_type)
+        self._add_config_to_store(identity, config_name, raw_contents, contents, config_type,
+                                  trigger_callback=trigger_callback, send_update=send_update)
+
+    @RPC.export
+    @RPC.allow('edit_config_store')
     def set_config(self, identity, config_name, raw_contents, config_type="raw", trigger_callback=True,
                    send_update=True):
         contents = process_raw_config(raw_contents, config_type)
@@ -170,8 +182,26 @@ class ConfigStoreService(Agent):
 
     @RPC.export
     @RPC.allow('edit_config_store')
+    @deprecated(reason="Use delete_config")
+    def manage_delete_config(self, identity, config_name, trigger_callback=True, send_update=True):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Please use delete_config instead
+        """
+        self.delete(identity, config_name, trigger_callback=trigger_callback, send_update=send_update)
+
+    @RPC.export
+    @RPC.allow('edit_config_store')
     def delete_config(self, identity, config_name, trigger_callback=True, send_update=True):
         self.delete(identity, config_name, trigger_callback=trigger_callback, send_update=send_update)
+
+    @RPC.export
+    @RPC.allow('edit_config_store')
+    @deprecated(reason="Use delete_store")
+    def manage_delete_store(self, identity):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Please use delete_store instead
+        """
+        self.delete_store(identity)
 
     @RPC.export
     @RPC.allow('edit_config_store')
@@ -212,16 +242,40 @@ class ConfigStoreService(Agent):
             self.store.pop(identity, None)
 
     @RPC.export
+    @deprecated(reason="Use list_configs")
+    def manage_list_configs(self, identity):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Use list_configs instead
+        """
+        return self.list_configs(identity)
+
+    @RPC.export
     def list_configs(self, identity):
         result = list(self.store.get(identity, {}).get("store", {}).keys())
         result.sort()
         return result
 
     @RPC.export
+    @deprecated(reason="Use list_stores")
+    def manage_list_stores(self):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Use list_stores instead
+        """
+        return self.list_stores()
+
+    @RPC.export
     def list_stores(self):
         result = list(self.store.keys())
         result.sort()
         return result
+
+    @RPC.export
+    @deprecated(reason="Use get_config")
+    def manage_get(self, identity, config_name, raw=True):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Use get_config instead
+        """
+        return self.get_config(identity, config_name, raw)
 
     @RPC.export
     def get_config(self, identity, config_name, raw=True):
@@ -247,6 +301,14 @@ class ConfigStoreService(Agent):
         return agent_configs[real_config_name]
 
     @RPC.export
+    @deprecated(reason="Use get_metadata")
+    def manage_get_metadata(self, identity, config_name):
+        """
+        This method is deprecated and will be removed in VOLTTRON 10. Please use get_metadata instead
+        """
+        return self.get_metadata(identity, config_name)
+
+    @RPC.export
     def get_metadata(self, identity, config_name):
         agent_store = self.store.get(identity)
         if agent_store is None:
@@ -265,7 +327,7 @@ class ConfigStoreService(Agent):
 
         real_config =  agent_disk_store[real_config_name]
 
-        #Set modified to none if we predate the modified flag.
+        # Set modified to none if we predate the modified flag.
         if real_config.get("modified") is None:
             real_config["modified"] = None
 

--- a/volttron/platform/vip/agent/subsystems/configstore.py
+++ b/volttron/platform/vip/agent/subsystems/configstore.py
@@ -90,7 +90,9 @@ class ConfigStore(SubsystemBase):
 
         def onsetup(sender, **kwargs):
             rpc.export(self._update_config, 'config.update')
+            rpc.allow('config.update', 'sync_agent_config')
             rpc.export(self._initial_update, 'config.initial_update')
+            rpc.allow('config.initial_update', 'sync_agent_config')
 
         core.onsetup.connect(onsetup, self)
         core.configuration.connect(self._onconfig, self)

--- a/volttron/platform/vip/agent/subsystems/configstore.py
+++ b/volttron/platform/vip/agent/subsystems/configstore.py
@@ -47,6 +47,8 @@ from volttron.platform.storeutils import list_unique_links, check_for_config_lin
 from volttron.platform.vip.agent import errors
 from volttron.platform.agent.known_identities import CONFIGURATION_STORE
 from volttron.platform import jsonapi
+from volttron.platform.agent.utils import is_auth_enabled
+
 
 from collections import defaultdict
 from copy import deepcopy
@@ -90,9 +92,10 @@ class ConfigStore(SubsystemBase):
 
         def onsetup(sender, **kwargs):
             rpc.export(self._update_config, 'config.update')
-            rpc.allow('config.update', 'sync_agent_config')
             rpc.export(self._initial_update, 'config.initial_update')
-            rpc.allow('config.initial_update', 'sync_agent_config')
+            if is_auth_enabled():
+                rpc.allow('config.update', 'sync_agent_config')
+                rpc.allow('config.initial_update', 'sync_agent_config')
 
         core.onsetup.connect(onsetup, self)
         core.configuration.connect(self._onconfig, self)

--- a/volttron/platform/web/topic_tree.py
+++ b/volttron/platform/web/topic_tree.py
@@ -151,17 +151,17 @@ class DeviceTree(TopicTree):
     def from_store(cls, platform, rpc_caller):
         # TODO: Duplicate logic for external_platform check from VUIEndpoints to remove reference to it from here.
         kwargs = {'external_platform': platform} if 'VUIEndpoints' in rpc_caller.__repr__() else {}
-        devices = rpc_caller(CONFIGURATION_STORE, 'manage_list_configs', 'platform.driver', **kwargs)
+        devices = rpc_caller(CONFIGURATION_STORE, 'list_configs', 'platform.driver', **kwargs)
         devices = devices if kwargs else devices.get(timeout=5)
         devices = [d for d in devices if re.match('^devices/.*', d)]
         device_tree = cls(devices)
         for d in devices:
-            dev_config = rpc_caller(CONFIGURATION_STORE, 'manage_get', 'platform.driver', d, raw=False, **kwargs)
+            dev_config = rpc_caller(CONFIGURATION_STORE, 'get_config', 'platform.driver', d, raw=False, **kwargs)
             # TODO: If not AsyncResponse instead of if kwargs
             dev_config = dev_config if kwargs else dev_config.get(timeout=5)
             reg_cfg_name = dev_config.pop('registry_config')[len('config://'):]
             device_tree.update_node(d, data=dev_config, segment_type='DEVICE')
-            registry_config = rpc_caller('config.store', 'manage_get', 'platform.driver',
+            registry_config = rpc_caller('config.store', 'get_config', 'platform.driver',
                                          f'{reg_cfg_name}', raw=False, **kwargs)
             registry_config = registry_config if kwargs else registry_config.get(timeout=5)
             for pnt in registry_config:

--- a/volttron/platform/web/vui_endpoints.py
+++ b/volttron/platform/web/vui_endpoints.py
@@ -331,15 +331,15 @@ class VUIEndpoints:
             try:
                 if no_config_name:
                     if vip_identity != '-':
-                        setting_list = self._rpc('config.store', 'manage_list_configs', vip_identity,
+                        setting_list = self._rpc('config.store', 'list_configs', vip_identity,
                                                  external_platform=platform)
                         route_dict = self._links(path_info, setting_list)
                         return Response(json.dumps(route_dict), 200, content_type='application/json')
                     else:
-                        list_of_agents = self._rpc('config.store', 'manage_list_stores', external_platform=platform)
+                        list_of_agents = self._rpc('config.store', 'list_stores', external_platform=platform)
                         return Response(json.dumps(list_of_agents), 200, content_type='application/json')
                 elif not no_config_name:
-                    setting_dict = self._rpc('config.store', 'manage_get', vip_identity, config_name,
+                    setting_dict = self._rpc('config.store', 'get_config', vip_identity, config_name,
                                              external_platform=platform)
                     return Response(json.dumps(setting_dict), 200, content_type='application/json')
             except RemoteError as e:
@@ -356,7 +356,7 @@ class VUIEndpoints:
 
         elif request_method == 'POST' and no_config_name:
             if config_type in ['application/json', 'text/csv', 'text/plain']:
-                setting_list = self._rpc('config.store', 'manage_list_configs', vip_identity,
+                setting_list = self._rpc('config.store', 'list_configs', vip_identity,
                                          external_platform=platform)
                 if config_name in setting_list:
                     e = {'Error': f'Configuration: "{config_name}" already exists for agent: "{vip_identity}"'}
@@ -373,13 +373,13 @@ class VUIEndpoints:
         elif request_method == 'DELETE':
             if no_config_name:
                 try:
-                    self._rpc('config.store', 'manage_delete_store', vip_identity, external_platform=platform)
+                    self._rpc('config.store', 'delete_store', vip_identity, external_platform=platform)
                     return Response(None, 204, content_type='application/json')
                 except RemoteError as e:
                     return Response(json.dumps({"Error": f"{e}"}), 400, content_type='application/json')
             else:
                 try:
-                    self._rpc('config.store', 'manage_delete_config', vip_identity, config_name,
+                    self._rpc('config.store', 'delete_config', vip_identity, config_name,
                               external_platform=platform)
                     return Response(None, 204, content_type='application/json')
                 except RemoteError as e:
@@ -998,7 +998,7 @@ class VUIEndpoints:
                                                                                       'text/csv'] else 'raw'
         if config_type == 'json':
             data = json.dumps(data)
-        self._rpc('config.store', 'manage_store', vip_identity, config_name, data, config_type,
+        self._rpc('config.store', 'set_config', vip_identity, config_name, data, config_type,
                   external_platform=platform)
         return None
 

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -117,7 +117,7 @@ def volttron_instance_module_web(request):
                 params=[
                     dict(messagebus='zmq'),
                     pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
-                    pytest.param(dict(messagebus='zmq', auth_enabled=False))
+                    dict(messagebus='zmq', auth_enabled=False)
                 ])
 def volttron_instance(request, **kwargs):
     """Fixture that returns a single instance of volttron platform for testing

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -116,8 +116,8 @@ def volttron_instance_module_web(request):
 @pytest.fixture(scope="module",
                 params=[
                     dict(messagebus='zmq'),
-                    # pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
-                    # dict(messagebus='zmq', auth_enabled=False),
+                    pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
+                    pytest.param(dict(messagebus='zmq', auth_enabled=False))
                 ])
 def volttron_instance(request, **kwargs):
     """Fixture that returns a single instance of volttron platform for testing

--- a/volttrontesting/fixtures/volttron_platform_fixtures.py
+++ b/volttrontesting/fixtures/volttron_platform_fixtures.py
@@ -116,8 +116,8 @@ def volttron_instance_module_web(request):
 @pytest.fixture(scope="module",
                 params=[
                     dict(messagebus='zmq'),
-                    pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
-                    dict(messagebus='zmq', auth_enabled=False),
+                    # pytest.param(dict(messagebus='rmq', ssl_auth=True), marks=rmq_skipif),
+                    # dict(messagebus='zmq', auth_enabled=False),
                 ])
 def volttron_instance(request, **kwargs):
     """Fixture that returns a single instance of volttron platform for testing

--- a/volttrontesting/multiplatform/test_multiplatform_pubsub.py
+++ b/volttrontesting/multiplatform/test_multiplatform_pubsub.py
@@ -544,14 +544,14 @@ def test_multiplatform_configstore_rpc(request, get_volttron_instances):
     test_agent = p2.build_agent()
     kwargs = {"external_platform": p1.instance_name}
     test_agent.vip.rpc.call(CONFIGURATION_STORE,
-                            'manage_store',
+                            'set_config',
                             'platform.thresholddetection',
                             'config',
                             jsonapi.dumps(updated_config),
                             'json',
                             **kwargs).get(timeout=10)
     config = test_agent.vip.rpc.call(CONFIGURATION_STORE,
-                                     'manage_get',
+                                     'get_config',
                                      'platform.thresholddetection',
                                      'config',
                                      raw=True,

--- a/volttrontesting/platform/security/SecurityAgent/security/agent.py
+++ b/volttrontesting/platform/security/SecurityAgent/security/agent.py
@@ -244,7 +244,7 @@ class SecurityAgent(Agent):
         """
         error = None
         try:
-            self.vip.rpc.call('config.store', 'manage_store', "security_agent", 'config',
+            self.vip.rpc.call('config.store', 'set_config', "security_agent", 'config',
                               json.dumps({"name": "value"}), config_type='json').get(timeout=2)
         except Exception as e:
             error = str(e)
@@ -253,12 +253,12 @@ class SecurityAgent(Agent):
             return error
 
         try:
-            self.vip.rpc.call('config.store', 'manage_store', agent2_identity, 'config',
+            self.vip.rpc.call('config.store', 'set_config', agent2_identity, 'config',
                               json.dumps({"test": "value"}), config_type='json').get(timeout=10)
             error = "Security agent is able to edit  config store entry of security_agent2"
         except Exception as e:
             error = e.message
-            if error == "User can call method manage_store only with identity=security_agent " \
+            if error == "User can call method set_config only with identity=security_agent " \
                         "but called with identity={}".format(agent2_identity):
                error = None
 

--- a/volttrontesting/platform/web/test_topic_tree.py
+++ b/volttrontesting/platform/web/test_topic_tree.py
@@ -241,17 +241,17 @@ def test_devices(nid, expected):
 
 
 def _mock_rpc_caller(peer, method, agent, file_name=None, raw=False, external_platform=None):
-    if method == 'manage_list_configs':
+    if method == 'list_configs':
         return ['config', 'devices/Campus/Building1/Fake1', 'devices/Campus/Building2/Fake1',
                 'devices/Campus/Building3/Fake1', 'registry_configs/fake.csv']
-    elif method == 'manage_get' and '.csv' in file_name:
+    elif method == 'get_config' and '.csv' in file_name:
         return [{'Point Name': 'SampleBool1',  'Volttron Point Name': 'SampleBool1',  'Units': 'On / Off',
                  'Units Details': 'on/off',  'Writable': 'FALSE',  'Starting Value': 'TRUE',  'Type': 'boolean',
                  'Notes': 'Status indidcator of cooling stage 1'},
                 {'Point Name': 'SampleWritableFloat1', 'Volttron Point Name': 'SampleWritableFloat1',  'Units': 'PPM',
                  'Units Details': '1000.00 (default)',  'Writable': 'TRUE',  'Starting Value': '10',  'Type': 'float',
                  'Notes': 'Setpoint to enable demand control ventilation'}]
-    elif method == 'manage_get' and '.csv' not in file_name:
+    elif method == 'get_config' and '.csv' not in file_name:
         return {'driver_config': {},  'registry_config': 'config://registry_configs/fake.csv', 'interval': 60,
                 'timezone': 'US/Pacific', 'driver_type': 'fakedriver', 'publish_breadth_first_all': False,
                 'publish_depth_first': False, 'publish_breadth_first': False, 'campus': 'campus',

--- a/volttrontesting/platform/web/test_vui_endpoints.py
+++ b/volttrontesting/platform/web/test_vui_endpoints.py
@@ -277,16 +277,16 @@ def _mock_agents_rpc(peer, meth, *args, external_platform=None, **kwargs):
                                                                'config2': {'setting1': 3, 'setting2': 4}}},
                               {'identity': 'run2', 'configs': {'config1': {'setting1': 5, 'setting2': 6},
                                                                'config2': {'setting1': 7, 'setting2': 8}}}]
-    if peer == 'config.store' and meth == 'manage_get':
+    if peer == 'config.store' and meth == 'get_config':
         config_list = [a['configs'].get(args[1]) for a in config_definition_list if a['identity'] == args[0]]
         if not config_list or config_list == [None]:
             raise RemoteError(f'''builtins.KeyError('No configuration file \"{args[1]}\" for VIP IDENTIY {args[0]}')''',
                               exc_info={"exc_type": '', "exc_args": []})
         return config_list[0] if config_list else []
-    elif peer == 'config.store' and meth == 'manage_list_configs':
+    elif peer == 'config.store' and meth == 'list_configs':
         config_list = [a['configs'].keys() for a in config_definition_list if a['identity'] == args[0]]
         return config_list[0] if config_list else []
-    elif peer == 'config.store' and meth == 'manage_list_stores':
+    elif peer == 'config.store' and meth == 'list_stores':
         return [a['identity'] for a in config_definition_list]
     elif peer == 'control' and meth == 'list_agents':
         return list_of_agents
@@ -458,7 +458,7 @@ def test_handle_platforms_agents_configs_config_put_response(mock_platform_web_s
     config_type = re.search(r'([^\/]+$)', config_type).group() if config_type in ['application/json',
                                                                                   'text/csv'] else 'raw'
     if status == '204':
-        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'manage_store', vip_identity, config_name,
+        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'set_config', vip_identity, config_name,
                                                        data_passed, config_type, external_platform='my_instance_name')])
     elif status == '400':
         assert json.loads(response.response[0]) == \
@@ -488,7 +488,7 @@ def test_handle_platforms_agents_configs_post_response(mock_platform_web_service
     response = vui_endpoints.handle_platforms_agents_configs(env, data_given)
     check_response_codes(response, status)
     if status == '204':
-        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'manage_store', vip_identity, config_name,
+        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'set_config', vip_identity, config_name,
                                                        data_passed, config_type, external_platform='my_instance_name')])
     elif status == '400':
         assert json.loads(response.response[0]) == \
@@ -510,7 +510,7 @@ def test_handle_platforms_agents_configs_delete_response(mock_platform_web_servi
     response = vui_endpoints.handle_platforms_agents_configs(env, {})
     check_response_codes(response, status)
     if status == '204':
-        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'manage_delete_store', vip_identity_passed,
+        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'delete_store', vip_identity_passed,
                                                        external_platform='my_instance_name')])
 
 
@@ -526,7 +526,7 @@ def test_handle_platforms_agents_configs_config_delete_response(mock_platform_we
     response = vui_endpoints.handle_platforms_agents_configs(env, {})
     check_response_codes(response, status)
     if status == '204':
-        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'manage_delete_config', vip_identity,
+        vui_endpoints._rpc.assert_has_calls([mock.call('config.store', 'delete_config', vip_identity,
                                                        config_name_passed, external_platform='my_instance_name')])
 
 

--- a/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
+++ b/volttrontesting/services/aggregate_historian/test_aggregate_historian.py
@@ -490,7 +490,7 @@ def test_get_supported_aggregations(aggregate_agent, query_agent):
     :param query_agent: fake agent used to query historian
     :return:
     """
-    query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+    query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                              AGG_AGENT_VIP, "config",
                              aggregate_agent).get()
     gevent.sleep(1)
@@ -565,7 +565,7 @@ def test_single_topic_pattern(aggregate_agent, query_agent):
              ]
              }
         ]
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
         gevent.sleep(1)
@@ -668,7 +668,7 @@ def test_single_topic(aggregate_agent, query_agent):
                 ]
             }
         ]
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
         gevent.sleep(3 * 60)  # sleep till we see two rows in aggregate table
@@ -841,7 +841,7 @@ def test_multiple_topic_pattern(aggregate_agent, query_agent):
              }
         ]
 
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
         gevent.sleep(1)
@@ -914,7 +914,7 @@ def test_multiple_topic_list(aggregate_agent, query_agent):
              }
         ]
 
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
         gevent.sleep(1)
@@ -991,7 +991,7 @@ def test_topic_reconfiguration(aggregate_agent, query_agent):
              }
         ]
 
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
         gevent.sleep(2)
@@ -1037,7 +1037,7 @@ def test_topic_reconfiguration(aggregate_agent, query_agent):
 
         print("Before reinstall current time is {}".format(datetime.utcnow()))
 
-        query_agent.vip.rpc.call(CONFIGURATION_STORE, "manage_store",
+        query_agent.vip.rpc.call(CONFIGURATION_STORE, "set_config",
                                  AGG_AGENT_VIP, "config",
                                  new_config).get()
 

--- a/volttrontesting/services/historian/test_base_historian.py
+++ b/volttrontesting/services/historian/test_base_historian.py
@@ -388,7 +388,7 @@ def test_time_tolerance_check(request, volttron_instance, client_agent):
         # Change config to modify topic for time tolerance check
         historian.publish_sleep = 0
         json_config = """{"time_tolerance_topics":["record"]}"""
-        historian.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+        historian.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                identity, "config", json_config, config_type="json").get()
         gevent.sleep(2)
 

--- a/volttrontesting/subsystems/test_config_store.py
+++ b/volttrontesting/subsystems/test_config_store.py
@@ -66,6 +66,14 @@ def _module_config_test_agent(request, volttron_instance):
     agent = volttron_instance.build_agent(identity='config_test_agent',
                                           agent_class=_config_test_agent,
                                           enable_store=True)
+    # wait for config store's onconnect method to complete. onconnect calls handle_callback we don't want this
+    # to interfere with tests that test the trigger_callback mechanism
+    # Quote from config store documentation:
+    #
+    # As the configuration subsystem calls all callbacks in the onconfig phase and none are called beforehand
+    # the trigger_callback setting is effectively ignored if an agent sets a configuration or default configuration
+    # before the end of the onstart phase.
+    gevent.sleep(3)
 
     def cleanup():
         agent.core.stop()
@@ -78,7 +86,7 @@ def _module_config_test_agent(request, volttron_instance):
 def config_test_agent(request, _module_config_test_agent, volttron_instance):
 
     def cleanup():
-        _module_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', 'config_test_agent').get()
+        _module_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', 'config_test_agent').get()
 
     request.addfinalizer(cleanup)
     return _module_config_test_agent
@@ -101,9 +109,9 @@ def default_config_test_agent(request, config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_store_json(default_config_test_agent):
+def test_set_config_json(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     results = default_config_test_agent.callback_results
@@ -113,9 +121,9 @@ def test_manage_store_json(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_store_csv(default_config_test_agent):
+def test_set_config_csv(default_config_test_agent):
     csv_config = "value\n1"
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", csv_config, config_type="csv").get()
 
     results = default_config_test_agent.callback_results
@@ -125,9 +133,9 @@ def test_manage_store_csv(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_store_raw(default_config_test_agent):
+def test_set_config_raw(default_config_test_agent):
     raw_config = "test_config_stuff"
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", raw_config, config_type="raw").get()
 
     results = default_config_test_agent.callback_results
@@ -137,9 +145,9 @@ def test_manage_store_raw(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_update_config(default_config_test_agent):
+def test_update_config(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     results = default_config_test_agent.callback_results
@@ -148,7 +156,7 @@ def test_manage_update_config(default_config_test_agent):
     assert first == ("config", "NEW", {"value": 1})
 
     json_config = """{"value":2}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     assert len(results) == 2
@@ -157,16 +165,16 @@ def test_manage_update_config(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_delete_config(default_config_test_agent):
+def test_delete_config(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     results = default_config_test_agent.callback_results
     assert len(results) == 1
     first = results[0]
     assert first == ("config", "NEW", {"value": 1})
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_config',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_config',
                                            "config_test_agent", "config").get()
     assert len(results) == 2
     second = results[1]
@@ -174,70 +182,70 @@ def test_manage_delete_config(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_manage_delete_store(default_config_test_agent):
+def test_delete_store(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     results = default_config_test_agent.callback_results
     assert len(results) == 1
     first = results[0]
     assert first == ("config", "NEW", {"value": 1})
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', "config_test_agent").get()
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', "config_test_agent").get()
     assert len(results) == 2
     second = results[1]
     assert second == ("config", "DELETE", None)
 
 
 @pytest.mark.config_store
-def test_manage_get_config(config_test_agent):
+def test_get_config(config_test_agent):
     json_config = """{"value":1}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config", json_config, config_type="json").get()
 
-    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get',
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'get_config',
                                             "config_test_agent", "config", raw=False).get()
 
     assert config == {"value": 1}
 
 
 @pytest.mark.config_store
-def test_manage_get_raw_config(config_test_agent):
+def test_get_raw_config(config_test_agent):
     json_config = """{"value":1}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config", json_config, config_type="json").get()
 
-    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get',
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'get_config',
                                             "config_test_agent", "config", raw=True).get()
 
     assert config == json_config
 
 
 @pytest.mark.config_store
-def test_manage_list_config(config_test_agent):
+def test_list_config(config_test_agent):
     json_config = """{"value":1}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config1", json_config, config_type="json").get()
     json_config = """{"value":2}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config2", json_config, config_type="json").get()
     json_config = """{"value":3}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config3", json_config, config_type="json").get()
 
-    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_list_configs',
+    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'list_configs',
                                                  "config_test_agent").get()
 
     assert config_list == ['config1', 'config2', 'config3']
 
 
 @pytest.mark.config_store
-def test_manage_list_store(config_test_agent):
+def test_list_store(config_test_agent):
     json_config = """{"value":1}"""
-    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config1", json_config, config_type="json").get()
 
-    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_list_stores').get()
+    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'list_stores').get()
 
     assert "config_test_agent" in config_list
 
@@ -245,13 +253,13 @@ def test_manage_list_store(config_test_agent):
 @pytest.mark.config_store
 def test_agent_list_config(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config1", json_config, config_type="json").get()
     json_config = """{"value":2}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config2", json_config, config_type="json").get()
     json_config = """{"value":3}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config3", json_config, config_type="json").get()
 
     config_list = default_config_test_agent.vip.config.list()
@@ -262,7 +270,7 @@ def test_agent_list_config(default_config_test_agent):
 @pytest.mark.config_store
 def test_agent_get_config(default_config_test_agent):
     json_config = """{"value":1}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                            "config_test_agent", "config", json_config, config_type="json").get()
 
     config = default_config_test_agent.vip.config.get("config")
@@ -273,7 +281,7 @@ def test_agent_get_config(default_config_test_agent):
 @pytest.mark.config_store
 def test_agent_reference_config_and_callback_order(default_config_test_agent):
     json_config = """{"config2":"config://config2", "config3":"config://config3"}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
 
     config = default_config_test_agent.vip.config.get("config")
@@ -281,7 +289,7 @@ def test_agent_reference_config_and_callback_order(default_config_test_agent):
     assert config == {"config2":None, "config3":None}
 
     json_config = """{"value":2}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config2", json_config, config_type="json").get()
 
     # Also use th to verify that the callback for "config" is called first.
@@ -289,7 +297,7 @@ def test_agent_reference_config_and_callback_order(default_config_test_agent):
     default_config_test_agent.reset_results()
 
     json_config = """{"value":3}"""
-    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config3", json_config, config_type="json").get()
 
     config = default_config_test_agent.vip.config.get("config")
@@ -304,12 +312,13 @@ def test_agent_reference_config_and_callback_order(default_config_test_agent):
     second = results[1]
     assert second == ("config3", "NEW", {"value": 3})
 
+
 @pytest.mark.config_store
-def test_agent_set_config(default_config_test_agent):
-    json_config = {"value":1}
+def test_agent_set_config(default_config_test_agent, volttron_instance):
+    json_config = {"value": 1}
 
     default_config_test_agent.vip.config.set("config", json_config)
-
+    gevent.sleep(5)  # wait to avoid case where we are simply missing the callback
     results = default_config_test_agent.callback_results
     assert len(results) == 0
 
@@ -318,7 +327,7 @@ def test_agent_set_config(default_config_test_agent):
     assert config == {"value": 1}
 
     default_config_test_agent.vip.config.set("config", json_config, trigger_callback=True)
-
+    gevent.sleep(5)
     results = default_config_test_agent.callback_results
     assert len(results) == 1
     first = results[0]
@@ -360,7 +369,7 @@ def test_agent_default_config(request, volttron_instance):
 
     def cleanup():
         if agent:
-            agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', 'test_default_agent').get()
+            agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', 'test_default_agent').get()
             agent.core.stop()
 
     request.addfinalizer(cleanup)
@@ -383,14 +392,14 @@ def test_agent_default_config(request, volttron_instance):
     result = results[0]
     assert result == ("config", "NEW", {"value": 2})
 
-    agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+    agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                        "test_default_agent", "config", '{"value": 1}', config_type="json").get()
 
     assert len(results) == 2
     result = results[-1]
     assert result == ("config", "UPDATE", {"value": 1})
 
-    agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_config', "test_default_agent", "config").get()
+    agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_config', "test_default_agent", "config").get()
 
     assert len(results) == 3
     result = results[-1]
@@ -401,7 +410,7 @@ def test_agent_default_config(request, volttron_instance):
 def test_agent_sub_options(request, volttron_instance):
 
     def cleanup():
-        agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', 'test_agent_sub_options').get()
+        agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', 'test_agent_sub_options').get()
         agent.core.stop()
 
     request.addfinalizer(cleanup)
@@ -424,13 +433,13 @@ def test_agent_sub_options(request, volttron_instance):
     update_json = """{"value": 2}"""
 
     for name in ("new/config", "update/config", "delete/config"):
-        agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+        agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                            "test_agent_sub_options", name, new_json, config_type="json").get()
 
-        agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+        agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                            "test_agent_sub_options", name, update_json, config_type="json").get()
 
-        agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_config',
+        agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_config',
                            "test_agent_sub_options", name).get()
 
     results = agent.callback_results
@@ -456,9 +465,9 @@ def test_config_store_security(volttron_instance, default_config_test_agent):
 
         # By default agents should have access to edit their own config store
         json_config = """{"value":1}"""
-        agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store', "rpc_agent", "config", json_config,
+        agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config', "rpc_agent", "config", json_config,
                            config_type="json").get()
-        config = agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get', "rpc_agent", "config", raw=False).get()
+        config = agent.vip.rpc.call(CONFIGURATION_STORE, 'get_config', "rpc_agent", "config", raw=False).get()
 
         assert config == {"value": 1}
 
@@ -466,20 +475,20 @@ def test_config_store_security(volttron_instance, default_config_test_agent):
         # default_config_test_agent unless explicitly granted permissions
         try:
             json_config = """{"value":1}"""
-            agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store', "config_test_agent", "config",
+            agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config', "config_test_agent", "config",
                                json_config, config_type="json").get()
         except jsonrpc.RemoteError as e:
-            assert e.message == "User rpc_agent can call method manage_store only with " \
+            assert e.message == "User rpc_agent can call method set_config only with " \
                                 "identity=rpc_agent but called with identity=config_test_agent"
 
         try:
-            agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', 'config_test_agent').get()
+            agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', 'config_test_agent').get()
         except jsonrpc.RemoteError as e:
-            assert e.message == "User rpc_agent can call method manage_delete_store only with " \
+            assert e.message == "User rpc_agent can call method delete_store only with " \
                                 "identity=rpc_agent but called with identity=config_test_agent"
 
         # Should be able to view
-        result = agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_list_configs', "config_test_agent").get()
+        result = agent.vip.rpc.call(CONFIGURATION_STORE, 'list_configs', "config_test_agent").get()
         print(result)
 
     finally:

--- a/volttrontesting/subsystems/test_config_store.py
+++ b/volttrontesting/subsystems/test_config_store.py
@@ -121,6 +121,18 @@ def test_set_config_json(default_config_test_agent):
 
 
 @pytest.mark.config_store
+def test_manage_store_json(default_config_test_agent):
+    json_config = """{"value":1}"""
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_store',
+                                           "config_test_agent", "config", json_config, config_type="json").get()
+
+    results = default_config_test_agent.callback_results
+    assert len(results) == 1
+    first = results[0]
+    assert first == ("config", "NEW", {"value": 1})
+
+
+@pytest.mark.config_store
 def test_set_config_csv(default_config_test_agent):
     csv_config = "value\n1"
     default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
@@ -182,7 +194,7 @@ def test_delete_config(default_config_test_agent):
 
 
 @pytest.mark.config_store
-def test_delete_store(default_config_test_agent):
+def test_manage_delete_config(default_config_test_agent):
     json_config = """{"value":1}"""
     default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                            "config_test_agent", "config", json_config, config_type="json").get()
@@ -191,7 +203,42 @@ def test_delete_store(default_config_test_agent):
     assert len(results) == 1
     first = results[0]
     assert first == ("config", "NEW", {"value": 1})
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_config',
+                                           "config_test_agent", "config").get()
+    assert len(results) == 2
+    second = results[1]
+    assert second == ("config", "DELETE", None)
+
+
+@pytest.mark.config_store
+def test_delete_store(default_config_test_agent):
+    json_config = """{"value":1}"""
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                           "config_test_agent", "config", json_config, config_type="json").get()
+
+    results = default_config_test_agent.callback_results
+    print(f"callback results is {results}")
+    assert len(results) == 1
+    first = results[0]
+    assert first == ("config", "NEW", {"value": 1})
     default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'delete_store', "config_test_agent").get()
+    assert len(results) == 2
+    second = results[1]
+    assert second == ("config", "DELETE", None)
+
+
+@pytest.mark.config_store
+def test_manage_delete_store(default_config_test_agent):
+    json_config = """{"value":1}"""
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                           "config_test_agent", "config", json_config, config_type="json").get()
+
+    results = default_config_test_agent.callback_results
+    print(f"callback results is {results}")
+    assert len(results) == 1
+    first = results[0]
+    assert first == ("config", "NEW", {"value": 1})
+    default_config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_delete_store', "config_test_agent").get()
     assert len(results) == 2
     second = results[1]
     assert second == ("config", "DELETE", None)
@@ -210,12 +257,74 @@ def test_get_config(config_test_agent):
 
 
 @pytest.mark.config_store
+def test_manage_get_config(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config", json_config, config_type="json").get()
+
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get',
+                                            "config_test_agent", "config", raw=False).get()
+
+    assert config == {"value": 1}
+
+
+@pytest.mark.config_store
+def test_get_metadata(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config", json_config, config_type="json").get()
+
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'get_config',
+                                            "config_test_agent", "config", raw=False).get()
+
+    assert config == {"value": 1}
+
+    metadata = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'get_metadata',
+                                              "config_test_agent", "config").get()
+    print(f"Metadata {metadata}")
+    assert metadata["type"] == "json"
+    assert metadata["modified"]
+    assert metadata["data"] == '{"value":1}'
+
+
+@pytest.mark.config_store
+def test_manage_get_metadata(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config", json_config, config_type="json").get()
+
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get',
+                                            "config_test_agent", "config", raw=False).get()
+
+    assert config == {"value": 1}
+
+    metadata = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get_metadata',
+                                              "config_test_agent", "config").get()
+    print(f"Metadata {metadata}")
+    assert metadata["type"] == "json"
+    assert metadata["modified"]
+    assert metadata["data"] == '{"value":1}'
+
+
+@pytest.mark.config_store
 def test_get_raw_config(config_test_agent):
     json_config = """{"value":1}"""
     config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config", json_config, config_type="json").get()
 
     config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'get_config',
+                                            "config_test_agent", "config", raw=True).get()
+
+    assert config == json_config
+
+
+@pytest.mark.config_store
+def test_manage_get_raw_config(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config", json_config, config_type="json").get()
+
+    config = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_get',
                                             "config_test_agent", "config", raw=True).get()
 
     assert config == json_config
@@ -240,12 +349,41 @@ def test_list_config(config_test_agent):
 
 
 @pytest.mark.config_store
+def test_manage_list_config(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config1", json_config, config_type="json").get()
+    json_config = """{"value":2}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config2", json_config, config_type="json").get()
+    json_config = """{"value":3}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config3", json_config, config_type="json").get()
+
+    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_list_configs',
+                                                 "config_test_agent").get()
+
+    assert config_list == ['config1', 'config2', 'config3']
+
+
+@pytest.mark.config_store
 def test_list_store(config_test_agent):
     json_config = """{"value":1}"""
     config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
                                    "config_test_agent", "config1", json_config, config_type="json").get()
 
     config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'list_stores').get()
+
+    assert "config_test_agent" in config_list
+
+
+@pytest.mark.config_store
+def test_manage_list_store(config_test_agent):
+    json_config = """{"value":1}"""
+    config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'set_config',
+                                   "config_test_agent", "config1", json_config, config_type="json").get()
+
+    config_list = config_test_agent.vip.rpc.call(CONFIGURATION_STORE, 'manage_list_stores').get()
 
     assert "config_test_agent" in config_list
 

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -305,9 +305,6 @@ class PlatformWrapper:
         # with older 2.0 agents.
         self.opts = None
 
-        keystorefile = os.path.join(self.volttron_home, 'keystore')
-        self.keystore = KeyStore(keystorefile)
-        self.keystore.generate()
         self.messagebus = messagebus if messagebus else 'zmq'
         # Regardless of what is passed in if using rmq we need auth and ssl.
         if self.messagebus == 'rmq':


### PR DESCRIPTION
1. Fixed issue #3097 
2. As side effect deprecated the duplicate manage_* RPC methods
3. Updated all core agents and test to not use the deprecated methods
4. Updated documentation
5. Updated config store test case for both new methods and deprecated methods
6. Added config store tests for get_metadata method