### PR TITLE
ci: force PEP 517 isolated builds so dependency install succeeds

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -144,7 +144,21 @@ def update(operation, verbose=None, offline=False, optional_requirements=[], rab
         optional_requirements = list(option_set)
     if optional_requirements:
         target += '[' + ','.join(optional_requirements) + ']'
-    args.extend(['--editable', target])
+    # Force the PEP 517 isolated build path for this install. Some
+    # transitive extras (modbus-tk, treelib) ship only a setup.py with no
+    # pyproject.toml, so pip's own use_pep517 fallback looks at whether
+    # setuptools and wheel are already importable in this environment. By
+    # this point in bootstrap they are (wheel==0.30 was just installed
+    # above), so pip takes the legacy, non-isolated setup.py path and hands
+    # those builds a modern setuptools running against the ambient
+    # wheel==0.30, whose bdist_wheel unconditionally imports
+    # wheel.wheelfile.WheelFile, an API wheel==0.30 does not have. Forcing
+    # --use-pep517 here makes pip provision a fresh, isolated build
+    # environment per requirement instead, which supplies its own
+    # setuptools/wheel pair and builds clean. This does not touch the
+    # wheel==0.30 pin above: it only changes how the *remaining* extras are
+    # built.
+    args.extend(['--use-pep517', '--editable', target])
     print(f"Target: {target}")
     pip(operation, args, verbose, offline)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -156,8 +156,12 @@ def update(operation, verbose=None, offline=False, optional_requirements=[], rab
     # --use-pep517 here makes pip provision a fresh, isolated build
     # environment per requirement instead, which supplies its own
     # setuptools/wheel pair and builds clean. This does not touch the
-    # wheel==0.30 pin above: it only changes how the *remaining* extras are
-    # built.
+    # wheel==0.30 pin above, but it does apply to the whole install call
+    # below, whose target is path[extras]: VOLTTRON's own editable install
+    # also switches from the legacy setup.py develop path to an isolated
+    # PEP 517 editable build, not just the remaining extras. Verified
+    # equivalent in outcome: pip install -e . succeeds and the auth suite
+    # is green.
     args.extend(['--use-pep517', '--editable', target])
     print(f"Target: {target}")
     pip(operation, args, verbose, offline)


### PR DESCRIPTION
# Description

The `develop` branch CI is fully red. Every build job fails at the dependency-install step with `ModuleNotFoundError: No module named 'wheel.wheelfile'` while building the `modbus-tk` and `treelib` sdists. This blocks the whole branch, not just one PR.

Root cause: pip's `use_pep517` legacy fallback picks the non-isolated build path when `setuptools` and `wheel` are already importable in the environment and the requirement ships no `pyproject.toml`. `bootstrap.py` installs the pinned `wheel==0.30` right before it resolves the extras, so the legacy path builds those sdists against the ambient `wheel==0.30`, whose `bdist_wheel` unconditionally imports `wheel.wheelfile.WheelFile`, an API that `wheel==0.30` does not have.

Fix: add `--use-pep517` to the extras/editable install so pip provisions a fresh, isolated build environment per requirement, supplying its own modern build-time `setuptools`/`wheel` pair. The runtime `wheel==0.30` pin is left in place, because `packaging.py` imports the removed `wheel.install.WheelFile` and still needs 0.30 at runtime. Build-time isolation and the runtime pin are now independent.

Fixes # (develop CI build failure; no separate issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Proven green on Python 3.10 (the CI interpreter) running the full `bootstrap.py --all --force`:

- [x] `modbus-tk` and `treelib` sdists build clean under the isolated PEP 517 path
- [x] `pip install -e .` succeeds (VOLTTRON's own editable install moves to the isolated PEP 517 editable build)
- [x] Platform auth suite: 46 passed, 70 skipped, 2 xfailed

**Test Configuration**:
* Python: 3.10 (CI interpreter)
* Toolchain: `bootstrap.py --all --force`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Note: this is a CI build-isolation fix in `bootstrap.py`; it unblocks the entire `develop` branch CI rather than adding new functionality, so no new unit tests are introduced.
