### PR TITLE
Added keyword to account for changes to watchdog API. 

### DIFF
--- a/volttron/utils/__init__.py
+++ b/volttron/utils/__init__.py
@@ -104,7 +104,7 @@ class VolttronHomeFileReloader(PatternMatchingEventHandler):
         # Protect from circular reference for file
         from volttron.platform import get_home
 
-        super(VolttronHomeFileReloader, self).__init__([get_home() + '/' + filetowatch])
+        super(VolttronHomeFileReloader, self).__init__(patterns=[get_home() + '/' + filetowatch])
         _log.debug("patterns is {}".format([get_home() + '/' + filetowatch]))
         self._callback = callback
 
@@ -125,7 +125,7 @@ class AbsolutePathFileReloader(PatternMatchingEventHandler):
     filetowatch *.json will watch all json files in <volttron_home>
     """
     def __init__(self, filetowatch, callback):
-        super(AbsolutePathFileReloader, self).__init__([filetowatch])
+        super(AbsolutePathFileReloader, self).__init__(patterns=[filetowatch])
         self._callback = callback
         self._filetowatch = filetowatch
 


### PR DESCRIPTION
# Description

The watchdog package added a requirement for keyword arguments in version 5.0.0. The current version watchdog is 6.0.0, so new environments will fail when the VolttronHomeFileReloader or AbsolutePathFileReloader are used. This affects the web API on startup, since VolttronHomeFileReloaders is used for web-users.json. 

Fixes #3200

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Started Volttron with and without the change while a bind-web-address was set. The error described in #3200 is present without the fix and no longer appears with the fix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
