### PR TITLE
Issue/3179

### DIFF
--- a/volttron/platform/vip/agent/subsystems/auth.py
+++ b/volttron/platform/vip/agent/subsystems/auth.py
@@ -265,6 +265,7 @@ class Auth(SubsystemBase):
         """
         rpc_method_authorizations = {}
         rpc_methods = self.get_rpc_exports()
+        updated_rpc_authorizations = None
         for method in rpc_methods:
             if len(method.split(".")) > 1:
                 pass
@@ -295,9 +296,7 @@ class Auth(SubsystemBase):
                 _log.info(
                     f"Skipping updating rpc auth capabilities for agent "
                     f"{self._core().identity} connecting to remote address: {self._core().address} ")
-                updated_rpc_authorizations = None
         except gevent.timeout.Timeout:
-            updated_rpc_authorizations = None
             _log.warning(f"update_id_rpc_authorization rpc call timed out for {self._core().identity}   {rpc_method_authorizations}")
         except MethodNotFound:
             _log.warning("update_id_rpc_authorization method is missing from "
@@ -306,7 +305,6 @@ class Auth(SubsystemBase):
                          "dynamic RPC authorizations.")
             return
         except Exception as e:
-            updated_rpc_authorizations = None
             _log.exception(f"Exception when calling rpc method update_id_rpc_authorizations for identity: "
                            f"{self._core().identity}  Exception:{e}")
         if updated_rpc_authorizations is None:
@@ -318,7 +316,7 @@ class Auth(SubsystemBase):
                 f"the identity of the agent"
             )
             return
-        if rpc_method_authorizations != updated_rpc_authorizations:
+        if rpc_method_authorizations != updated_rpc_authorizations and updated_rpc_authorizations is not None:
             for method in updated_rpc_authorizations:
                 self.set_rpc_authorizations(
                     method, updated_rpc_authorizations[method]

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -101,6 +101,8 @@ class AdminEndpoints:
                     self._userdict = jsonapi.loads(fp.read())
                 except json.decoder.JSONDecodeError:
                     self._userdict = {}
+                    # Keep same behavior as with PersistentDict
+                    raise ValueError("File not in a supported format")
 
     def get_routes(self):
         """

--- a/volttron/platform/web/admin_endpoints.py
+++ b/volttron/platform/web/admin_endpoints.py
@@ -46,7 +46,6 @@ from volttron.platform.agent.web import Response
 from volttron.platform import get_home
 from volttron.platform import jsonapi
 from volttron.utils import VolttronHomeFileReloader
-from volttron.utils.persistance import PersistentDict
 
 
 _log = logging.getLogger(__name__)
@@ -84,7 +83,7 @@ class AdminEndpoints:
         else:
             self._ssl_public_key = None
 
-        self._userdict = None
+        self._userdict = {}
         self.reload_userdict()
 
         self._observer = Observer()
@@ -96,7 +95,12 @@ class AdminEndpoints:
 
     def reload_userdict(self):
         webuserpath = os.path.join(get_home(), 'web-users.json')
-        self._userdict = PersistentDict(webuserpath, format="json")
+        if os.path.exists(webuserpath):
+            with open(webuserpath) as fp:
+                try:
+                    self._userdict = jsonapi.loads(fp.read())
+                except json.decoder.JSONDecodeError:
+                    self._userdict = {}
 
     def get_routes(self):
         """
@@ -339,4 +343,5 @@ class AdminEndpoints:
             groups=groups
         )
 
-        self._userdict.sync()
+        with open(os.path.join(get_home(), 'web-users.json'), 'w') as fp:
+            fp.write(jsonapi.dumps(self._userdict, indent=2))


### PR DESCRIPTION
# Description

This PR fixes issue #3179 by removing the PersistentDict from the admin_endpoint.py file.  This file is responsible for initiating the creation of the web admin user.  The syncing of the persistent dictionary to disk caused issues with the watchdog reloader.

This fix should be able to be merged with [releases/8.2](https://github.com/VOLTTRON/volttron/tree/releases/8.2) branch

Fixes #3179 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests are in the process of running, and have run locally in order to verify the expected results.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
