### PR TITLE
fix: correct aip.py import of undefined DRIVER_WRITE_METHODS (develop broken at collection)

### DIFF
--- a/volttron/platform/aip.py
+++ b/volttron/platform/aip.py
@@ -41,7 +41,7 @@ from gevent import subprocess
 from gevent.subprocess import PIPE
 from wheel.tool import unpack
 
-from volttron.platform.agent.known_identities import VOLTTRON_CENTRAL_PLATFORM, DRIVER_WRITE_METHODS
+from volttron.platform.agent.known_identities import VOLTTRON_CENTRAL_PLATFORM, DRIVER_WRITES
 from volttron.platform.agent.utils import get_fq_identity, is_secure_mode
 # Can't use zmq.utils.jsonapi because it is missing the load() method.
 from volttron.platform import jsonapi
@@ -577,7 +577,7 @@ class AIPplatform:
     def _authorize_agent_keys(self, agent_uuid, identity, publickey):
         capabilities = {
             'edit_config_store': {'identity': identity},
-            DRIVER_WRITE_METHODS: None
+            DRIVER_WRITES: None
         }
 
         if identity == VOLTTRON_CENTRAL_PLATFORM:


### PR DESCRIPTION
# Description

`develop` HEAD is broken for everyone at test collection. Importing `volttron.platform.aip` dies with:

```
ImportError: cannot import name 'DRIVER_WRITE_METHODS' from 'volttron.platform.agent.known_identities'
```

Because `aip.py` is imported transitively by the platform wrapper and much of the test suite, pytest fails at collection time before any test runs.

## Root cause

Commit f5156b7d5 ("Added capabilities for driver override and write RPCs") introduced a granular capability split. It defined two capability constants in `known_identities.py`:

```python
DRIVER_OVERRIDES = 'driver_override'
DRIVER_WRITES = 'driver_write'
```

and gated the driver write RPCs in `PlatformDriverAgent/agent.py` with `@RPC.allow(DRIVER_WRITES)` (on `set_point`, `set_multiple_points`, `revert_point`, `revert_device`). In the same commit, the install-time capability grant in `aip.py._authorize_agent_keys` was written to reference `DRIVER_WRITE_METHODS`, a name that was never defined anywhere. The import at `aip.py:44` therefore fails at module load.

## The fix

Rename both references in `aip.py` (the import at line 44 and the capability-grant dict key at line 580) from the never-defined `DRIVER_WRITE_METHODS` to `DRIVER_WRITES`.

`DRIVER_WRITES` is the semantically correct target, not just an import that resolves:

- The `capabilities` dict in `_authorize_agent_keys` is keyed by capability names (the sibling key `edit_config_store` matches `@RPC.allow('edit_config_store')` in `store.py`), not by method names. The plural "METHODS" in the dead name was misleading; the value it needed was always the single capability string.
- `@RPC.allow(DRIVER_WRITES)` is the guard on the four driver write RPCs. Granting the `driver_write` capability at install time is exactly what lets an authorized agent pass that guard. The grant and the guard now reference the same constant, which is the intended security semantics.

Fixes the collection-time `ImportError`; makes the install-time capability grant match the `RPC.allow` guard.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `python -c "import volttron.platform.aip"` succeeds (previously raised ImportError on the same tree).
- [x] `pytest --collect-only volttrontesting/` no longer reports any `DRIVER_WRITE_METHODS` / `known_identities` import error; `test_aip_security.py` collects cleanly. Remaining collection errors in my environment are unrelated optional-dependency gaps (deepdiff, pint, jwt, werkzeug), not this change.

**Test Configuration**:
* Python: 3.10.19
* Toolchain: pytest 9.1.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
