### PR TITLE
Pinned setuptools in requirements.py. Newer versions that 70 are inco…

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -56,7 +56,7 @@ install_requires = ['gevent==21.12.0',
                     'python-dateutil==2.8.2',
                     'pytz==2022.1',
                     'PyYAML==6.0',
-                    'setuptools>=40.0.0',
+                    'setuptools>=40.0.0,<=70.0.0',
                     # tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/
                     'tzlocal==2.1',
                     #'pyOpenSSL==19.0.0',


### PR DESCRIPTION
Pinned setuptools in requirements.py. Newer versions that 70 are incompatible with wheel 0.30.0.

# Description

Changed pin on setuptools to be between 40.0.0 and 70.0.0. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Installed on new environment and tested installing agents both with and without the pin.  It will fail if setuptools is newer than 70.0.0. 
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
