### PR TITLE
Pinned watchdog to less than version 5.

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -47,6 +47,7 @@ install_requires = ['gevent==21.12.0',
                     'tzlocal==2.1',
                     #'pyOpenSSL==19.0.0',
                     'cryptography==37.0.4',
+                    'watchdog<5.0',
                     'watchdog-gevent==0.1.1',
                     'deprecated==1.2.14']
 


### PR DESCRIPTION
# Description

The watchdog package added a requirement for keyword arguments in version 5.0.0. The current version watchdog is 6.0.0, so new environments will fail when the VolttronHomeFileReloader or AbsolutePathFileReloader are used. This affects the web API on startup, since VolttronHomeFileReloaders is used for web-users.json.

Unfortunately, simply updating to use keyword arguments also broke other things when running on python 3.8, as watchdog removed support for python 3.8 in the same version. Instead, pinned watchdog version to less than 5.0.0, since we need to continue support for python 3.8.

Fixes #3200

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Started Volttron with and without the change while a bind-web-address was set. The error described in #3200 is present without the fix and no longer appears with the fix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
