### PR TITLE
Fixed missing Interface attribute required for BACnet COV.

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -42,7 +42,7 @@ install_requires = ['gevent==21.12.0',
                     'python-dateutil==2.8.2',
                     'pytz==2022.1',
                     'PyYAML==6.0',
-                    'setuptools>=40.0.0',
+                    'setuptools>=40.0.0,<=70.0.0',
                     # tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/
                     'tzlocal==2.1',
                     #'pyOpenSSL==19.0.0',

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/__init__.py
@@ -237,12 +237,12 @@ class BaseInterface(object, metaclass=abc.ABCMeta):
 
     """
 
-    def __init__(self, vip=None, core=None, **kwargs):
+    def __init__(self, vip=None, core=None, device_path=None, **kwargs):
         # Object does not take any arguments to the init.
         super(BaseInterface, self).__init__()
         self.vip = vip
         self.core = core
-
+        self.device_path = device_path
         self.point_map = {}
 
         self.build_register_map()


### PR DESCRIPTION
# Description

The device_path is passed from the DriverAgent to the Inteface on initialization, but was not being saved. It is a required argument to BACnetProxy RPC "create_cov_subscription." Added self.device_path variable in BaseInterface.

Fixes #2484

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This has been tested on real hardware.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
