### PR TITLE
Handle error num passed as a string in platform.vip.agent.errors.

### DIFF
--- a/volttron/platform/vip/agent/errors.py
+++ b/volttron/platform/vip/agent/errors.py
@@ -46,6 +46,8 @@ class VIPError(Exception):
 
     @classmethod
     def from_errno(cls, errnum, msg, *args):
+        if isinstance(errnum, str) and errnum.lower().startswith('errno.'):
+            errnum = getattr(errno, errnum[len('errno.'):])
         errnum = int(errnum)
         return {
             errno.EHOSTUNREACH: Unreachable,


### PR DESCRIPTION
This pull request makes a small update to the error handling logic in `volttron/platform/vip/agent/errors.py`. The change improves flexibility by allowing the `from_errno` method to accept error numbers as strings prefixed with `'errno.'`, in addition to numeric values.

* Enhanced `from_errno` to accept error numbers as strings like `'errno.EHOSTUNREACH'`, converting them to the corresponding `errno` constant if necessary.