### PR TITLE
Postgres primary key

### DIFF
--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -177,11 +177,6 @@ class PostgreSqlFuncts(DbDriver):
                 self.execute_stmt(SQL(
                     "SELECT create_hypertable({}, 'ts', if_not_exists => true)").format(
                     Literal(self.data_table)))
-                self.execute_stmt(SQL(
-                    'CREATE INDEX IF NOT EXISTS {} ON {} (topic_id, ts)').format(
-                    Identifier(f"idx_{self.data_table}"),
-                    Identifier(self.data_table))
-                )
             else:
                 self.execute_stmt(SQL(
                     'CREATE INDEX IF NOT EXISTS {} ON {} (ts ASC)').format(

--- a/volttron/platform/dbutils/postgresqlfuncts.py
+++ b/volttron/platform/dbutils/postgresqlfuncts.py
@@ -154,7 +154,7 @@ class PostgreSqlFuncts(DbDriver):
 
     def setup_historian_tables(self):
         rows = self.select(f"""SELECT table_name FROM information_schema.tables
-                            WHERE table_catalog = '{self.db_name}' and table_schema = 'public' 
+                            WHERE table_catalog = '{self.db_name}' and table_schema = 'public'
                             AND table_name = '{self.data_table}'""")
         if rows:
             _log.debug("Found table {}. Historian table exists".format(
@@ -167,10 +167,10 @@ class PostgreSqlFuncts(DbDriver):
         else:
             self.execute_stmt(SQL(
                 'CREATE TABLE IF NOT EXISTS {} ('
-                    'ts TIMESTAMP NOT NULL, '
-                    'topic_id INTEGER NOT NULL, '
-                    'value_string TEXT NOT NULL, '
-                    'UNIQUE (topic_id, ts)'
+                'ts TIMESTAMP NOT NULL, '
+                'topic_id INTEGER NOT NULL, '
+                'value_string TEXT NOT NULL, '
+                'PRIMARY KEY (topic_id, ts)'
                 ')').format(Identifier(self.data_table)))
             if self.timescale_dialect:
                 _log.debug("trying to create hypertable")
@@ -187,18 +187,17 @@ class PostgreSqlFuncts(DbDriver):
                     'CREATE INDEX IF NOT EXISTS {} ON {} (ts ASC)').format(
                     Identifier('idx_' + self.data_table),
                     Identifier(self.data_table)))
-
             self.execute_stmt(SQL(
                 'CREATE TABLE IF NOT EXISTS {} ('
-                    'topic_id SERIAL PRIMARY KEY NOT NULL, '
-                    'topic_name VARCHAR(512) NOT NULL, '
-                    'metadata TEXT, '
-                    'UNIQUE (topic_name)'
+                'topic_id SERIAL PRIMARY KEY NOT NULL, '
+                'topic_name VARCHAR(512) NOT NULL, '
+                'metadata TEXT, '
+                'UNIQUE (topic_name)'
                 ')').format(Identifier(self.topics_table)))
             # metadata is in topics table
             self.meta_table = self.topics_table
             self.commit()
-
+            
     def setup_aggregate_historian_tables(self):
 
         self.execute_stmt(SQL(


### PR DESCRIPTION
This pull request makes a key change to the database schema setup in the `setup_historian_tables` function, specifically for the data table in `postgresqlfuncts.py`. The main update is to enforce a composite primary key on the `(topic_id, ts)` columns, replacing the previous unique constraint, and to remove a redundant index creation when using TimescaleDB.

**Database schema improvements:**

* Changed the data table definition to use a composite primary key on `(topic_id, ts)` instead of a unique constraint, ensuring stronger data integrity and potentially improving query performance.
* Removed the creation of an explicit index on `(topic_id, ts)` when using TimescaleDB, as the primary key already provides the necessary indexing.# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
