### PR TITLE
Fixes process overload from file events

### DIFF
--- a/volttron/utils/__init__.py
+++ b/volttron/utils/__init__.py
@@ -122,7 +122,7 @@ class VolttronHomeFileReloader(PatternMatchingEventHandler):
         _log.debug("patterns is {}".format([get_home() + '/' + filetowatch]))
         self._callback = callback
 
-    def on_any_event(self, event):
+    def on_closed(self, event):
         _log.debug("Calling callback on event {}. Calling {}".format(event, self._callback))
         try:
             self._callback()
@@ -147,7 +147,7 @@ class AbsolutePathFileReloader(PatternMatchingEventHandler):
     def watchfile(self):
         return self._filetowatch
 
-    def on_any_event(self, event):
+    def on_closed(self, event):
         _log.debug("Calling callback on event {}. Calling {}".format(event, self._callback))
         try:
             self._callback(self._filetowatch)


### PR DESCRIPTION
# Description

Changes file watcher classes to use "on_closed" rather than "on_any_change" event type, reducing frequency of events.
Fixes #3172 

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Deployed to platforms that were experiencing extreme resource utilization and verified utilization dropped significantly
- [ ] Deployed to platforms with ongoing system profiling and verified the hotpaths in the platforms changed.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
