### PR TITLE
Driver rpc tries

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -42,7 +42,7 @@ install_requires = ['gevent==21.12.0',
                     'python-dateutil==2.8.2',
                     'pytz==2022.1',
                     'PyYAML==6.0',
-                    'setuptools>=40.0.0',
+                    'setuptools>=40.0.0,<=70.0.0',
                     # tzlocal 3.0 breaks without the backports.tzinfo package on python < 3.9 https://pypi.org/project/tzlocal/3.0/
                     'tzlocal==2.1',
                     #'pyOpenSSL==19.0.0',

--- a/services/core/PlatformDriverAgent/platform_driver/driver.py
+++ b/services/core/PlatformDriverAgent/platform_driver/driver.py
@@ -326,29 +326,47 @@ class DriverAgent(BasicAgent):
         return depth_first, breadth_first
 
     def get_point(self, point_name, **kwargs):
-        return self.interface.get_point(point_name, **kwargs)
+        try:
+            return self.interface.get_point(point_name, **kwargs)
+        except AttributeError as e:
+            _log.warning(e)
+
 
     def set_point(self, point_name, value, **kwargs):
-        return self.interface.set_point(point_name, value, **kwargs)
+        try:
+            return self.interface.set_point(point_name, value, **kwargs)
+        except AttributeError as e:
+            _log.warning(e)
 
     def scrape_all(self):
-        return self.interface.scrape_all()
+        try:
+            return self.interface.scrape_all()
+        except AttributeError as e:
+            _log.warning(e)
 
     def get_multiple_points(self, point_names, **kwargs):
-        return self.interface.get_multiple_points(self.device_name,
-                                                  point_names,
-                                                  **kwargs)
+        try:
+            return self.interface.get_multiple_points(self.device_name, point_names, **kwargs)
+        except AttributeError as e:
+            _log.warning(e)
 
     def set_multiple_points(self, point_names_values, **kwargs):
-        return self.interface.set_multiple_points(self.device_name,
-                                                  point_names_values,
-                                                  **kwargs)
+        try:
+            return self.interface.set_multiple_points(self.device_name, point_names_values, **kwargs)
+        except AttributeError as e:
+            _log.warning(e)
 
     def revert_point(self, point_name, **kwargs):
-        self.interface.revert_point(point_name, **kwargs)
+        try:
+            self.interface.revert_point(point_name, **kwargs)
+        except AttributeError as e:
+            _log.warning(e)
 
     def revert_all(self, **kwargs):
-        self.interface.revert_all(**kwargs)
+        try:
+            self.interface.revert_all(**kwargs)
+        except AttributeError as e:
+            _log.warning(e)
 
     def publish_cov_value(self, point_name, point_values):
         """


### PR DESCRIPTION
# Description
Try blocks are added to avoid breaking the DriverAgent instance for a device if an RPC method is called before the onstart runs for the DriverAgent.  This is necessary because the interface is not ready at the time the RPC arrives. Checking for readiness, meanwhile, would add overhead to every read and write, when this can only happen in the first second or two after creating the device. Instead, we avoid the problem by catching the AttributeError and simply logging that this has happened.

Fixes # (issue)
#3202

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
