### PR TITLE
fix for issue#3159 (fix for deprecated pip --install-options)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -123,7 +123,7 @@ def update(operation, verbose=None, offline=False, optional_requirements=[], rab
     # option_requirements contains wheel as first entry
 
     # Build option_requirements separately to pass install options
-    build_option = '--build-option' if wheeling else '--install-option'
+    build_option = '--build-option' if wheeling else '--config-settings'
 
     for requirement, options in option_requirements:
         args = []

--- a/requirements.py
+++ b/requirements.py
@@ -30,7 +30,7 @@
 # wheel version 0.31 has removed metadata.json file
 # https://github.com/pypa/wheel/issues/195
 # so sticking to 0.30 for now. Could upgrade to wheel 0.31 with code changes
-option_requirements = [('wheel==0.30', []), ('pyzmq==22.2.1', ['--zmq=bundled'])]
+option_requirements = [('pip==24.0', []), ('wheel==0.30', []), ('pyzmq==22.2.1', ['--zmq=bundled'])]
 
 
 install_requires = ['gevent==21.12.0',


### PR DESCRIPTION
fix for pip's deprecated --install-options issue.  We now use the latest 24.0 version of pip inside the virtual environment created by bootstrap.  Tested the change on Ubunu 20 + python 3.8 and Ubuntu 22 +python 3.10. In both the case volttron bootstraps, starts and vctl install, vctl status, vctl start, vctl stop works fine