### PR TITLE
Fixed home assistant tests

### DIFF
--- a/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
+++ b/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
@@ -61,11 +61,11 @@ Registry Configuration
 +++++++++++++++++++++++
 
 Registry file can contain one single device and its attributes or a logical group of devices and its
-attributes. Each entry should include the full entity id of the device, including but not limited to home assistant provided prefix 
+attributes. Each entry should include the full entity id of the device, including but not limited to home assistant provided prefix
 such as "light.",  "climate." etc. The driver uses these prefixes to convert states into integers.
 Like mentioned before, the driver can only control lights and thermostats but can get data from all devices
 controlled by home assistant
- 
+
 Each entry in a registry file should also have a 'Entity Point' and a unique value for 'Volttron Point Name'. The 'Entity ID' maps to the device instance, the 'Entity Point' extracts the attribute or state, and 'Volttron Point Name' determines the name of that point as it appears in VOLTTRON.
 
 Attributes can be located in the developer tools in the Home Assistant GUI.
@@ -108,7 +108,7 @@ id 'light.example':
 .. note::
 
 When using a single registry file to represent a logical group of multiple physical entities, make sure the
-"Volttron Point Name" is unique within a single registry file. 
+"Volttron Point Name" is unique within a single registry file.
 
 For example, if a registry file contains entities with
 id  'light.instance1' and 'light.instance2' the entry for the attribute brightness for these two light instances could
@@ -175,3 +175,12 @@ Upon completion, initiate the platform driver. Utilize the listener agent to ver
    [{'light_brightness': 254, 'state': 'on'},
     {'light_brightness': {'type': 'integer', 'tz': 'UTC', 'units': 'int'},
      'state': {'type': 'integer', 'tz': 'UTC', 'units': 'On / Off'}}]
+
+Running Tests
++++++++++++++++++++++++
+To run tests on the VOLTTRON home assistant driver you need to create a helper in your home assistant instance. This can be done by going to **Settings > Devices & services > Helpers > Create Helper > Toggle**. Name this new toggle **volttrontest**. After that run the pytest from the root of your VOLTTRON file.
+
+.. code-block:: bash
+    pytest volttron/services/core/PlatformDriverAgent/tests/test_home_assistant.py
+
+If everything works, you will see 6 passed tests.

--- a/services/core/PlatformDriverAgent/tests/test_home_assistant.py
+++ b/services/core/PlatformDriverAgent/tests/test_home_assistant.py
@@ -1,26 +1,41 @@
 # -*- coding: utf-8 -*- {{{
-# ===----------------------------------------------------------------------===
+# vim: set fenc=utf-8 ft=python sw=4 ts=4 sts=4 et:
 #
-#                 Component of Eclipse VOLTTRON
+# Copyright 2020, Battelle Memorial Institute.
 #
-# ===----------------------------------------------------------------------===
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Copyright 2023 Battelle Memorial Institute
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy
-# of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
-# ===----------------------------------------------------------------------===
+# This material was prepared as an account of work sponsored by an agency of
+# the United States Government. Neither the United States Government nor the
+# United States Department of Energy, nor Battelle, nor any of their
+# employees, nor any jurisdiction or organization that has cooperated in the
+# development of these materials, makes any warranty, express or
+# implied, or assumes any legal liability or responsibility for the accuracy,
+# completeness, or usefulness or any information, apparatus, product,
+# software, or process disclosed, or represents that its use would not infringe
+# privately owned rights. Reference herein to any specific commercial product,
+# process, or service by trade name, trademark, manufacturer, or otherwise
+# does not necessarily constitute or imply its endorsement, recommendation, or
+# favoring by the United States Government or any agency thereof, or
+# Battelle Memorial Institute. The views and opinions of authors expressed
+# herein do not necessarily state or reflect those of the
+# United States Government or any agency thereof.
+#
+# PACIFIC NORTHWEST NATIONAL LABORATORY operated by
+# BATTELLE for the UNITED STATES DEPARTMENT OF ENERGY
+# under Contract DE-AC05-76RL01830
 # }}}
+
 import json
 import logging
 import pytest
@@ -38,7 +53,8 @@ from volttrontesting.utils.platformwrapper import PlatformWrapper
 utils.setup_logging()
 logger = logging.getLogger(__name__)
 
-HOMEASSISTANT_DEVICE_TOPIC = "devices/home_assistant"
+# To run these tests, create a helper toggle named volttrontest in your Home Assistant instance.
+# This can be done by going to Settings > Devices & services > Helpers > Create Helper > Toggle
 HOMEASSISTANT_TEST_IP = ""
 ACCESS_TOKEN = ""
 PORT = ""
@@ -57,14 +73,14 @@ HOMEASSISTANT_DEVICE_TOPIC = "devices/home_assistant"
 def test_get_point(volttron_instance, config_store):
     expected_values = 0
     agent = volttron_instance.dynamic_agent
-    result = agent.vip.rpc.call(PLATFORM_DRIVER, 'get_point', 'home_assistant', 'light_state').get(timeout=20)
+    result = agent.vip.rpc.call(PLATFORM_DRIVER, 'get_point', 'home_assistant', 'bool_state').get(timeout=20)
     assert result == expected_values, "The result does not match the expected result."
 
 
 # The default value for this fake light is 3. If the test cannot reach out to home assistant,
-# the value will default to 3 meking the test fail.
+# the value will default to 3 making the test fail.
 def test_data_poll(volttron_instance: PlatformWrapper, config_store):
-    expected_values = [{'light_state': 0}, {'light_state': 1}]
+    expected_values = [{'bool_state': 0}, {'bool_state': 1}]
     agent = volttron_instance.dynamic_agent
     result = agent.vip.rpc.call(PLATFORM_DRIVER, 'scrape_all', 'home_assistant').get(timeout=20)
     assert result in expected_values, "The result does not match the expected result."
@@ -73,9 +89,9 @@ def test_data_poll(volttron_instance: PlatformWrapper, config_store):
 # Turn on the light. Light is automatically turned off every 30 seconds to allow test to turn
 # it on and receive the correct value.
 def test_set_point(volttron_instance, config_store):
-    expected_values = {'light_state': 1}
+    expected_values = {'bool_state': 1}
     agent = volttron_instance.dynamic_agent
-    agent.vip.rpc.call(PLATFORM_DRIVER, 'set_point', 'home_assistant', 'light_state', 1)
+    agent.vip.rpc.call(PLATFORM_DRIVER, 'set_point', 'home_assistant', 'bool_state', 1)
     gevent.sleep(10)
     result = agent.vip.rpc.call(PLATFORM_DRIVER, 'scrape_all', 'home_assistant').get(timeout=20)
     assert result == expected_values, "The result does not match the expected result."
@@ -89,9 +105,9 @@ def config_store(volttron_instance, platform_driver):
 
     registry_config = "homeassistant_test.json"
     registry_obj = [{
-        "Entity ID": "light.fake_light",
+        "Entity ID": "input_boolean.volttrontest",
         "Entity Point": "state",
-        "Volttron Point Name": "light_state",
+        "Volttron Point Name": "bool_state",
         "Units": "On / Off",
         "Units Details": "off: 0, on: 1",
         "Writable": True,


### PR DESCRIPTION
# Description

Previously, home assistant tests required the use of a light entity. Considering not everyone has smart lights or the time to create a fake one, input_boolean controls have been implemented into the tests. This makes it much easier to run tests with a fresh installation of home assistant. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

To test the home assistant tests. You need your IP, Access token, and port from home assistant. You also need to create a input_boolean entity by going to Settings > Devices & services > Helpers > Create Helper > Toggle within home assistant. Name this toggle volttrontest. Once you have done that, you can run the pytest with pytest volttron/services/core/PlatformDriverAgent/tests/test_home_assistant.py.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
