### PR TITLE
Handle duplicate point names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,9 +90,9 @@ copyright = '2023, The VOLTTRON Community'
 author = 'The VOLTTRON Community'
 
 # The short X.Y version
-version = '9.0'
+version = '9.0.1'
 # The full version, including alpha/beta/rc tags
-release = '9.0'
+release = '9.0.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/services/core/PlatformDriverAgent/platform_driver/driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/driver.py
@@ -167,13 +167,17 @@ class DriverAgent(BasicAgent):
 
         self.heart_beat_point = config.get("heart_beat_point")
 
-        # Check for duplicate names in registry entries and warn if this will cause rows to be skipped.
-        point_names = [r['Volttron Point Name'] for r in registry_config]
-        seen = set(point_names)
-        duplicates = [n for n in point_names if n not in seen or seen.remove(n)]
-        if duplicates:
-            _log.warning(f'Duplicate point names detected in registry file for {self.device_path}. '
-                         f'Only the last registry row will be used for points with names: {set(duplicates)}')
+        # Warn if there is no registry:
+        if registry_config is None:
+            _log.warning(f'No registry was found for device: devices/{self.device_path}')
+        else:
+            # Check for duplicate names in registry entries and warn if this will cause rows to be skipped.
+            point_names = [r['Volttron Point Name'] for r in registry_config]
+            seen = set(point_names)
+            duplicates = [n for n in point_names if n not in seen or seen.remove(n)]
+            if duplicates:
+                _log.warning(f'Duplicate point names detected in registry file for devices/{self.device_path}. '
+                             f'Only the last registry row will be used for points with names: {set(duplicates)}')
 
         self.interface = self.get_interface(driver_type, driver_config, registry_config)
         self.meta_data = {}

--- a/services/core/PlatformDriverAgent/platform_driver/driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/driver.py
@@ -167,7 +167,13 @@ class DriverAgent(BasicAgent):
 
         self.heart_beat_point = config.get("heart_beat_point")
 
-
+        # Check for duplicate names in registry entries and warn if this will cause rows to be skipped.
+        point_names = [r['Volttron Point Name'] for r in registry_config]
+        seen = set(point_names)
+        duplicates = [n for n in point_names if n not in seen or seen.remove(n)]
+        if duplicates:
+            _log.warning(f'Duplicate point names detected in registry file for {self.device_path}. '
+                         f'Only the last registry row will be used for points with names: {set(duplicates)}')
 
         self.interface = self.get_interface(driver_type, driver_config, registry_config)
         self.meta_data = {}

--- a/volttron/platform/__init__.py
+++ b/volttron/platform/__init__.py
@@ -35,7 +35,7 @@ from configparser import ConfigParser
 from urllib.parse import urlparse
 
 from ..utils.frozendict import FrozenDict
-__version__ = '9.0rc0'
+__version__ = '9.0.1'
 
 _log = logging.getLogger(__name__)
 

--- a/volttron/platform/vip/agent/subsystems/auth.py
+++ b/volttron/platform/vip/agent/subsystems/auth.py
@@ -265,6 +265,7 @@ class Auth(SubsystemBase):
         """
         rpc_method_authorizations = {}
         rpc_methods = self.get_rpc_exports()
+        updated_rpc_authorizations = None
         for method in rpc_methods:
             if len(method.split(".")) > 1:
                 pass
@@ -295,9 +296,7 @@ class Auth(SubsystemBase):
                 _log.info(
                     f"Skipping updating rpc auth capabilities for agent "
                     f"{self._core().identity} connecting to remote address: {self._core().address} ")
-                updated_rpc_authorizations = None
         except gevent.timeout.Timeout:
-            updated_rpc_authorizations = None
             _log.warning(f"update_id_rpc_authorization rpc call timed out for {self._core().identity}   {rpc_method_authorizations}")
         except MethodNotFound:
             _log.warning("update_id_rpc_authorization method is missing from "
@@ -306,7 +305,6 @@ class Auth(SubsystemBase):
                          "dynamic RPC authorizations.")
             return
         except Exception as e:
-            updated_rpc_authorizations = None
             _log.exception(f"Exception when calling rpc method update_id_rpc_authorizations for identity: "
                            f"{self._core().identity}  Exception:{e}")
         if updated_rpc_authorizations is None:
@@ -318,7 +316,7 @@ class Auth(SubsystemBase):
                 f"the identity of the agent"
             )
             return
-        if rpc_method_authorizations != updated_rpc_authorizations:
+        if rpc_method_authorizations != updated_rpc_authorizations and updated_rpc_authorizations is not None:
             for method in updated_rpc_authorizations:
                 self.set_rpc_authorizations(
                     method, updated_rpc_authorizations[method]

--- a/volttron/platform/web/topic_tree.py
+++ b/volttron/platform/web/topic_tree.py
@@ -166,6 +166,9 @@ class DeviceTree(TopicTree):
             registry_config = registry_config if kwargs else registry_config.get(timeout=5)
             for pnt in registry_config:
                 point_name = pnt.pop('Volttron Point Name')
-                n = device_tree.create_node(point_name, f"{d}/{point_name}", parent=d, data=pnt)
-                n.segment_type = 'POINT'
+                try:
+                    n = device_tree.create_node(point_name, f"{d}/{point_name}", parent=d, data=pnt)
+                    n.segment_type = 'POINT'
+                except DuplicatedNodeIdError:
+                    _log.warning(f'Duplicate Voltron Point Name ({point_name}) found in registry: {reg_cfg_name}.')
         return device_tree


### PR DESCRIPTION
# Description

Provides better handling of case where there are missing or duplicate registry entries both for driver, when it is loading configurations, and in the web API when it is building a TopicTree from the driver configurations.

Fixes # (issue)
#3183

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Started driver with test configurations which are missing registry entries and which have duplicated point names.  Observed that correct warnings appeared in log. Navigated through vui/platforms/.../devices endpoints in browser. Found correct devices and points without errors.  Confirmed that log receives notice of duplicate points when building TopicTree.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
